### PR TITLE
Fix versioned db tests

### DIFF
--- a/common/db/versioned_db_test.go
+++ b/common/db/versioned_db_test.go
@@ -67,6 +67,7 @@ func newMockTransaction(seed int64, db DB) *mockTransaction {
 
 func TestVersionedDBConcurrentUse(t *testing.T) {
 	m := NewLevelDBManager(t.TempDir())
+	defer m.Stop()
 	v0 := m.Frontier()
 	v01 := m.Frontier()
 
@@ -235,6 +236,7 @@ f25f4b21eef64b43 - 9c0a8a2bfc0914df`)
 
 	common.FailIfErr(t, m.Stop())
 	m2 := NewLevelDBManager(dir)
+	defer m2.Stop()
 	db = m2.Frontier()
 	common.ExpectString(t, DebugDB(db), `
 00 - 0a220a20d8ba48392cd7843812028c9fc3d7c92e232b8a725db741d69c930772e8551a851003


### PR DESCRIPTION
The test cases `TestVersionedDBConcurrentUse` and `TestVersionedDBVersions` in `versioned_db_test.go` will fail because the `LevelDBManager` instances are not cleaned up during teardown.

The following error messages will be shown when running the tests:

```TempDir RemoveAll cleanup: remove ...\TestVersionedDBConcurrentUse2208946391\001\000001.log: The process cannot access the file because it is being used by another process.```

```TempDir RemoveAll cleanup: remove ...\TestVersionedDBVersions80412342\001\000002.ldb: The process cannot access the file because it is being used by another process.```

This commit makes sure the resources are properly cleaned up during teardown.