### PR TITLE
Updated bech32 dependency URL

### DIFF
--- a/common/types/address.go
+++ b/common/types/address.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/btcsuite/btcutil/bech32"
+	"github.com/btcsuite/btcd/tree/master/btcutil/bech32"
 	"golang.org/x/crypto/sha3"
 )
 


### PR DESCRIPTION
github.com/btcsuite/btcutil/bech32 moved to github.com/btcsuite/btcd/tree/master/btcutil/bech32