### PR TITLE
Fix memory leaks

### DIFF
--- a/p2p/server.go
+++ b/p2p/server.go
@@ -614,16 +614,7 @@ func (srv *Server) setupConn(fd net.Conn, flags connFlag, dialDest *discover.Nod
 		c.close(errServerStopped)
 		return
 	}
-	timeout := time.NewTimer(dialHistoryExpiration * 9)
-	defer timeout.Stop()
-	go func() {
-		select {
-		case <-timeout.C:
-			c.close(DiscReadTimeout)
-		case <-srv.quit:
-			c.close(errServerStopped)
-		}
-	}()
+
 	// Run the encryption handshake.
 	var err error
 	if c.id, err = c.doEncHandshake(srv.PrivateKey, dialDest); err != nil {

--- a/protocol/handler.go
+++ b/protocol/handler.go
@@ -207,13 +207,6 @@ func (pm *ProtocolManager) handle(p *peer) error {
 // peer. The remote connection is torn down upon returning any error.
 func (pm *ProtocolManager) handleMsg(p *peer) error {
 	// Read the next message from the remote peer, and ensure it's fully consumed
-	go func() {
-		select {
-		case <-pm.quitSync:
-			p.Disconnect(ErrNoStatusMsg)
-		}
-	}()
-
 	msg, err := p.rw.ReadMsg()
 	if err != nil {
 		return err


### PR DESCRIPTION
The leaks were created by spawning go routines on each setupConn or handle that would never returned. The Ethereum code base did not include these go routines in the releases so I removed them after thoroughly looking for other implications. I have tested it with a full resync and RPC.