### PR TITLE
Fix isRevocable field in plasma getEntriesByAddress API

### DIFF
--- a/rpc/api/embedded/plasma.go
+++ b/rpc/api/embedded/plasma.go
@@ -76,12 +76,14 @@ type FusionEntry struct {
 	Beneficiary      types.Address `json:"beneficiary"`
 	ExpirationHeight uint64        `json:"expirationHeight"`
 	Id               types.Hash    `json:"id"`
+	IsRevocable      bool          `json:"isRevocable"`
 }
 type FusionEntryMarshal struct {
 	QsrAmount        string        `json:"qsrAmount"`
 	Beneficiary      types.Address `json:"beneficiary"`
 	ExpirationHeight uint64        `json:"expirationHeight"`
 	Id               types.Hash    `json:"id"`
+	IsRevocable      bool          `json:"isRevocable"`
 }
 
 func (r *FusionEntry) ToFusionEntryMarshal() *FusionEntryMarshal {
@@ -90,6 +92,7 @@ func (r *FusionEntry) ToFusionEntryMarshal() *FusionEntryMarshal {
 		Beneficiary:      r.Beneficiary,
 		ExpirationHeight: r.ExpirationHeight,
 		Id:               r.Id,
+		IsRevocable:      r.IsRevocable,
 	}
 
 	return aux
@@ -108,6 +111,7 @@ func (r *FusionEntry) UnmarshalJSON(data []byte) error {
 	r.Beneficiary = aux.Beneficiary
 	r.ExpirationHeight = aux.ExpirationHeight
 	r.Id = aux.Id
+	r.IsRevocable = aux.IsRevocable
 	return nil
 }
 
@@ -192,7 +196,7 @@ func (a *PlasmaApi) GetEntriesByAddress(address types.Address, pageIndex, pageSi
 		return nil, api.ErrPageSizeParamTooBig
 	}
 
-	_, context, err := api.GetFrontierContext(a.chain, types.PlasmaContract)
+	momentum, context, err := api.GetFrontierContext(a.chain, types.PlasmaContract)
 	if err != nil {
 		return nil, err
 	}
@@ -208,10 +212,11 @@ func (a *PlasmaApi) GetEntriesByAddress(address types.Address, pageIndex, pageSi
 
 	for i, info := range list[start:end] {
 		entryList[i] = &FusionEntry{
-			info.Amount,
-			info.Beneficiary,
-			info.ExpirationHeight,
-			info.Id,
+			QsrAmount:        info.Amount,
+			Beneficiary:      info.Beneficiary,
+			ExpirationHeight: info.ExpirationHeight,
+			Id:               info.Id,
+			IsRevocable:      momentum.Height >= info.ExpirationHeight,
 		}
 	}
 	return &FusionEntryList{amount, listLen, entryList}, nil

--- a/vm/embedded/tests/plasma_test.go
+++ b/vm/embedded/tests/plasma_test.go
@@ -242,19 +242,22 @@ func TestPlasma_rpc(t *testing.T) {
 			"qsrAmount": "1000000000000",
 			"beneficiary": "z1qqfmjdays57w488sta69ykc2ey7r6d0q9wdvtj",
 			"expirationHeight": 0,
-			"id": "XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+			"id": "XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+			"isRevocable": true
 		},
 		{
 			"qsrAmount": "1000000000000",
 			"beneficiary": "z1qzal6c5s9rjnnxd2z7dvdhjxpmmj4fmw56a0mz",
 			"expirationHeight": 0,
-			"id": "XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+			"id": "XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+			"isRevocable": true
 		},
 		{
 			"qsrAmount": "1000000000",
 			"beneficiary": "z1qqdt06lnwz57x38rwlyutcx5wgrtl0ynkfe3kv",
 			"expirationHeight": 102,
-			"id": "XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+			"id": "XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+			"isRevocable": false
 		}
 	]
 }`)
@@ -287,13 +290,15 @@ t=2001-09-09T01:46:50+0000 lvl=dbug msg="canceled fusion entry" module=embedded 
 			"qsrAmount": "1000000000000",
 			"beneficiary": "z1qqfmjdays57w488sta69ykc2ey7r6d0q9wdvtj",
 			"expirationHeight": 0,
-			"id": "0000000000000000000000000000000000000000000000000000000000000000"
+			"id": "0000000000000000000000000000000000000000000000000000000000000000",
+			"isRevocable": true
 		},
 		{
 			"qsrAmount": "1000000000000",
 			"beneficiary": "z1qzal6c5s9rjnnxd2z7dvdhjxpmmj4fmw56a0mz",
 			"expirationHeight": 0,
-			"id": "117613e734b6cb0fd7b7583f5b0e863a3f0c856cd32fa36f1b60b464d068c5a6"
+			"id": "117613e734b6cb0fd7b7583f5b0e863a3f0c856cd32fa36f1b60b464d068c5a6",
+			"isRevocable": true
 		}
 	]
 }`)
@@ -374,7 +379,8 @@ t=2001-09-09T01:46:50+0000 lvl=dbug msg="canceled fusion entry" module=embedded 
 			"qsrAmount": "1000000000000",
 			"beneficiary": "z1qqfmjdays57w488sta69ykc2ey7r6d0q9wdvtj",
 			"expirationHeight": 0,
-			"id": "0000000000000000000000000000000000000000000000000000000000000000"
+			"id": "0000000000000000000000000000000000000000000000000000000000000000",
+			"isRevocable": true
 		}
 	]
 }`)
@@ -408,13 +414,15 @@ t=2001-09-09T01:52:10+0000 lvl=dbug msg="canceled fusion entry" module=embedded 
 			"qsrAmount": "1000000000000",
 			"beneficiary": "z1qqfmjdays57w488sta69ykc2ey7r6d0q9wdvtj",
 			"expirationHeight": 0,
-			"id": "0000000000000000000000000000000000000000000000000000000000000000"
+			"id": "0000000000000000000000000000000000000000000000000000000000000000",
+			"isRevocable": true
 		},
 		{
 			"qsrAmount": "1000000000000",
 			"beneficiary": "z1qzal6c5s9rjnnxd2z7dvdhjxpmmj4fmw56a0mz",
 			"expirationHeight": 0,
-			"id": "117613e734b6cb0fd7b7583f5b0e863a3f0c856cd32fa36f1b60b464d068c5a6"
+			"id": "117613e734b6cb0fd7b7583f5b0e863a3f0c856cd32fa36f1b60b464d068c5a6",
+			"isRevocable": true
 		}
 	]
 }`)
@@ -441,19 +449,22 @@ t=2001-09-09T01:52:10+0000 lvl=dbug msg="canceled fusion entry" module=embedded 
 			"qsrAmount": "1000000000000",
 			"beneficiary": "z1qqfmjdays57w488sta69ykc2ey7r6d0q9wdvtj",
 			"expirationHeight": 0,
-			"id": "XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+			"id": "XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+			"isRevocable": true
 		},
 		{
 			"qsrAmount": "1000000000000",
 			"beneficiary": "z1qzal6c5s9rjnnxd2z7dvdhjxpmmj4fmw56a0mz",
 			"expirationHeight": 0,
-			"id": "XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+			"id": "XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+			"isRevocable": true
 		},
 		{
 			"qsrAmount": "1000000000",
 			"beneficiary": "z1qzal6c5s9rjnnxd2z7dvdhjxpmmj4fmw56a0mz",
 			"expirationHeight": 32,
-			"id": "XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+			"id": "XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
+			"isRevocable": true
 		}
 	]
 }`)


### PR DESCRIPTION
The getEntriesByAddress method now correctly returns the isRevocable boolean field for fusion entries based on whether the current momentum height has reached the entry's expiration height.

Changes:
- Added IsRevocable field to FusionEntry and FusionEntryMarshal structs
- Updated JSON marshaling methods to handle IsRevocable
- Modified GetEntriesByAddress to calculate isRevocable status
- Updated all plasma tests to reflect new field in responses