### PR TITLE
Improve account block validation performance

### DIFF
--- a/chain/account/keys.go
+++ b/chain/account/keys.go
@@ -6,6 +6,9 @@ var (
 	chainPlasmaKey           = []byte{5}
 	receivedBlockPrefix      = []byte{6}
 	sequencerLastReceivedKey = []byte{7}
+
+	StorageKeyPrefix = storageKeyPrefix
+	ChainPlasmaKey   = chainPlasmaKey
 )
 
 const (

--- a/chain/cache.go
+++ b/chain/cache.go
@@ -1,0 +1,164 @@
+package chain
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/inconshreveable/log15"
+	"github.com/pkg/errors"
+	"github.com/zenon-network/go-zenon/chain/cache"
+	"github.com/zenon-network/go-zenon/chain/cache/storage"
+	"github.com/zenon-network/go-zenon/chain/nom"
+	"github.com/zenon-network/go-zenon/chain/store"
+	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/common/db"
+	"github.com/zenon-network/go-zenon/common/types"
+)
+
+type chainCache struct {
+	manager storage.CacheManager
+	log     log15.Logger
+	changes sync.Mutex
+}
+
+func (c *chainCache) getFrontierStore() store.Cache {
+	if db := c.manager.DB(); db == nil {
+		return nil
+	} else {
+		return cache.NewCacheStore(storage.GetFrontierIdentifier(db), c.manager)
+	}
+}
+
+func (c *chainCache) GetFrontierCacheStore() store.Cache {
+	c.changes.Lock()
+	defer c.changes.Unlock()
+	return c.getFrontierStore()
+}
+
+func (c *chainCache) GetCacheStore(identifier types.HashHeight) store.Cache {
+	c.changes.Lock()
+	defer c.changes.Unlock()
+	return cache.NewCacheStore(identifier, c.manager)
+}
+
+func (c *chainCache) UpdateCache(insertLocker sync.Locker, detailed *nom.DetailedMomentum, changes db.Patch) error {
+	if insertLocker == nil {
+		return errors.Errorf("insertLocker can't be nil")
+	}
+	if changes == nil {
+		return errors.Errorf("changes can't be nil")
+	}
+	c.changes.Lock()
+	defer c.changes.Unlock()
+	if err := c.update(detailed, changes); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *chainCache) update(detailed *nom.DetailedMomentum, changes db.Patch) error {
+	momentum := detailed.Momentum
+	c.log.Info("inserting new momentum to chain cache", "identifier", momentum.Identifier())
+	store := c.getFrontierStore()
+	store.ApplyMomentum(detailed, changes)
+	patch, err := store.Changes()
+	if err != nil {
+		return err
+	}
+	if err := c.manager.Add(momentum.Identifier(), patch); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *chainCache) RollbackCacheTo(insertLocker sync.Locker, identifier types.HashHeight) error {
+	if insertLocker == nil {
+		return errors.Errorf("insertLocker can't be nil")
+	}
+	c.changes.Lock()
+	defer c.changes.Unlock()
+	if err := c.rollbackTo(identifier); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *chainCache) rollbackTo(identifier types.HashHeight) error {
+	c.log.Info("rollbacking cache", "to-identifier", identifier)
+	frontier := c.getFrontierStore().Identifier()
+
+	if identifier.Height > frontier.Height {
+		return errors.Errorf("can't rollback cache. Expected identifier height %v is greater than frontier %v", identifier, frontier)
+	}
+
+	if frontier.Height-identifier.Height > uint64(storage.GetRollbackCacheSize()) {
+		return errors.Errorf("can't rollback cache. Target identifier %v is outside the rollback cache", identifier)
+	}
+
+	for {
+		store := c.getFrontierStore()
+		frontier := store.Identifier()
+		if frontier.Height == identifier.Height {
+			break
+		}
+		c.log.Info("rollbacking", "momentum-identifier", frontier)
+		if err := c.manager.Pop(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *chainCache) Init(chainManager db.Manager, momentumStore store.Momentum) error {
+	c.changes.Lock()
+	defer c.changes.Unlock()
+	chainFrontier := db.GetFrontierIdentifier(chainManager.Frontier())
+	cacheFrontier := storage.GetFrontierIdentifier(c.manager.DB())
+
+	if cacheFrontier.Height == chainFrontier.Height {
+		if cacheFrontier.Hash != chainFrontier.Hash {
+			return errors.Errorf("The cache's state is incorrect. " +
+				"You can fix the problem by removing the cache database manually.")
+		}
+		return nil
+	}
+
+	if cacheFrontier.Height > chainFrontier.Height {
+		if err := c.rollbackTo(chainFrontier); err != nil {
+			return err
+		}
+		return nil
+	}
+
+	if chainFrontier.Height-cacheFrontier.Height >= 100000 {
+		fmt.Println("Initializing cache: 0%")
+	}
+
+	for i := cacheFrontier.Height + 1; i <= chainFrontier.Height; i++ {
+		momentum, err := momentumStore.GetMomentumByHeight(i)
+		if err != nil {
+			return err
+		}
+		changes := chainManager.GetPatch(momentum.Identifier())
+		detailed, err := momentumStore.PrefetchMomentum(momentum)
+		if err != nil {
+			return err
+		}
+		if err := c.update(detailed, changes); err != nil {
+			return err
+		}
+		if i%100000 == 0 {
+			fmt.Printf("Initializing cache: %d%%\n", i*100/chainFrontier.Height)
+		}
+	}
+
+	return nil
+}
+
+func NewChainCache(cacheManager storage.CacheManager) *chainCache {
+	return &chainCache{
+		manager: cacheManager,
+		log:     common.ChainLogger.New("submodule", "chain-cache"),
+	}
+}

--- a/chain/cache/account.go
+++ b/chain/cache/account.go
@@ -1,0 +1,69 @@
+package cache
+
+import (
+	"math/big"
+
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/zenon-network/go-zenon/chain/nom"
+	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/common/types"
+)
+
+var (
+	fusedAmountKeyPrefix = []byte{0}
+	chainPlasmaKeyPrefix = []byte{1}
+)
+
+func getFusedAmountKeyPrefix(address []byte) []byte {
+	return common.JoinBytes(accountCacheKeyPrefix, fusedAmountKeyPrefix, address)
+}
+
+func getChainPlasmaKeyPrefix(address []byte) []byte {
+	return common.JoinBytes(accountCacheKeyPrefix, chainPlasmaKeyPrefix, address)
+}
+
+func (cs *cacheStore) GetStakeBeneficialAmount(address types.Address) (*big.Int, error) {
+	value, err := cs.findValue(getFusedAmountKeyPrefix(address.Bytes()))
+	if err == leveldb.ErrNotFound {
+		return big.NewInt(0), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return big.NewInt(0).SetBytes(value), nil
+}
+
+func (cs *cacheStore) GetChainPlasma(address types.Address) (*big.Int, error) {
+	value, err := cs.findValue(getChainPlasmaKeyPrefix(address.Bytes()))
+	if err == leveldb.ErrNotFound {
+		return big.NewInt(0), nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return big.NewInt(0).SetBytes(value), nil
+}
+
+func (cs *cacheStore) pruneAccountCache(blocks []*nom.AccountBlock) error {
+	for _, block := range blocks {
+		all := append([]*nom.AccountBlock{block}, block.DescendantBlocks...)
+		for _, b := range all {
+			prefix := getFusedAmountKeyPrefix(b.Address.Bytes())
+			fusedPlasmaKeys, err := cs.findExpiredKeys(prefix, b.MomentumAcknowledged.Height)
+			if err != nil {
+				return err
+			}
+
+			prefix = getChainPlasmaKeyPrefix(b.Address.Bytes())
+			chainPlasmaKeys, err := cs.findExpiredKeys(prefix, b.MomentumAcknowledged.Height)
+			if err != nil {
+				return err
+			}
+
+			for _, key := range append(fusedPlasmaKeys, chainPlasmaKeys...) {
+				cs.changes.Delete(key)
+			}
+		}
+	}
+	return nil
+}

--- a/chain/cache/extractor.go
+++ b/chain/cache/extractor.go
@@ -58,7 +58,7 @@ func (e *cacheExtractor) tryToGetCacheKey(key []byte, value []byte) []byte {
 		// Cache chain plasma
 		if bytes.HasPrefix(keyWithoutAddress, account.ChainPlasmaKey) {
 			if value == nil {
-				return nil
+				return e.getHeightKey(getChainPlasmaKeyPrefix(address.Bytes()))
 			}
 			// Verify that the state has changed
 			current, err := e.cache.GetChainPlasma(address)

--- a/chain/cache/extractor.go
+++ b/chain/cache/extractor.go
@@ -1,0 +1,78 @@
+package cache
+
+import (
+	"bytes"
+
+	"github.com/zenon-network/go-zenon/chain/account"
+	"github.com/zenon-network/go-zenon/chain/momentum"
+	"github.com/zenon-network/go-zenon/chain/store"
+	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/common/db"
+	"github.com/zenon-network/go-zenon/common/types"
+	"github.com/zenon-network/go-zenon/vm/embedded/definition"
+)
+
+type cacheExtractor struct {
+	cache  store.Cache
+	height uint64
+	patch  db.Patch
+}
+
+func (e *cacheExtractor) Put(key []byte, value []byte) {
+	if cacheKey := e.tryToGetCacheKey(key, value); cacheKey != nil {
+		e.patch.Put(cacheKey, value)
+	}
+}
+
+func (e *cacheExtractor) Delete(key []byte) {
+	if cacheKey := e.tryToGetCacheKey(key, nil); cacheKey != nil {
+		e.patch.Put(cacheKey, []byte{})
+	}
+}
+
+func (e *cacheExtractor) tryToGetCacheKey(key []byte, value []byte) []byte {
+	if bytes.HasPrefix(key, momentum.AccountStorePrefix) {
+		key = bytes.TrimPrefix(key, momentum.AccountStorePrefix)
+		keyWithoutAddress := key[types.AddressSize:]
+		address, err := types.BytesToAddress(key[:types.AddressSize])
+		common.DealWithErr(err)
+
+		// Cache fused plasma
+		if address == types.PlasmaContract {
+			prefix := common.JoinBytes(account.StorageKeyPrefix, definition.FusedAmountKeyPrefix)
+			if bytes.HasPrefix(keyWithoutAddress, prefix) {
+				beneficiary := bytes.TrimPrefix(keyWithoutAddress, prefix)
+				return e.getHeightKey(getFusedAmountKeyPrefix(beneficiary))
+			}
+		}
+
+		// Cache sporks
+		if address == types.SporkContract {
+			prefix := common.JoinBytes(account.StorageKeyPrefix, []byte{definition.SporkInfoPrefix})
+			if bytes.HasPrefix(keyWithoutAddress, prefix) {
+				sporkId := bytes.TrimPrefix(keyWithoutAddress, prefix)
+				return e.getHeightKey(getSporkInfoKeyPrefix(sporkId))
+			}
+		}
+
+		// Cache chain plasma
+		if bytes.HasPrefix(keyWithoutAddress, account.ChainPlasmaKey) {
+			if value == nil {
+				return nil
+			}
+			// Verify that the state has changed
+			current, err := e.cache.GetChainPlasma(address)
+			common.DealWithErr(err)
+			if current.Cmp(common.BytesToBigInt(value)) == 0 {
+				return nil
+			}
+			return e.getHeightKey(getChainPlasmaKeyPrefix(address.Bytes()))
+		}
+	}
+
+	return nil
+}
+
+func (e *cacheExtractor) getHeightKey(prefix []byte) []byte {
+	return common.JoinBytes(prefix, common.Uint64ToBytes(e.height))
+}

--- a/chain/cache/extractor_test.go
+++ b/chain/cache/extractor_test.go
@@ -1,0 +1,83 @@
+package cache
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/zenon-network/go-zenon/chain/cache/storage"
+	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/common/db"
+	"github.com/zenon-network/go-zenon/common/types"
+)
+
+func getMockPatch() db.Patch {
+	patch := db.NewPatch()
+	fusedPlasmaKey, _ := hex.DecodeString("0301b3b6e5adcb4c1ff61be98c6318c6318c6318c60402aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	patch.Put(fusedPlasmaKey, []byte{1})
+	sporkKey, _ := hex.DecodeString("0301b3b6e5adcb4d00bc76318c6318c6318c6318c60401aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	patch.Put(sporkKey, []byte{1})
+	chainPlasmaKey, _ := hex.DecodeString("03aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa05")
+	patch.Put(chainPlasmaKey, []byte{1})
+	return patch
+}
+
+func getMockIdentifier(height uint64) types.HashHeight {
+	return types.HashHeight{
+		Hash:   types.NewHash([]byte(fmt.Sprint(height))),
+		Height: height,
+	}
+}
+
+func TestExtractor(t *testing.T) {
+	dir := t.TempDir()
+	m := storage.NewCacheDBManager(dir)
+	defer m.Stop()
+
+	identifier := types.ZeroHashHeight
+	cs := NewCacheStore(identifier, m)
+
+	changes := getMockPatch()
+	extractor := &cacheExtractor{cache: cs, height: 1, patch: db.NewPatch()}
+	if err := changes.Replay(extractor); err != nil {
+		t.Fatal(err)
+	}
+	common.ExpectString(t, db.DebugPatch(extractor.patch), `
+0300aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000001 - 01
+0400aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000001 - 01
+0301aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000001 - 01
+`)
+
+	identifier = getMockIdentifier(1)
+	m.Add(identifier, extractor.patch)
+
+	common.ExpectString(t, db.DebugDB(m.DB()), `
+00 - 0a220a2067b176705b46206614219f47a05aee7ae6a3edbe850bbbe214c536b989aea4d21001
+0300aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000001 - 01
+0301aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000001 - 01
+0400aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000001 - 01
+`)
+
+	cs = NewCacheStore(identifier, m)
+	changes = getMockPatch()
+	extractor = &cacheExtractor{cache: cs, height: 2, patch: db.NewPatch()}
+	if err := changes.Replay(extractor); err != nil {
+		t.Fatal(err)
+	}
+	common.ExpectString(t, db.DebugPatch(extractor.patch), `
+0300aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000002 - 01
+0400aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000002 - 01
+`)
+
+	identifier = getMockIdentifier(2)
+	m.Add(identifier, extractor.patch)
+
+	common.ExpectString(t, db.DebugDB(m.DB()), `
+00 - 0a220a20b1b1bd1ed240b1496c81ccf19ceccf2af6fd24fac10ae42023628abbe26873101002
+0300aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000001 - 01
+0300aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000002 - 01
+0301aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000001 - 01
+0400aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000001 - 01
+0400aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa0000000000000002 - 01
+`)
+}

--- a/chain/cache/keys.go
+++ b/chain/cache/keys.go
@@ -1,0 +1,6 @@
+package cache
+
+var (
+	accountCacheKeyPrefix = []byte{3}
+	sporkCacheKeyPrefix   = []byte{4}
+)

--- a/chain/cache/spork.go
+++ b/chain/cache/spork.go
@@ -1,0 +1,38 @@
+package cache
+
+import (
+	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/common/types"
+	"github.com/zenon-network/go-zenon/vm/embedded/definition"
+)
+
+var (
+	sporkInfoKeyPrefix = []byte{0}
+)
+
+func getSporkInfoKeyPrefix(id []byte) []byte {
+	return common.JoinBytes(sporkCacheKeyPrefix, sporkInfoKeyPrefix, id)
+}
+
+func (cs *cacheStore) IsSporkActive(implemented *types.ImplementedSpork) (bool, error) {
+	identifier := cs.Identifier()
+	if identifier.Height == 1 {
+		return false, nil
+	}
+
+	data, err := cs.findValue(getSporkInfoKeyPrefix(implemented.SporkId.Bytes()))
+	if err != nil {
+		return false, err
+	}
+
+	if len(data) == 0 {
+		return false, nil
+	}
+
+	spork := definition.ParseSporkInfo(data)
+	if spork.Activated && spork.EnforcementHeight <= identifier.Height && spork.Id == implemented.SporkId {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/chain/cache/storage/db.go
+++ b/chain/cache/storage/db.go
@@ -1,0 +1,161 @@
+package storage
+
+import (
+	"path"
+	"runtime"
+	"sync"
+
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/syndtr/goleveldb/leveldb/util"
+	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/common/db"
+	"github.com/zenon-network/go-zenon/common/types"
+)
+
+const (
+	rollbackCacheSize = 100
+)
+
+var (
+	storageByte  = []byte{85}
+	rollbackByte = []byte{119}
+)
+
+func getConsensusOpenFilesCacheCapacity() int {
+	switch runtime.GOOS {
+	case "darwin":
+		return 20
+	case "windows":
+		return 200
+	default:
+		return 200
+	}
+}
+
+type CacheManager interface {
+	DB() db.DB
+
+	Add(types.HashHeight, db.Patch) error
+	Pop() error
+
+	Stop() error
+}
+
+type cacheManager struct {
+	ldb     *leveldb.DB
+	changes sync.Mutex
+	stopped bool
+}
+
+func NewCacheDBManager(dataDir string) CacheManager {
+	opts := &opt.Options{OpenFilesCacheCapacity: getConsensusOpenFilesCacheCapacity()}
+	db, err := leveldb.OpenFile(path.Join(dataDir, "cache"), opts)
+	common.DealWithErr(err)
+	return &cacheManager{
+		ldb: db,
+	}
+}
+
+func GetRollbackCacheSize() int {
+	return rollbackCacheSize
+}
+
+func GetFrontierIdentifier(db db.DB) types.HashHeight {
+	data, err := db.Get(frontierIdentifierKey)
+	if err == leveldb.ErrNotFound {
+		return types.ZeroHashHeight
+	}
+	common.DealWithErr(err)
+	hh, err := types.DeserializeHashHeight(data)
+	common.DealWithErr(err)
+	return *hh
+}
+
+func (m *cacheManager) DB() db.DB {
+	m.changes.Lock()
+	defer m.changes.Unlock()
+	if m.stopped {
+		return nil
+	}
+	return db.NewLevelDBWrapper(m.ldb).Subset(storageByte)
+}
+
+func (m *cacheManager) Add(identifier types.HashHeight, patch db.Patch) error {
+	temp := db.NewMemDB()
+	if err := temp.Put(frontierIdentifierKey, identifier.Serialize()); err != nil {
+		return err
+	}
+	frontierPatch, err := temp.Changes()
+	if err != nil {
+		return err
+	}
+	if err := frontierPatch.Replay(patch); err != nil {
+		return err
+	}
+	rollbackPatch := db.RollbackPatch(m.DB(), patch)
+
+	m.changes.Lock()
+	defer m.changes.Unlock()
+
+	if err := m.ldb.Put(common.JoinBytes(rollbackByte, common.Uint64ToBytes(identifier.Height)), rollbackPatch.Dump(), nil); err != nil {
+		return err
+	}
+	if identifier.Height > rollbackCacheSize {
+		if err := m.ldb.Delete(common.JoinBytes(rollbackByte, common.Uint64ToBytes(identifier.Height-rollbackCacheSize)), nil); err != nil {
+			return err
+		}
+	}
+	if err := db.ApplyPatch(db.NewLevelDBWrapperWithFullDelete(m.ldb).Subset(storageByte), patch); err != nil {
+		return err
+	}
+	// Compact the db manually since the automatic compaction mechanism causes performance issues when throughput increases.
+	if identifier.Height%100 == 0 {
+		m.ldb.CompactRange(*util.BytesPrefix([]byte{}))
+	}
+	return nil
+}
+
+func (m *cacheManager) Pop() error {
+	frontierIdentifier := GetFrontierIdentifier(m.DB())
+	rollbackPatch, err := m.getRollback(frontierIdentifier.Height)
+	if err != nil {
+		return err
+	}
+
+	m.changes.Lock()
+	defer m.changes.Unlock()
+
+	if err := db.ApplyPatch(db.NewLevelDBWrapperWithFullDelete(m.ldb).Subset(storageByte), rollbackPatch); err != nil {
+		return err
+	}
+	if err := m.ldb.Delete(common.JoinBytes(rollbackByte, common.Uint64ToBytes(frontierIdentifier.Height)), nil); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *cacheManager) Stop() error {
+	m.changes.Lock()
+	defer m.changes.Unlock()
+	if err := m.ldb.Close(); err != nil {
+		return err
+	}
+	m.stopped = true
+	m.ldb = nil
+	return nil
+}
+
+func (m *cacheManager) getRollback(height uint64) (db.Patch, error) {
+	snapshot, _ := m.ldb.GetSnapshot()
+	value, err := snapshot.Get(common.JoinBytes(rollbackByte, common.Uint64ToBytes(height)), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	patch, err := db.NewPatchFromDump(value)
+	if err != nil {
+		return nil, err
+	}
+	return patch, nil
+}

--- a/chain/cache/storage/db_test.go
+++ b/chain/cache/storage/db_test.go
@@ -1,0 +1,63 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/common/db"
+	"github.com/zenon-network/go-zenon/common/types"
+)
+
+func getMockPatch(value []byte) db.Patch {
+	patch := db.NewPatch()
+	patch.Put(value, value)
+	return patch
+}
+
+func getMockIdentifier(height uint64) types.HashHeight {
+	return types.HashHeight{
+		Hash:   types.NewHash([]byte(fmt.Sprint(height))),
+		Height: height,
+	}
+}
+
+func TestPop(t *testing.T) {
+	dir := t.TempDir()
+	m := NewCacheDBManager(dir)
+	defer m.Stop()
+
+	for i := 1; i <= 10; i++ {
+		m.Add(getMockIdentifier(uint64(i)), getMockPatch([]byte{byte(i)}))
+	}
+
+	common.ExpectString(t, db.DebugDB(m.DB()), `
+00 - 0a220a20dd121e36961a04627eacff629765dd3528471ed745c1e32222db4a8a5f3421c4100a
+01 - 01
+02 - 02
+03 - 03
+04 - 04
+05 - 05
+06 - 06
+07 - 07
+08 - 08
+09 - 09
+0a - 0a
+`)
+
+	for i := 0; i < 5; i++ {
+		m.Pop()
+	}
+
+	frontierIdentifier := GetFrontierIdentifier(m.DB())
+	expectedIdentifier := getMockIdentifier(5)
+	common.Expect(t, frontierIdentifier, expectedIdentifier)
+	common.ExpectString(t, db.DebugDB(m.DB()), `
+00 - 0a220a2086bc56fc56af4c3cde021282f6b727ee9f90dd636e0b0c712a85d416c75e652d1005
+01 - 01
+02 - 02
+03 - 03
+04 - 04
+05 - 05
+`)
+}

--- a/chain/cache/storage/keys.go
+++ b/chain/cache/storage/keys.go
@@ -1,0 +1,5 @@
+package storage
+
+var (
+	frontierIdentifierKey = []byte{0}
+)

--- a/chain/cache/store.go
+++ b/chain/cache/store.go
@@ -1,0 +1,107 @@
+package cache
+
+import (
+	"github.com/zenon-network/go-zenon/chain/cache/storage"
+	"github.com/zenon-network/go-zenon/chain/nom"
+	"github.com/zenon-network/go-zenon/chain/store"
+	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/common/db"
+	"github.com/zenon-network/go-zenon/common/types"
+)
+
+type cacheStore struct {
+	identifier types.HashHeight
+	changes    db.DB
+	db         db.DB
+}
+
+func NewCacheStore(identifier types.HashHeight, manager storage.CacheManager) store.Cache {
+	if manager == nil {
+		panic("cache store can't operate with nil db manager")
+	}
+	frontier := storage.GetFrontierIdentifier(manager.DB())
+	if identifier.Height > frontier.Height {
+		panic("cache store identifier height cannot be greater than db height")
+	}
+	return &cacheStore{
+		identifier: identifier,
+		changes:    db.NewMemDB(),
+		db:         manager.DB(),
+	}
+}
+
+func (cs *cacheStore) Identifier() types.HashHeight {
+	return cs.identifier
+}
+
+func (cs *cacheStore) Changes() (db.Patch, error) {
+	return cs.changes.Changes()
+}
+
+func (cs *cacheStore) ApplyMomentum(detailed *nom.DetailedMomentum, changes db.Patch) error {
+	if len(detailed.AccountBlocks) == 0 {
+		return nil
+	}
+	extractor := &cacheExtractor{cache: cs, height: detailed.Momentum.Height, patch: db.NewPatch()}
+	if err := changes.Replay(extractor); err != nil {
+		return err
+	}
+	if err := cs.changes.Apply(extractor.patch); err != nil {
+		return err
+	}
+	err := cs.pruneAccountCache(detailed.AccountBlocks)
+	return err
+}
+
+func (cs *cacheStore) findValue(prefix []byte) ([]byte, error) {
+	iterator := cs.db.NewIterator(prefix)
+	defer iterator.Release()
+
+	if !iterator.Last() {
+		return []byte{}, nil
+	}
+
+	for {
+		if getKeyHeight(iterator.Key()) <= cs.identifier.Height {
+			return iterator.Value(), nil
+		}
+		if !iterator.Prev() {
+			if iterator.Error() != nil {
+				return nil, iterator.Error()
+			}
+			return []byte{}, nil
+		}
+	}
+}
+
+func (cs *cacheStore) findExpiredKeys(prefix []byte, validHeight uint64) ([][]byte, error) {
+	iterator := cs.db.NewIterator(prefix)
+	defer iterator.Release()
+
+	keys := [][]byte{}
+	for {
+		if !iterator.Next() {
+			if iterator.Error() != nil {
+				return nil, iterator.Error()
+			}
+			break
+		}
+		if getKeyHeight(iterator.Key()) > validHeight {
+			break
+		}
+		key := make([]byte, len(iterator.Key()))
+		copy(key, iterator.Key())
+		keys = append(keys, key)
+	}
+
+	// Remove key of the current state, so that it's not returned as expired
+	if len(keys) > 0 {
+		keys = keys[:len(keys)-1]
+	}
+	return keys, nil
+}
+
+func getKeyHeight(key []byte) uint64 {
+	const uint64Size = 8
+	return common.BytesToUint64(key[len(key)-uint64Size:])
+}

--- a/chain/interface.go
+++ b/chain/interface.go
@@ -23,6 +23,7 @@ type Chain interface {
 	AccountPool
 	MomentumPool
 	MomentumEventManager
+	ChainCache
 }
 
 type MomentumEventListener interface {
@@ -62,4 +63,11 @@ type AccountPool interface {
 	GetNewMomentumContent() []*nom.AccountBlock
 	GetAllUncommittedAccountBlocks() []*nom.AccountBlock
 	GetUncommittedAccountBlocksByAddress(address types.Address) []*nom.AccountBlock
+}
+
+type ChainCache interface {
+	UpdateCache(insertLocker sync.Locker, detailed *nom.DetailedMomentum, changes db.Patch) error
+	RollbackCacheTo(insertLocker sync.Locker, identifier types.HashHeight) error
+	GetCacheStore(identifier types.HashHeight) store.Cache
+	GetFrontierCacheStore() store.Cache
 }

--- a/chain/momentum/keys.go
+++ b/chain/momentum/keys.go
@@ -8,4 +8,6 @@ var (
 	blockConfirmationHeightPrefix = []byte{5}
 	accountZNNBalancePrefix       = []byte{8}
 	accountHeaderByHashPrefix     = []byte{9}
+
+	AccountStorePrefix = accountStorePrefix
 )

--- a/chain/store/cache.go
+++ b/chain/store/cache.go
@@ -1,0 +1,19 @@
+package store
+
+import (
+	"math/big"
+
+	"github.com/zenon-network/go-zenon/chain/nom"
+	"github.com/zenon-network/go-zenon/common/db"
+	"github.com/zenon-network/go-zenon/common/types"
+)
+
+type Cache interface {
+	Identifier() types.HashHeight
+	GetStakeBeneficialAmount(types.Address) (*big.Int, error)
+	GetChainPlasma(types.Address) (*big.Int, error)
+	IsSporkActive(*types.ImplementedSpork) (bool, error)
+
+	ApplyMomentum(*nom.DetailedMomentum, db.Patch) error
+	Changes() (db.Patch, error)
+}

--- a/chain/tests/cache_test.go
+++ b/chain/tests/cache_test.go
@@ -1,0 +1,208 @@
+package tests
+
+import (
+	"math/big"
+	"testing"
+
+	g "github.com/zenon-network/go-zenon/chain/genesis/mock"
+	"github.com/zenon-network/go-zenon/chain/nom"
+	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/common/types"
+	"github.com/zenon-network/go-zenon/rpc/api"
+	"github.com/zenon-network/go-zenon/rpc/api/embedded"
+	"github.com/zenon-network/go-zenon/vm/constants"
+	"github.com/zenon-network/go-zenon/vm/embedded/definition"
+	"github.com/zenon-network/go-zenon/zenon/mock"
+)
+
+func activateSpork(z mock.MockZenon) {
+	sporkAPI := embedded.NewSporkApi(z)
+	z.InsertSendBlock(&nom.AccountBlock{
+		Address:   g.Spork.Address,
+		ToAddress: types.SporkContract,
+		Data: definition.ABISpork.PackMethodPanic(definition.SporkCreateMethodName,
+			"spork-accelerator",              // name
+			"activate spork for accelerator", // description
+		),
+	}, nil, mock.SkipVmChanges)
+	z.InsertNewMomentum()
+
+	sporkList, _ := sporkAPI.GetAll(0, 10)
+	id := sporkList.List[0].Id
+
+	z.InsertSendBlock(&nom.AccountBlock{
+		Address:   g.Spork.Address,
+		ToAddress: types.SporkContract,
+		Data: definition.ABISpork.PackMethodPanic(definition.SporkActivateMethodName,
+			id, // id
+		),
+	}, nil, mock.SkipVmChanges)
+	z.InsertNewMomentum()
+	types.AcceleratorSpork.SporkId = id
+	types.ImplementedSporksMap[id] = true
+	z.InsertMomentumsTo(20)
+}
+
+func TestCache_ChainPlasma(t *testing.T) {
+	z := mock.NewMockZenon(t)
+	defer z.StopPanic()
+	ledgerApi := api.NewLedgerApi(z)
+
+	z.InsertSendBlock(&nom.AccountBlock{
+		Address:       g.User1.Address,
+		ToAddress:     g.User6.Address,
+		TokenStandard: types.ZnnTokenStandard,
+		Amount:        big.NewInt(10 * g.Zexp),
+	}, nil, mock.SkipVmChanges)
+	z.InsertNewMomentum()
+
+	momentums, err := ledgerApi.GetMomentumsByHeight(1, 2)
+	common.FailIfErr(t, err)
+
+	z.InsertSendBlock(&nom.AccountBlock{
+		Address:              g.User1.Address,
+		ToAddress:            g.User6.Address,
+		TokenStandard:        types.ZnnTokenStandard,
+		Amount:               big.NewInt(10 * g.Zexp),
+		MomentumAcknowledged: momentums.List[0].Identifier(),
+	}, nil, mock.SkipVmChanges)
+	z.InsertNewMomentum()
+
+	store := z.Chain().GetFrontierCacheStore()
+	current, err := store.GetChainPlasma(g.User1.Address)
+	common.FailIfErr(t, err)
+	common.ExpectAmount(t, current, big.NewInt(42000))
+
+	store = z.Chain().GetCacheStore(momentums.List[1].Identifier())
+	current, err = store.GetChainPlasma(g.User1.Address)
+	common.FailIfErr(t, err)
+	common.ExpectAmount(t, current, big.NewInt(21000))
+
+	store = z.Chain().GetCacheStore(momentums.List[0].Identifier())
+	current, err = store.GetChainPlasma(g.User1.Address)
+	common.FailIfErr(t, err)
+	common.ExpectAmount(t, current, common.Big0)
+}
+
+func TestCache_Spork(t *testing.T) {
+	z := mock.NewMockZenon(t)
+	defer z.StopPanic()
+	ledgerApi := api.NewLedgerApi(z)
+
+	activateSpork(z)
+
+	momentums, err := ledgerApi.GetMomentumsByHeight(1, 20)
+	common.FailIfErr(t, err)
+
+	store := z.Chain().GetCacheStore(momentums.List[0].Identifier())
+	isActive, err := store.IsSporkActive(types.AcceleratorSpork)
+	common.FailIfErr(t, err)
+	common.Expect(t, isActive, false)
+
+	store = z.Chain().GetCacheStore(momentums.List[7].Identifier())
+	isActive, err = store.IsSporkActive(types.AcceleratorSpork)
+	common.FailIfErr(t, err)
+	common.Expect(t, isActive, false)
+
+	store = z.Chain().GetCacheStore(momentums.List[8].Identifier())
+	isActive, err = store.IsSporkActive(types.AcceleratorSpork)
+	common.FailIfErr(t, err)
+	common.Expect(t, isActive, true)
+
+	store = z.Chain().GetCacheStore(momentums.List[19].Identifier())
+	isActive, err = store.IsSporkActive(types.AcceleratorSpork)
+	common.FailIfErr(t, err)
+	common.Expect(t, isActive, true)
+}
+
+func TestCache_FusedPlasma(t *testing.T) {
+	z := mock.NewMockZenon(t)
+	defer z.StopPanic()
+	ledgerApi := api.NewLedgerApi(z)
+
+	constants.FuseExpiration = 100
+
+	defer z.CallContract(&nom.AccountBlock{
+		Address:       g.User1.Address,
+		ToAddress:     types.PlasmaContract,
+		Data:          definition.ABIPlasma.PackMethodPanic(definition.FuseMethodName, g.User6.Address),
+		TokenStandard: types.QsrTokenStandard,
+		Amount:        big.NewInt(10 * g.Zexp),
+	}).Error(t, nil)
+
+	z.InsertMomentumsTo(101)
+
+	defer z.CallContract(&nom.AccountBlock{
+		Address:   g.User1.Address,
+		ToAddress: types.PlasmaContract,
+		Data:      definition.ABIPlasma.PackMethodPanic(definition.CancelFuseMethodName, types.HexToHashPanic("6fce867a507bf026e4299761b6dd7fa51d288fed75716adcbd71bd6d241fc7ee")),
+	}).Error(t, nil)
+
+	z.InsertNewMomentum()
+	z.InsertNewMomentum()
+
+	momentum, err := ledgerApi.GetMomentumsByHeight(1, 1)
+	common.FailIfErr(t, err)
+
+	store := z.Chain().GetCacheStore(momentum.List[0].Identifier())
+	amount, err := store.GetStakeBeneficialAmount(g.User6.Address)
+	common.FailIfErr(t, err)
+	common.ExpectAmount(t, amount, common.Big0)
+
+	momentum, err = ledgerApi.GetMomentumsByHeight(3, 1)
+	common.FailIfErr(t, err)
+
+	store = z.Chain().GetCacheStore(momentum.List[0].Identifier())
+	amount, err = store.GetStakeBeneficialAmount(g.User6.Address)
+	common.FailIfErr(t, err)
+	common.ExpectAmount(t, amount, big.NewInt(10*g.Zexp))
+
+	momentum, err = ledgerApi.GetMomentumsByHeight(102, 1)
+	common.FailIfErr(t, err)
+
+	store = z.Chain().GetCacheStore(momentum.List[0].Identifier())
+	amount, err = store.GetStakeBeneficialAmount(g.User6.Address)
+	common.FailIfErr(t, err)
+	common.ExpectAmount(t, amount, big.NewInt(10*g.Zexp))
+
+	momentum, err = ledgerApi.GetMomentumsByHeight(103, 1)
+	common.FailIfErr(t, err)
+
+	store = z.Chain().GetCacheStore(momentum.List[0].Identifier())
+	amount, err = store.GetStakeBeneficialAmount(g.User6.Address)
+	common.FailIfErr(t, err)
+	common.ExpectAmount(t, amount, common.Big0)
+}
+
+func TestCache_Rollback(t *testing.T) {
+	z := mock.NewMockZenon(t)
+	defer z.StopPanic()
+
+	z.InsertMomentumsTo(200)
+
+	frontier := z.Chain().GetFrontierCacheStore().Identifier()
+	common.Expect(t, frontier.Height, 200)
+
+	momentum, err := z.Chain().GetFrontierMomentumStore().GetMomentumByHeight(99)
+	common.FailIfErr(t, err)
+
+	insert := z.Chain().AcquireInsert("")
+	err = z.Chain().RollbackCacheTo(insert, momentum.Identifier())
+	insert.Unlock()
+
+	// Expect rollback to fail when trying to rollback more than rollbackCacheSize
+	common.ExpectTrue(t, err != nil)
+	frontier = z.Chain().GetFrontierCacheStore().Identifier()
+	common.Expect(t, frontier.Height, 200)
+
+	momentum, err = z.Chain().GetFrontierMomentumStore().GetMomentumByHeight(100)
+	common.FailIfErr(t, err)
+
+	insert = z.Chain().AcquireInsert("")
+	err = z.Chain().RollbackCacheTo(insert, momentum.Identifier())
+	insert.Unlock()
+
+	common.ExpectTrue(t, err == nil)
+	frontier = z.Chain().GetFrontierCacheStore().Identifier()
+	common.Expect(t, frontier.Height, 100)
+}

--- a/common/db/interfaces.go
+++ b/common/db/interfaces.go
@@ -28,6 +28,8 @@ type Transaction interface {
 
 type StorageIterator interface {
 	Next() bool
+	Prev() bool
+	Last() bool
 
 	Key() []byte
 	Value() []byte
@@ -53,6 +55,7 @@ type db interface {
 	Get([]byte) ([]byte, error)
 	Has([]byte) (bool, error)
 	Put(key, value []byte) error
+	Delete(key []byte) error
 
 	NewIterator(prefix []byte) StorageIterator
 

--- a/common/db/leveldb.go
+++ b/common/db/leveldb.go
@@ -41,6 +41,9 @@ func (ro *levelDBROWrapper) Has(key []byte) (bool, error) {
 func (ro *levelDBROWrapper) Put(key []byte, value []byte) error {
 	panic("unimplemented")
 }
+func (ro *levelDBROWrapper) Delete(key []byte) error {
+	panic("unimplemented")
+}
 func (ro *levelDBROWrapper) changesInternal(prefix []byte) (Patch, error) {
 	panic("unimplemented")
 }
@@ -51,6 +54,7 @@ func (ro *levelDBROWrapper) NewIterator(prefix []byte) StorageIterator {
 type LevelDBLike interface {
 	LevelDBLikeRO
 	Put(key []byte, value []byte, wo *opt.WriteOptions) error
+	Delete(key []byte, wo *opt.WriteOptions) error
 }
 
 type levelDBWrapper struct {
@@ -65,6 +69,9 @@ func (ldbw *levelDBWrapper) Has(key []byte) (bool, error) {
 }
 func (ldbw *levelDBWrapper) Put(key, value []byte) error {
 	return ldbw.db.Put(key, value, nil)
+}
+func (ldbw *levelDBWrapper) Delete(key []byte) error {
+	return ldbw.db.Delete(key, nil)
 }
 func (ldbw *levelDBWrapper) NewIterator(prefix []byte) StorageIterator {
 	return ldbw.db.NewIterator(util.BytesPrefix(prefix), nil)
@@ -89,14 +96,21 @@ func NewLevelDBSnapshotWrapper(ldb *leveldb.Snapshot) DB {
 		&levelDBROWrapper{
 			db: ldb,
 		},
-	}))
+	}), false)
 }
 
 func NewLevelDBWrapper(db *leveldb.DB) DB {
 	return enableDelete(
 		&levelDBWrapper{
 			db: db,
-		})
+		}, false)
+}
+
+func NewLevelDBWrapperWithFullDelete(db *leveldb.DB) DB {
+	return enableDelete(
+		&levelDBWrapper{
+			db: db,
+		}, true)
 }
 
 func NewLevelDB(dirname string) (DB, *leveldb.DB) {

--- a/common/db/memdb.go
+++ b/common/db/memdb.go
@@ -44,5 +44,5 @@ func newMemDBInternal() db {
 }
 
 func NewMemDB() DB {
-	return enableDelete(newMemDBInternal())
+	return enableDelete(newMemDBInternal(), false)
 }

--- a/common/db/memdb_test.go
+++ b/common/db/memdb_test.go
@@ -61,7 +61,7 @@ func TestMergedIterators(t *testing.T) {
 
 	common.ExpectString(t, DebugDB(enableDelete(newMergedDb([]db{
 		db1, db2,
-	}))), `
+	}), false)), `
 000101 - 102001
 000102 - 
 000103 - 102013
@@ -72,7 +72,7 @@ func TestMergedIterators(t *testing.T) {
 000302 - `)
 	common.ExpectString(t, DebugDB(enableDelete(newMergedDb([]db{
 		db1, newSkipDelete(db2),
-	}))), `
+	}), false)), `
 000101 - 102001
 000102 - 
 000103 - 102013
@@ -82,7 +82,7 @@ func TestMergedIterators(t *testing.T) {
 000302 - `)
 	common.ExpectString(t, DebugDB(enableDelete(newSkipDelete(newMergedDb([]db{
 		db1, db2,
-	})))), `
+	})), false)), `
 000101 - 102001
 000103 - 102013
 000201 - 102003

--- a/common/db/merged.go
+++ b/common/db/merged.go
@@ -38,6 +38,16 @@ func (u *mergedDB) Has(key []byte) (bool, error) {
 func (u *mergedDB) Put(key, value []byte) error {
 	return u.dbs[0].Put(key, value)
 }
+func (u *mergedDB) Delete(key []byte) error {
+	for _, db := range u.dbs {
+		if ok, err := db.Has(key); err != nil {
+			return err
+		} else if ok {
+			return db.Delete(key)
+		}
+	}
+	return nil
+}
 func (u *mergedDB) NewIterator(prefix []byte) StorageIterator {
 	iterators := make([]StorageIterator, len(u.dbs))
 	for i := range u.dbs {
@@ -86,6 +96,12 @@ func newMergedIterator(iterators []StorageIterator) StorageIterator {
 
 func (mi *mergedIterator) Next() bool {
 	return mi.step()
+}
+func (mi *mergedIterator) Prev() bool {
+	panic("unimplemented")
+}
+func (mi *mergedIterator) Last() bool {
+	panic("unimplemented")
 }
 func (mi *mergedIterator) Key() []byte {
 	if mi.current == noCurrent || mi.err != nil {

--- a/common/db/subdb.go
+++ b/common/db/subdb.go
@@ -34,6 +34,9 @@ func (u *subDB) Has(key []byte) (bool, error) {
 func (u *subDB) Put(key, value []byte) error {
 	return u.db.Put(common.JoinBytes(u.prefix, key), value)
 }
+func (u *subDB) Delete(key []byte) error {
+	return u.db.Delete(common.JoinBytes(u.prefix, key))
+}
 func (u *subDB) NewIterator(prefix []byte) StorageIterator {
 	return newSubIterator(len(u.prefix), u.db.NewIterator(common.JoinBytes(u.prefix, prefix)))
 }

--- a/common/db/versioned_db.go
+++ b/common/db/versioned_db.go
@@ -286,7 +286,7 @@ func (m *ldbManager) Get(identifier types.HashHeight) DB {
 				newSubDB(frontierByte, newLevelDBSnapshotWrapper(snapshot)),
 			})),
 	})
-	return enableDelete(u)
+	return enableDelete(u, false)
 }
 func (m *ldbManager) GetPatch(identifier types.HashHeight) Patch {
 	m.changes.Lock()

--- a/pillar/worker.go
+++ b/pillar/worker.go
@@ -94,7 +94,8 @@ func (w *worker) work(task common.TaskResolver, e consensus.ProducerEvent) {
 	var momentumStore store.Momentum
 
 	w.log.Info("producing momentum", "event", e)
-	momentum, err := w.generateMomentum(e)
+	transaction, detailed, err := w.generateMomentum(e)
+
 	if err != nil {
 		w.log.Error("failed to generate momentum", "reason", err)
 		return
@@ -107,10 +108,10 @@ func (w *worker) work(task common.TaskResolver, e consensus.ProducerEvent) {
 		return
 	}
 	if common.Clock.Now().After(e.StartTime.Add(3 * time.Second)) {
-		w.log.Error("do not broadcast own momentum", "identifier", momentum.Momentum.Identifier(), "reason", "too-late")
+		w.log.Error("do not broadcast own momentum", "identifier", transaction.Momentum.Identifier(), "reason", "too-late")
 	} else {
-		w.log.Info("broadcasting own momentum", "identifier", momentum.Momentum.Identifier())
-		w.broadcaster.CreateMomentum(momentum)
+		w.log.Info("broadcasting own momentum", "identifier", transaction.Momentum.Identifier())
+		w.broadcaster.CreateMomentum(transaction, detailed)
 	}
 
 	if task.ShouldStop() {

--- a/pillar/worker_updater.go
+++ b/pillar/worker_updater.go
@@ -13,7 +13,7 @@ import (
 
 func canPerformEmbeddedUpdate(momentumStore store.Momentum, pool chain.AccountPool, contract types.Address) error {
 	store := pool.GetFrontierAccountStore(contract)
-	context := vm_context.NewAccountContext(momentumStore, store, nil)
+	context := vm_context.NewAccountContext(momentumStore, store, nil, nil)
 	return implementation.CanPerformUpdate(context)
 }
 

--- a/protocol/interfaces.go
+++ b/protocol/interfaces.go
@@ -51,6 +51,6 @@ type ChainBridge interface {
 
 type Broadcaster interface {
 	SyncInfo() *SyncInfo
-	CreateMomentum(*nom.MomentumTransaction)
+	CreateMomentum(*nom.MomentumTransaction, *nom.DetailedMomentum)
 	CreateAccountBlock(*nom.AccountBlockTransaction)
 }

--- a/rpc/api/embedded/plasma.go
+++ b/rpc/api/embedded/plasma.go
@@ -176,7 +176,7 @@ func (a *PlasmaApi) Get(address types.Address) (*PlasmaInfo, error) {
 		return nil, err
 	}
 
-	available, err := vm.AvailablePlasma(context.MomentumStore(), context)
+	available, err := vm.AvailablePlasma(context.CacheStore(), context)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +250,7 @@ func (a *PlasmaApi) GetRequiredPoWForAccountBlock(param GetRequiredParam) (*GetR
 		return nil, errors.New("toAddress is nil")
 	}
 
-	availablePlasma, err := vm.AvailablePlasma(context.MomentumStore(), context)
+	availablePlasma, err := vm.AvailablePlasma(context.CacheStore(), context)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/api/utils.go
+++ b/rpc/api/utils.go
@@ -37,6 +37,7 @@ func GetFrontierContext(c chain.Chain, addr types.Address) (*nom.Momentum, vm_co
 	context := vm_context.NewAccountContext(
 		store,
 		c.GetFrontierAccountStore(addr),
+		c.GetFrontierCacheStore(),
 		nil,
 	)
 	return frontier, context, nil

--- a/verifier/account_block.go
+++ b/verifier/account_block.go
@@ -281,7 +281,16 @@ func (abv *accountBlockVerifier) previous() error {
 	return nil
 }
 func (abv *accountBlockVerifier) momentumAcknowledged() error {
-	if abv.momentumStore != nil {
+	if abv.momentumStore == nil {
+		// When the momentumStore is not used, explicitly verify that the block's acknowledgement momentum exists
+		m, err := abv.frontierStore.GetMomentumByHeight(abv.block.MomentumAcknowledged.Height)
+		if err != nil {
+			return InternalError(err)
+		}
+		if m == nil || m.Hash != abv.block.MomentumAcknowledged.Hash {
+			return ErrABMAMissing
+		}
+	} else {
 		momentum, err := abv.momentumStore.GetFrontierMomentum()
 		if err != nil {
 			return InternalError(err)

--- a/vm/embedded/definition/plasma.go
+++ b/vm/embedded/definition/plasma.go
@@ -46,6 +46,8 @@ var (
 
 	fusionInfoKeyPrefix  = []byte{1}
 	fusedAmountKeyPrefix = []byte{2}
+
+	FusedAmountKeyPrefix = fusedAmountKeyPrefix
 )
 
 type FusionInfo struct {

--- a/vm/embedded/definition/spork.go
+++ b/vm/embedded/definition/spork.go
@@ -38,6 +38,8 @@ var (
 const (
 	_ byte = iota
 	sporkInfoPrefix
+
+	SporkInfoPrefix = sporkInfoPrefix
 )
 
 type Spork struct {
@@ -66,7 +68,7 @@ func (spork *Spork) Key() []byte {
 	return common.JoinBytes([]byte{sporkInfoPrefix}, spork.Id.Bytes())
 }
 
-func parseSporkInfo(data []byte) *Spork {
+func ParseSporkInfo(data []byte) *Spork {
 	spork := new(Spork)
 	ABISpork.UnpackVariablePanic(spork, sporkInfoVariableName, data)
 	return spork
@@ -81,7 +83,7 @@ func GetSporkInfoById(context db.DB, id types.Hash) *Spork {
 	if len(data) == 0 {
 		return nil
 	} else {
-		return parseSporkInfo(data)
+		return ParseSporkInfo(data)
 	}
 }
 func GetAllSporks(context db.DB) []*Spork {
@@ -94,7 +96,7 @@ func GetAllSporks(context db.DB) []*Spork {
 			common.DealWithErr(iterator.Error())
 			break
 		}
-		spork := parseSporkInfo(iterator.Value())
+		spork := ParseSporkInfo(iterator.Value())
 		sporks = append(sporks, spork)
 	}
 	return sporks

--- a/vm/plasma.go
+++ b/vm/plasma.go
@@ -54,13 +54,13 @@ func FussedAmountToPlasma(amount *big.Int) uint64 {
 // *Takes* into consideration used plasma by unconfirmed blocks.
 //
 // Plasma equals to fusedPlasma - plasmaUsedByUnconfirmedBlocks
-func AvailablePlasma(momentum store.Momentum, account store.Account) (uint64, error) {
+func AvailablePlasma(cache store.Cache, account store.Account) (uint64, error) {
 	address := *account.Address()
-	committed, err := momentum.GetAccountStore(address).GetChainPlasma()
+	committed, err := cache.GetChainPlasma(address)
 	if err != nil {
 		return 0, err
 	}
-	fused, err := momentum.GetStakeBeneficialAmount(address)
+	fused, err := cache.GetStakeBeneficialAmount(address)
 	if err != nil {
 		return 0, err
 	}

--- a/vm/vm_context/account_context.go
+++ b/vm/vm_context/account_context.go
@@ -13,20 +13,26 @@ type accountVmContext struct {
 	api.PillarReader
 	store.Account
 	momentumStore store.Momentum
+	cacheStore    store.Cache
 }
 
 func (ctx *accountVmContext) MomentumStore() store.Momentum {
 	return ctx.momentumStore
 }
 
-func NewAccountContext(momentumStore store.Momentum, accountBlock store.Account, pillarReader api.PillarReader) AccountVmContext {
+func (ctx *accountVmContext) CacheStore() store.Cache {
+	return ctx.cacheStore
+}
+
+func NewAccountContext(momentumStore store.Momentum, accountBlock store.Account, cacheStore store.Cache, pillarReader api.PillarReader) AccountVmContext {
 	return &accountVmContext{
 		momentumStore: momentumStore,
 		Account:       accountBlock,
+		cacheStore:    cacheStore,
 		PillarReader:  pillarReader,
 	}
 }
 
 func NewGenesisAccountContext(address types.Address) AccountVmContext {
-	return NewAccountContext(nil, account.NewAccountStore(address, db.NewMemDB()), nil)
+	return NewAccountContext(nil, account.NewAccountStore(address, db.NewMemDB()), nil, nil)
 }

--- a/vm/vm_context/interfaces.go
+++ b/vm/vm_context/interfaces.go
@@ -12,6 +12,7 @@ import (
 type AccountVmContext interface {
 	api.PillarReader
 	store.Account
+	CacheStore() store.Cache
 	MomentumStore() store.Momentum
 
 	// ====== State ======

--- a/vm/vm_context/spork.go
+++ b/vm/vm_context/spork.go
@@ -6,19 +6,19 @@ import (
 )
 
 func (ctx *accountVmContext) IsAcceleratorSporkEnforced() bool {
-	active, err := ctx.momentumStore.IsSporkActive(types.AcceleratorSpork)
+	active, err := ctx.cacheStore.IsSporkActive(types.AcceleratorSpork)
 	common.DealWithErr(err)
 	return active
 }
 
 func (ctx *accountVmContext) IsHtlcSporkEnforced() bool {
-	active, err := ctx.momentumStore.IsSporkActive(types.HtlcSpork)
+	active, err := ctx.cacheStore.IsSporkActive(types.HtlcSpork)
 	common.DealWithErr(err)
 	return active
 }
 
 func (ctx *accountVmContext) IsBridgeAndLiquiditySporkEnforced() bool {
-	active, err := ctx.momentumStore.IsSporkActive(types.BridgeAndLiquiditySpork)
+	active, err := ctx.cacheStore.IsSporkActive(types.BridgeAndLiquiditySpork)
 	common.DealWithErr(err)
 	return active
 }

--- a/zenon/mock/interfaces.go
+++ b/zenon/mock/interfaces.go
@@ -20,4 +20,5 @@ type MockZenon interface {
 
 	SaveLogs(logger common.Logger) *common.Expecter
 	ExpectBalance(address types.Address, standard types.ZenonTokenStandard, expected int64)
+	ExpectCacheFusedAmount(address types.Address, expected int64)
 }

--- a/zenon/mock/zenon_test.go
+++ b/zenon/mock/zenon_test.go
@@ -17,11 +17,15 @@ func TestStateGenesis(t *testing.T) {
 	store := z.Chain().GetFrontierMomentumStore()
 	common.ExpectBytes(t, store.Identifier().Hash.Bytes(), "0x0385d849ee33b94c8783288c148e3ae741c2ecec98b08b3f59d6bcc219168fe5")
 
+	cacheStore := z.Chain().GetFrontierCacheStore()
+	common.ExpectBytes(t, cacheStore.Identifier().Hash.Bytes(), "0x0385d849ee33b94c8783288c148e3ae741c2ecec98b08b3f59d6bcc219168fe5")
+
 	genesis, err := store.GetMomentumByHeight(1)
 	common.FailIfErr(t, err)
 	common.ExpectString(t, string(genesis.Data[0:43]), "This is the genesis config used for testing")
 
 	z.ExpectBalance(g.User1.Address, types.ZnnTokenStandard, 12000*g.Zexp)
+	z.ExpectCacheFusedAmount(g.User1.Address, 10000*g.Zexp)
 }
 
 func TestStateProducer(t *testing.T) {

--- a/zenon/zenon.go
+++ b/zenon/zenon.go
@@ -4,6 +4,7 @@ import (
 	"github.com/syndtr/goleveldb/leveldb"
 
 	"github.com/zenon-network/go-zenon/chain"
+	cache "github.com/zenon-network/go-zenon/chain/cache/storage"
 	"github.com/zenon-network/go-zenon/consensus"
 	"github.com/zenon-network/go-zenon/pillar"
 	"github.com/zenon-network/go-zenon/protocol"
@@ -30,8 +31,7 @@ func NewZenon(cfg *Config) (Zenon, error) {
 	z := &zenon{
 		config: cfg,
 	}
-
-	z.chain = chain.NewChain(cfg.NewDBManager("nom"), cfg.GenesisConfig)
+	z.chain = chain.NewChain(cfg.NewDBManager("nom"), cache.NewCacheDBManager(cfg.DataDir), cfg.GenesisConfig)
 	db, levelDb := cfg.NewLevelDB("consensus")
 	z.consensus = consensus.NewConsensus(db, z.chain, false)
 	z.verifier = verifier.NewVerifier(z.chain, z.consensus)


### PR DESCRIPTION
Significant performance issues start appearing when the node validates an account block that uses an old momentum acknowledgement height.

The reason for the slow processing time of such an account block is that in order to verify the account block, the node must rollback the chain database's state to the block's momentum acknowledgement height. The rollback operation is done in the `Get` function in `versioned_db.go`.

In order to prevent the need for an expensive rollback operation, this PR introduces an additional chain cache database that stores the necessary state information in a way that can be accessed quickly.

To validate a *user* account block, the following stateful information is needed:

1. The amount of plasma fused to the sender's address at momentum acknowledgement height.
2. The amount of total chain plasma committed by the sender at momentum acknowledgement height.
3. What sporks are active at momentum acknowledgement height.

These three data items are stored in the cache using a momentum height composite key, allowing the key-value pairs to be iterated over in order to get the value at a specific height. Using the cache removes the need to rollback the momentum store to the momentum acknowledgment height, when validating a user account block.

To validate an *embedded* account block, various stateful data items are needed, since processing an embedded account block executes contract functionality. This means that the validation of an embedded account block still rolls back the momentum store to the momentum acknowledgement height. An embedded account block uses the send block's confirmation height as its acknowledgement height, which means that the amount of momentums needed to be rolled back will always be small, minimizing potential issues related to performance.

**Note:** An account block is not allowed to reference an older momentum acknowledgement height than what the previous account block has used. Because of this, the old states related to plasma are pruned. This significantly reduces the cache's size.

### Benchmarks
Benchmarking the time it takes to process the troublesome momentum 6,606,105 produces the following results:
|Version|Processing time|
|-----|-----|
|Current (v0.0.7)|10 min 21.6126 s|
|New|11.6853 ms|

### Testing

A full resync of the node has been tested with these changes.