### PR TITLE
Fix libznn for Windows

### DIFF
--- a/.github/workflows/znn_builder.yml
+++ b/.github/workflows/znn_builder.yml
@@ -59,7 +59,23 @@ jobs:
           dest: build
           prefix: libznn
           pkg: cmd/libznn
-          targets: darwin/arm64,darwin/amd64,windows/amd64,linux/amd64,linux/arm64
+          targets: darwin/arm64,darwin/amd64,linux/amd64,linux/arm64
+          v: true
+          x: true
+          tags: libznn
+          ldflags: -s -w
+          buildvcs: false
+          buildmode: c-shared
+          trimpath: true
+      - name: Build libznn (windows/amd64)
+        uses: crazy-max/ghaction-xgo@588a1a9bc6aa44305ce5d2c669c11687316f87bf
+        with:
+          xgo_version: latest
+          go_version: 1.19.10
+          dest: build
+          prefix: libznn
+          pkg: cmd/libznn
+          targets: windows/amd64
           v: true
           x: true
           tags: libznn

--- a/rpc/api/embedded/bridge.go
+++ b/rpc/api/embedded/bridge.go
@@ -8,6 +8,7 @@ import (
 	"github.com/zenon-network/go-zenon/vm/constants"
 	"github.com/zenon-network/go-zenon/vm/embedded/implementation"
 	"reflect"
+	"sort"
 
 	"github.com/zenon-network/go-zenon/chain"
 	"github.com/zenon-network/go-zenon/common"


### PR DESCRIPTION
This issue has been affecting some Windows users for the last few months.
The absence of any stack trace related to the sudden crash hindered the investigation, but we discovered that the output is stable if we compile it with xgo and go <1.20.0

More details can be found here: https://github.com/hypercore-one/go-zenon/issues/4
User reports: https://forum.zenon.org/t/syrius-v0-0-6-crashes-with-embedded-node/1376