### PR TITLE
Improve account pool performance

### DIFF
--- a/chain/tests/account_pool_test.go
+++ b/chain/tests/account_pool_test.go
@@ -1,0 +1,149 @@
+package tests
+
+import (
+	"math/big"
+	"testing"
+
+	g "github.com/zenon-network/go-zenon/chain/genesis/mock"
+	"github.com/zenon-network/go-zenon/chain/nom"
+	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/common/types"
+	"github.com/zenon-network/go-zenon/vm/constants"
+	"github.com/zenon-network/go-zenon/vm/embedded/definition"
+	"github.com/zenon-network/go-zenon/zenon/mock"
+)
+
+func TestAccountPool_GetAllUncommittedAccountBlocks(t *testing.T) {
+	z := mock.NewMockZenon(t)
+	defer z.StopPanic()
+
+	blocks := []*nom.AccountBlock{
+		{
+			Address: g.User1.Address,
+		},
+		{
+			Address: g.User2.Address,
+		},
+		{
+			Address: g.User3.Address,
+		},
+		{
+			Address:       g.User1.Address,
+			ToAddress:     types.TokenContract,
+			TokenStandard: types.ZnnTokenStandard,
+			Amount:        constants.TokenIssueAmount,
+			Data: definition.ABIToken.PackMethodPanic(definition.IssueMethodName,
+				"test.tok3n_na-m3", //param.TokenName
+				"TEST",             //param.TokenSymbol
+				"",                 //param.TokenDomain
+				big.NewInt(100),    //param.TotalSupply
+				big.NewInt(1000),   //param.MaxSupply
+				uint8(1),           //param.Decimals
+				true,               //param.IsMintable
+				true,               //param.IsBurnable
+				false,              //param.IsUtility
+			),
+		},
+	}
+
+	for _, block := range blocks {
+		if types.IsEmbeddedAddress(block.ToAddress) {
+			z.CallContract(block)
+		} else {
+			z.InsertSendBlock(block, nil, mock.SkipVmChanges)
+		}
+	}
+
+	uncommitted := z.Chain().GetAllUncommittedAccountBlocks()
+	common.Expect(t, len(uncommitted), 4)
+
+	z.InsertNewMomentum() // generate contract receive and its descendant block
+
+	uncommitted = z.Chain().GetAllUncommittedAccountBlocks()
+	common.Expect(t, len(uncommitted), 2)
+
+	z.InsertNewMomentum()
+
+	uncommitted = z.Chain().GetAllUncommittedAccountBlocks()
+	common.Expect(t, len(uncommitted), 0)
+}
+
+func TestAccountPool_Rebuild(t *testing.T) {
+	z := mock.NewMockZenon(t)
+	defer z.StopPanic()
+
+	for i := 0; i < 100; i++ {
+		z.InsertSendBlock(&nom.AccountBlock{
+			Address: g.User1.Address,
+		}, nil, mock.SkipVmChanges)
+		z.InsertSendBlock(&nom.AccountBlock{
+			Address: g.User2.Address,
+		}, nil, mock.SkipVmChanges)
+	}
+
+	uncommitted := z.Chain().GetAllUncommittedAccountBlocks()
+	common.Expect(t, len(uncommitted), 200)
+
+	z.InsertNewMomentum() // trigger rebuild
+
+	uncommitted = z.Chain().GetAllUncommittedAccountBlocks()
+	common.Expect(t, len(uncommitted), 100)
+}
+
+func TestAccountPool_Priority(t *testing.T) {
+	z := mock.NewMockZenon(t)
+	defer z.StopPanic()
+
+	lowPriorityBlock := &nom.AccountBlock{
+		Address:     g.User1.Address,
+		FusedPlasma: 21000,
+	}
+
+	z.InsertSendBlock(lowPriorityBlock, nil, mock.SkipVmChanges)
+
+	uncommitted := z.Chain().GetAllUncommittedAccountBlocks()
+	common.Expect(t, len(uncommitted), 1)
+
+	highPriorityBlock := uncommitted[0]
+	highPriorityBlock.FusedPlasma = 22000
+
+	z.InsertSendBlock(highPriorityBlock, nil, mock.SkipVmChanges)
+
+	uncommitted = z.Chain().GetAllUncommittedAccountBlocks()
+	common.Expect(t, len(uncommitted), 1)
+	common.ExpectString(t, uncommitted[0].Hash.String(), highPriorityBlock.Hash.String())
+
+	z.InsertSendBlock(lowPriorityBlock, nil, mock.SkipVmChanges)
+
+	uncommitted = z.Chain().GetAllUncommittedAccountBlocks()
+	common.Expect(t, len(uncommitted), 1)
+	common.ExpectString(t, uncommitted[0].Hash.String(), highPriorityBlock.Hash.String())
+}
+
+func BenchmarkAccountPool_GetAllUncommittedAccountBlocks(b *testing.B) {
+	z := mock.NewMockZenon(b)
+	defer z.StopPanic()
+
+	for i := 0; i < 500; i++ {
+		z.InsertSendBlock(&nom.AccountBlock{
+			Address: g.User1.Address,
+		}, nil, mock.SkipVmChanges)
+		z.InsertSendBlock(&nom.AccountBlock{
+			Address: g.User2.Address,
+		}, nil, mock.SkipVmChanges)
+		z.InsertSendBlock(&nom.AccountBlock{
+			Address: g.User3.Address,
+		}, nil, mock.SkipVmChanges)
+		z.InsertSendBlock(&nom.AccountBlock{
+			Address: g.User4.Address,
+		}, nil, mock.SkipVmChanges)
+		z.InsertSendBlock(&nom.AccountBlock{
+			Address: g.User5.Address,
+		}, nil, mock.SkipVmChanges)
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		z.Chain().GetAllUncommittedAccountBlocks()
+	}
+}


### PR DESCRIPTION
The account pool starts experiencing performance issues when it holds a large amount of account blocks from account chains that have long unconfirmed states. Specifically the account pool's (`account_pool.go`) functions `getUncommittedAccountBlocksByAddress` and `rebuild` become unacceptably slow if there are more than a few account chains with hundreds of pending account blocks on each chain.

The reason for the slowness is the multiple consecutive read operations done to the account chain's unconfirmed (frontier) database in the `getUncommittedAccountBlocksByAddress` and `rebuild` functions. The account chain's unconfirmed database's performance is not adequate for this use case.

To fix this issue, this commit introduces an `accountManager` which is responsible for maintaining a key-value map of an account's pending blocks. This way the pending blocks do not have to be fetched from the unconfirmed account database, significantly improving performance.

### Benchmarks
[This benchmark](https://github.com/vilkris4/go-zenon/blob/c59d17ac9c967f6c59dfe432122d1c68ebba4c59/chain/tests/account_pool_test.go#L123) was used to compare the performance of the current implementation to the new implementation. The benchmark adds a total of 2,500 account blocks from five different accounts into the account pool and then benchmarks the public function `GetAllUncommittedAccountBlocks`, which internally uses the problematic `getUncommittedAccountBlocksByAddress` function.

|Version|ns/op|ms/op|B/op|allocs/op|
|-----|-----|-----|-----|-----|
|Current (v0.0.7)|4476964800 ns/op|4476.96 ms/op|11485528 B/op|188399 allocs/op|
|New|4331860 ns/op|4.33 ms/op|5766849 B/op|95988 allocs/op|

As can be seen from the results, the current implementation becomes slow when there are a few hundred pending blocks for each account in the account pool.

### Testing

A full resync of the node has been tested with these changes.