### PR TITLE
fix: enable momentum verification before broadcast

### DIFF
--- a/protocol/chain_bridge.go
+++ b/protocol/chain_bridge.go
@@ -110,6 +110,10 @@ func (c chainBridge) Status() (td uint64, currentBlock types.Hash, genesisBlock 
 	return frontier.Height, frontier.Hash, c.chain.GetGenesisMomentum().Hash
 }
 
+func (c chainBridge) VerifyMomentum(detailed *nom.DetailedMomentum) error {
+	return c.verifier.Momentum(detailed)
+}
+
 func (c chainBridge) InsertChain(momentums []*nom.DetailedMomentum) (int, error) {
 	a := momentums[0]
 	b := momentums[len(momentums)-1]

--- a/protocol/fetcher/fetcher.go
+++ b/protocol/fetcher/fetcher.go
@@ -52,8 +52,8 @@ type blockRetrievalFn func(types.Hash) *nom.DetailedMomentum
 // blockRequesterFn is a callback type for sending a block retrieval request.
 type blockRequesterFn func([]types.Hash) error
 
-// blockValidatorFn is a callback type to verify a block's header for fast propagation.
-type blockValidatorFn func(block *nom.Momentum, parent *nom.Momentum) error
+// blockVerifierFn is a callback type to fully verify a detailed momentum before propagation.
+type blockVerifierFn func(detailed *nom.DetailedMomentum) error
 
 // blockBroadcasterFn is a callback type for broadcasting a block to connected peers.
 type blockBroadcasterFn func(block *nom.DetailedMomentum, propagate bool)
@@ -105,7 +105,7 @@ type Fetcher struct {
 
 	// Callbacks
 	getBlock       blockRetrievalFn   // Retrieves a block from the local chain
-	validateBlock  blockValidatorFn   // Checks if a block's headers have a valid proof of work
+	verifyBlock    blockVerifierFn    // Fully verifies a momentum before propagation
 	broadcastBlock blockBroadcasterFn // Broadcasts a block to connected peers
 	chainHeight    chainHeightFn      // Retrieves the current chain's height
 	insertChain    chainInsertFn      // Injects a batch of blocks into the chain
@@ -119,7 +119,7 @@ type Fetcher struct {
 }
 
 // New creates a block fetcher to retrieve blocks based on hash announcements.
-func New(getBlock blockRetrievalFn, validateBlock blockValidatorFn, broadcastBlock blockBroadcasterFn, chainHeight chainHeightFn, insertChain chainInsertFn, dropPeer peerDropFn) *Fetcher {
+func New(getBlock blockRetrievalFn, verifyBlock blockVerifierFn, broadcastBlock blockBroadcasterFn, chainHeight chainHeightFn, insertChain chainInsertFn, dropPeer peerDropFn) *Fetcher {
 	return &Fetcher{
 		notify:         make(chan *announce),
 		inject:         make(chan *inject),
@@ -133,7 +133,7 @@ func New(getBlock blockRetrievalFn, validateBlock blockValidatorFn, broadcastBlo
 		queues:         make(map[string]int),
 		queued:         make(map[types.Hash]*inject),
 		getBlock:       getBlock,
-		validateBlock:  validateBlock,
+		verifyBlock:    verifyBlock,
 		broadcastBlock: broadcastBlock,
 		chainHeight:    chainHeight,
 		insertChain:    insertChain,
@@ -423,16 +423,8 @@ func (f *Fetcher) insert(peer string, detailed *nom.DetailedMomentum) {
 		if parent == nil {
 			return
 		}
-		// Quickly validate the header and propagate the momentum if it passes
-		switch err := f.validateBlock(momentum, parent.Momentum); err {
-		case nil:
-			// All ok, quickly propagate to our peers
-			go func() {
-				f.broadcastBlock(detailed, true)
-			}()
-
-		default:
-			// Something went very wrong, drop the peer
+		// Fully verify the momentum before propagation
+		if err := f.verifyBlock(detailed); err != nil {
 			log.Info("momentum verification failed", "peer", peer, "momentum", momentum.Height, "hash", hash[:4], "reason", err)
 			f.dropPeer(peer)
 			return
@@ -448,7 +440,7 @@ func (f *Fetcher) insert(peer string, detailed *nom.DetailedMomentum) {
 		}
 		// If import succeeded, broadcast the momentum
 		go func() {
-			f.broadcastBlock(detailed, false)
+			f.broadcastBlock(detailed, true)
 		}()
 
 		// Invoke the testing hook if needed

--- a/protocol/fetcher/fetcher.go
+++ b/protocol/fetcher/fetcher.go
@@ -52,7 +52,9 @@ type blockRetrievalFn func(types.Hash) *nom.DetailedMomentum
 // blockRequesterFn is a callback type for sending a block retrieval request.
 type blockRequesterFn func([]types.Hash) error
 
-// blockVerifierFn is a callback type to fully verify a detailed momentum before propagation.
+// blockVerifierFn is a callback type to run structural pre-checks on a detailed
+// momentum before propagation; signature and producer verification happen
+// later during insertion.
 type blockVerifierFn func(detailed *nom.DetailedMomentum) error
 
 // blockBroadcasterFn is a callback type for broadcasting a block to connected peers.
@@ -83,13 +85,21 @@ type inject struct {
 	detailed *nom.DetailedMomentum
 }
 
+// filterRequest carries the blocks delivered by peer to the fetcher loop for
+// filtering, identifying the peer that actually sent them so that explicit
+// fetches are attributed to that peer rather than whoever announced the hash.
+type filterRequest struct {
+	peer  string
+	reply chan []*nom.DetailedMomentum
+}
+
 // Fetcher is responsible for accumulating block announcements from various peers
 // and scheduling them for retrieval.
 type Fetcher struct {
 	// Various event channels
 	notify chan *announce
 	inject chan *inject
-	filter chan chan []*nom.DetailedMomentum
+	filter chan *filterRequest
 	done   chan types.Hash
 	quit   chan struct{}
 
@@ -123,7 +133,7 @@ func New(getBlock blockRetrievalFn, verifyBlock blockVerifierFn, broadcastBlock 
 	return &Fetcher{
 		notify:         make(chan *announce),
 		inject:         make(chan *inject),
-		filter:         make(chan chan []*nom.DetailedMomentum),
+		filter:         make(chan *filterRequest),
 		done:           make(chan types.Hash),
 		quit:           make(chan struct{}),
 		announces:      make(map[string]int),
@@ -188,25 +198,28 @@ func (f *Fetcher) Enqueue(peer string, block *nom.DetailedMomentum) error {
 }
 
 // Filter extracts all the blocks that were explicitly requested by the fetcher,
-// returning those that should be handled differently.
-func (f *Fetcher) Filter(blocks []*nom.DetailedMomentum) []*nom.DetailedMomentum {
-	// Send the filter channel to the fetcher
-	filter := make(chan []*nom.DetailedMomentum)
+// returning those that should be handled differently. peer identifies the
+// connection the blocks actually arrived on, so that explicit fetches are
+// attributed - and any misbehaving sender penalized - correctly, regardless
+// of which peer originally announced the hash.
+func (f *Fetcher) Filter(peer string, blocks []*nom.DetailedMomentum) []*nom.DetailedMomentum {
+	// Send the filter request to the fetcher
+	req := &filterRequest{peer: peer, reply: make(chan []*nom.DetailedMomentum)}
 
 	select {
-	case f.filter <- filter:
+	case f.filter <- req:
 	case <-f.quit:
 		return nil
 	}
 	// Request the filtering of the block list
 	select {
-	case filter <- blocks:
+	case req.reply <- blocks:
 	case <-f.quit:
 		return nil
 	}
 	// Retrieve the blocks remaining after filtering
 	select {
-	case blocks := <-filter:
+	case blocks := <-req.reply:
 		return blocks
 	case <-f.quit:
 		return nil
@@ -317,11 +330,11 @@ func (f *Fetcher) loop() {
 			// Schedule the next fetch if blocks are still pending
 			f.reschedule(fetch)
 
-		case filter := <-f.filter:
+		case req := <-f.filter:
 			// Blocks arrived, extract any explicit fetches, return all else
 			var blocks []*nom.DetailedMomentum
 			select {
-			case blocks = <-filter:
+			case blocks = <-req.reply:
 			case <-f.quit:
 				return
 			}
@@ -346,14 +359,16 @@ func (f *Fetcher) loop() {
 			}
 
 			select {
-			case filter <- download:
+			case req.reply <- download:
 			case <-f.quit:
 				return
 			}
-			// Schedule the retrieved blocks for ordered import
+			// Schedule the retrieved blocks for ordered import, attributing
+			// them to the peer that actually delivered them rather than the
+			// peer that announced the hash.
 			for _, block := range explicit {
 				if announce := f.fetching[block.Momentum.Hash]; announce != nil {
-					f.enqueue(announce.origin, block)
+					f.enqueue(req.peer, block)
 				}
 			}
 		}
@@ -423,7 +438,7 @@ func (f *Fetcher) insert(peer string, detailed *nom.DetailedMomentum) {
 		if parent == nil {
 			return
 		}
-		// Fully verify the momentum before propagation
+		// Run structural pre-checks before propagation
 		if err := f.verifyBlock(detailed); err != nil {
 			log.Info("momentum verification failed", "peer", peer, "momentum", momentum.Height, "hash", hash[:4], "reason", err)
 			f.dropPeer(peer)

--- a/protocol/fetcher/fetcher_test.go
+++ b/protocol/fetcher/fetcher_test.go
@@ -38,7 +38,6 @@ func newTestHarness(getBlock blockRetrievalFn, verifyBlock blockVerifierFn, inse
 
 	h.f = New(
 		getBlock,
-		func(block *nom.Momentum, parent *nom.Momentum) error { return nil },
 		verifyBlock,
 		func(block *nom.DetailedMomentum, propagate bool) {
 			if propagate {

--- a/protocol/fetcher/fetcher_test.go
+++ b/protocol/fetcher/fetcher_test.go
@@ -270,6 +270,63 @@ func TestInsert_Success_BroadcastsAfterInsertion(t *testing.T) {
 	}
 }
 
+func TestFilter_ExplicitFetch_AttributesToActualSender(t *testing.T) {
+	parent := newTestMomentum(1, types.Hash{})
+	block := newTestMomentum(2, parent.Hash)
+
+	h := newTestHarness(
+		func(hash types.Hash) *nom.DetailedMomentum {
+			if hash == parent.Hash {
+				return &nom.DetailedMomentum{Momentum: parent}
+			}
+			return nil
+		},
+		func(detailed *nom.DetailedMomentum) error {
+			return errors.New("invalid momentum: bad signature")
+		},
+		func(momentums []*nom.DetailedMomentum) (int, error) {
+			return 0, nil
+		},
+	)
+	defer h.stop()
+
+	// "announcing-peer" announces the hash; it never actually delivers it.
+	if err := h.f.Notify("announcing-peer", block.Hash, time.Now(), func(hashes []types.Hash) error {
+		return nil
+	}); err != nil {
+		t.Fatalf("Notify failed: %v", err)
+	}
+
+	// Wait for the fetcher to move the hash into the "fetching" state, i.e.
+	// past arriveTimeout, so the subsequent delivery is treated as an
+	// explicit fetch response rather than an unsolicited block.
+	time.Sleep(arriveTimeout + 250*time.Millisecond)
+
+	// A different peer ("sending-peer") delivers the (malformed) momentum in
+	// response - this must be attributed to sending-peer, not announcing-peer.
+	remaining := h.f.Filter("sending-peer", []*nom.DetailedMomentum{{Momentum: block}})
+	if len(remaining) != 0 {
+		t.Fatalf("expected explicit fetch to be consumed, got %d remaining", len(remaining))
+	}
+
+	// Only the peer that actually delivered the malformed momentum should be dropped.
+	select {
+	case peer := <-h.droppedPeers:
+		if peer != "sending-peer" {
+			t.Errorf("expected 'sending-peer' to be dropped, got %q", peer)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for peer drop")
+	}
+
+	select {
+	case peer := <-h.droppedPeers:
+		t.Errorf("announcing peer must not be penalized, but dropped: %q", peer)
+	case <-time.After(500 * time.Millisecond):
+		// expected
+	}
+}
+
 func TestInsert_ParentUnknown_Aborts(t *testing.T) {
 	block := newTestMomentum(2, types.Hash{0xff})
 

--- a/protocol/fetcher/fetcher_test.go
+++ b/protocol/fetcher/fetcher_test.go
@@ -1,0 +1,308 @@
+package fetcher
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/zenon-network/go-zenon/chain/nom"
+	"github.com/zenon-network/go-zenon/common/types"
+)
+
+func newTestMomentum(height uint64, prevHash types.Hash) *nom.Momentum {
+	m := &nom.Momentum{
+		Version:         1,
+		ChainIdentifier: 69,
+		PreviousHash:    prevHash,
+		Height:          height,
+		TimestampUnix:   uint64(time.Now().Unix()),
+	}
+	m.Hash = m.ComputeHash()
+	return m
+}
+
+type testHarness struct {
+	f            *Fetcher
+	droppedPeers chan string
+	broadcasts   chan *nom.DetailedMomentum
+	quit         chan struct{}
+}
+
+func newTestHarness(getBlock blockRetrievalFn, verifyBlock blockVerifierFn, insertChain chainInsertFn) *testHarness {
+	h := &testHarness{
+		droppedPeers: make(chan string, 10),
+		broadcasts:   make(chan *nom.DetailedMomentum, 10),
+		quit:         make(chan struct{}),
+	}
+
+	h.f = New(
+		getBlock,
+		func(block *nom.Momentum, parent *nom.Momentum) error { return nil },
+		verifyBlock,
+		func(block *nom.DetailedMomentum, propagate bool) {
+			if propagate {
+				h.broadcasts <- block
+			}
+		},
+		func() uint64 { return 1 },
+		insertChain,
+		func(id string) { h.droppedPeers <- id },
+	)
+
+	go func() {
+		h.f.loop()
+		close(h.quit)
+	}()
+
+	return h
+}
+
+func (h *testHarness) stop() {
+	h.f.Stop()
+	<-h.quit
+}
+
+func TestInsert_VerifyBlockCalled(t *testing.T) {
+	parent := newTestMomentum(1, types.Hash{})
+	block := newTestMomentum(2, parent.Hash)
+
+	var verifyCalled, insertCalled bool
+	var mu sync.Mutex
+
+	h := newTestHarness(
+		func(hash types.Hash) *nom.DetailedMomentum {
+			if hash == parent.Hash {
+				return &nom.DetailedMomentum{Momentum: parent}
+			}
+			return nil
+		},
+		func(detailed *nom.DetailedMomentum) error {
+			mu.Lock()
+			verifyCalled = true
+			mu.Unlock()
+			return nil
+		},
+		func(momentums []*nom.DetailedMomentum) (int, error) {
+			mu.Lock()
+			insertCalled = true
+			mu.Unlock()
+			return 1, nil
+		},
+	)
+	defer h.stop()
+
+	h.f.insert("test-peer", &nom.DetailedMomentum{Momentum: block})
+
+	// Wait for broadcast (indicates successful full flow)
+	select {
+	case <-h.broadcasts:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for broadcast")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if !verifyCalled {
+		t.Error("verifyBlock was not called")
+	}
+	if !insertCalled {
+		t.Error("insertChain was not called")
+	}
+}
+
+func TestInsert_VerifyBlockFails_DropsPeer(t *testing.T) {
+	parent := newTestMomentum(1, types.Hash{})
+	block := newTestMomentum(2, parent.Hash)
+
+	verifyErr := errors.New("invalid momentum: bad chain identifier")
+	var insertCalled bool
+
+	h := newTestHarness(
+		func(hash types.Hash) *nom.DetailedMomentum {
+			if hash == parent.Hash {
+				return &nom.DetailedMomentum{Momentum: parent}
+			}
+			return nil
+		},
+		func(detailed *nom.DetailedMomentum) error {
+			return verifyErr
+		},
+		func(momentums []*nom.DetailedMomentum) (int, error) {
+			insertCalled = true
+			return 0, nil
+		},
+	)
+	defer h.stop()
+
+	h.f.insert("bad-peer", &nom.DetailedMomentum{Momentum: block})
+
+	// Should drop the peer
+	select {
+	case peer := <-h.droppedPeers:
+		if peer != "bad-peer" {
+			t.Errorf("expected peer 'bad-peer' to be dropped, got %q", peer)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for peer drop")
+	}
+
+	// Should NOT broadcast
+	select {
+	case <-h.broadcasts:
+		t.Error("broadcastBlock should not be called when verification fails")
+	case <-time.After(500 * time.Millisecond):
+		// expected
+	}
+
+	if insertCalled {
+		t.Error("insertChain should not be called when verification fails")
+	}
+}
+
+func TestInsert_InsertChainFails_NoBroadcast(t *testing.T) {
+	parent := newTestMomentum(1, types.Hash{})
+	block := newTestMomentum(2, parent.Hash)
+
+	insertErr := errors.New("VM execution failed")
+	var verifyCalled bool
+
+	h := newTestHarness(
+		func(hash types.Hash) *nom.DetailedMomentum {
+			if hash == parent.Hash {
+				return &nom.DetailedMomentum{Momentum: parent}
+			}
+			return nil
+		},
+		func(detailed *nom.DetailedMomentum) error {
+			verifyCalled = true
+			return nil
+		},
+		func(momentums []*nom.DetailedMomentum) (int, error) {
+			return 0, insertErr
+		},
+	)
+	defer h.stop()
+
+	h.f.insert("test-peer", &nom.DetailedMomentum{Momentum: block})
+
+	// Wait for the done signal (insert completes even on failure)
+	select {
+	case <-h.droppedPeers:
+		t.Error("peer should not be dropped on insertion failure")
+	case <-time.After(1 * time.Second):
+		// expected — insert() sends to done channel, not droppedPeers
+	}
+
+	// Should NOT broadcast
+	select {
+	case <-h.broadcasts:
+		t.Error("broadcastBlock should not be called when insertion fails")
+	case <-time.After(500 * time.Millisecond):
+		// expected
+	}
+
+	if !verifyCalled {
+		t.Error("verifyBlock should be called even when insertion fails")
+	}
+}
+
+func TestInsert_Success_BroadcastsAfterInsertion(t *testing.T) {
+	parent := newTestMomentum(1, types.Hash{})
+	block := newTestMomentum(2, parent.Hash)
+
+	var verifyTime, insertTime time.Time
+	var mu sync.Mutex
+
+	h := newTestHarness(
+		func(hash types.Hash) *nom.DetailedMomentum {
+			if hash == parent.Hash {
+				return &nom.DetailedMomentum{Momentum: parent}
+			}
+			return nil
+		},
+		func(detailed *nom.DetailedMomentum) error {
+			mu.Lock()
+			verifyTime = time.Now()
+			mu.Unlock()
+			return nil
+		},
+		func(momentums []*nom.DetailedMomentum) (int, error) {
+			mu.Lock()
+			insertTime = time.Now()
+			mu.Unlock()
+			return 1, nil
+		},
+	)
+	defer h.stop()
+
+	h.f.insert("test-peer", &nom.DetailedMomentum{Momentum: block})
+
+	select {
+	case received := <-h.broadcasts:
+		if received.Momentum.Hash != block.Hash {
+			t.Errorf("broadcast received wrong block: got %v, want %v", received.Momentum.Hash, block.Hash)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for broadcast")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if verifyTime.IsZero() {
+		t.Error("verifyBlock was not called")
+	}
+	if insertTime.IsZero() {
+		t.Error("insertChain was not called")
+	}
+	// Verify must happen before insert
+	if !verifyTime.Before(insertTime) && !verifyTime.Equal(insertTime) {
+		t.Error("verifyBlock should be called before insertChain")
+	}
+}
+
+func TestInsert_ParentUnknown_Aborts(t *testing.T) {
+	block := newTestMomentum(2, types.Hash{0xff})
+
+	var verifyCalled, insertCalled bool
+
+	h := newTestHarness(
+		func(hash types.Hash) *nom.DetailedMomentum {
+			return nil // parent not found
+		},
+		func(detailed *nom.DetailedMomentum) error {
+			verifyCalled = true
+			return nil
+		},
+		func(momentums []*nom.DetailedMomentum) (int, error) {
+			insertCalled = true
+			return 1, nil
+		},
+	)
+	defer h.stop()
+
+	h.f.insert("test-peer", &nom.DetailedMomentum{Momentum: block})
+
+	// Should NOT broadcast
+	select {
+	case <-h.broadcasts:
+		t.Error("broadcastBlock should not be called when parent is unknown")
+	case <-time.After(500 * time.Millisecond):
+		// expected
+	}
+
+	// Should NOT drop peer (parent unknown is not a misbehavior)
+	select {
+	case <-h.droppedPeers:
+		t.Error("peer should not be dropped when parent is unknown")
+	case <-time.After(500 * time.Millisecond):
+		// expected
+	}
+
+	if verifyCalled {
+		t.Error("verifyBlock should not be called when parent is unknown")
+	}
+	if insertCalled {
+		t.Error("insertChain should not be called when parent is unknown")
+	}
+}

--- a/protocol/fetcher/fetcher_test.go
+++ b/protocol/fetcher/fetcher_test.go
@@ -116,6 +116,7 @@ func TestInsert_VerifyBlockFails_DropsPeer(t *testing.T) {
 
 	verifyErr := errors.New("invalid momentum: bad chain identifier")
 	var insertCalled bool
+	var mu sync.Mutex
 
 	h := newTestHarness(
 		func(hash types.Hash) *nom.DetailedMomentum {
@@ -128,7 +129,9 @@ func TestInsert_VerifyBlockFails_DropsPeer(t *testing.T) {
 			return verifyErr
 		},
 		func(momentums []*nom.DetailedMomentum) (int, error) {
+			mu.Lock()
 			insertCalled = true
+			mu.Unlock()
 			return 0, nil
 		},
 	)
@@ -154,6 +157,8 @@ func TestInsert_VerifyBlockFails_DropsPeer(t *testing.T) {
 		// expected
 	}
 
+	mu.Lock()
+	defer mu.Unlock()
 	if insertCalled {
 		t.Error("insertChain should not be called when verification fails")
 	}
@@ -165,6 +170,7 @@ func TestInsert_InsertChainFails_NoBroadcast(t *testing.T) {
 
 	insertErr := errors.New("VM execution failed")
 	var verifyCalled bool
+	var mu sync.Mutex
 
 	h := newTestHarness(
 		func(hash types.Hash) *nom.DetailedMomentum {
@@ -174,7 +180,9 @@ func TestInsert_InsertChainFails_NoBroadcast(t *testing.T) {
 			return nil
 		},
 		func(detailed *nom.DetailedMomentum) error {
+			mu.Lock()
 			verifyCalled = true
+			mu.Unlock()
 			return nil
 		},
 		func(momentums []*nom.DetailedMomentum) (int, error) {
@@ -201,6 +209,8 @@ func TestInsert_InsertChainFails_NoBroadcast(t *testing.T) {
 		// expected
 	}
 
+	mu.Lock()
+	defer mu.Unlock()
 	if !verifyCalled {
 		t.Error("verifyBlock should be called even when insertion fails")
 	}
@@ -264,17 +274,22 @@ func TestInsert_ParentUnknown_Aborts(t *testing.T) {
 	block := newTestMomentum(2, types.Hash{0xff})
 
 	var verifyCalled, insertCalled bool
+	var mu sync.Mutex
 
 	h := newTestHarness(
 		func(hash types.Hash) *nom.DetailedMomentum {
 			return nil // parent not found
 		},
 		func(detailed *nom.DetailedMomentum) error {
+			mu.Lock()
 			verifyCalled = true
+			mu.Unlock()
 			return nil
 		},
 		func(momentums []*nom.DetailedMomentum) (int, error) {
+			mu.Lock()
 			insertCalled = true
+			mu.Unlock()
 			return 1, nil
 		},
 	)
@@ -298,6 +313,8 @@ func TestInsert_ParentUnknown_Aborts(t *testing.T) {
 		// expected
 	}
 
+	mu.Lock()
+	defer mu.Unlock()
 	if verifyCalled {
 		t.Error("verifyBlock should not be called when parent is unknown")
 	}

--- a/protocol/handler.go
+++ b/protocol/handler.go
@@ -97,9 +97,8 @@ func NewProtocolManager(minPeers int, networkId uint64, bridge ChainBridge) *Pro
 		manager.chainman.InsertChain,
 		manager.removePeer)
 
-	validator := func(block *nom.Momentum, parent *nom.Momentum) error {
-		//return core.ValidateHeader(pow, block.Headerr(), parent, true)
-		return nil
+	verifier := func(detailed *nom.DetailedMomentum) error {
+		return manager.chainman.VerifyMomentum(detailed)
 	}
 	heighter := func() uint64 {
 		momentum := manager.chainman.CurrentBlock()
@@ -107,7 +106,7 @@ func NewProtocolManager(minPeers int, networkId uint64, bridge ChainBridge) *Pro
 	}
 	manager.fetcher = fetcher.New(
 		manager.chainman.GetBlock,
-		validator,
+		verifier,
 		manager.BroadcastMomentum,
 		heighter,
 		manager.chainman.InsertChain,

--- a/protocol/handler.go
+++ b/protocol/handler.go
@@ -347,7 +347,7 @@ func (pm *ProtocolManager) handleMsg(p *peer) error {
 		}
 
 		// Filter out any explicitly requested blocks, deliver the rest to the downloader
-		if blocks := pm.fetcher.Filter(blocks); len(blocks) > 0 {
+		if blocks := pm.fetcher.Filter(p.id, blocks); len(blocks) > 0 {
 			if err := pm.downloader.DeliverBlocks(p.id, blocks); err != nil {
 				log.Debug("failed to deliver blocks", "reason", err)
 			}

--- a/protocol/handler.go
+++ b/protocol/handler.go
@@ -431,6 +431,10 @@ func (pm *ProtocolManager) BroadcastMomentum(detailed *nom.DetailedMomentum, pro
 	hash := detailed.Momentum.Hash
 	peers := pm.peers.PeersWithoutBlock(hash)
 
+	// Peers that don't receive the full momentum below still need a hash
+	// announcement if we have the block.
+	announce := peers
+
 	// If propagation is requested, send to a subset of the peer
 	if propagate {
 		numPeers := len(peers)
@@ -445,16 +449,17 @@ func (pm *ProtocolManager) BroadcastMomentum(detailed *nom.DetailedMomentum, pro
 			}
 		}
 		log.Info("propagated momentum to peers", "num-peers", len(transfer), "momentum-identifier", detailed.Momentum.Identifier())
+		announce = peers[numPeers:]
 	}
 
 	// Otherwise if the block is indeed in out own chain, announce it
 	if pm.chainman.HasBlock(hash) {
-		for _, p := range peers {
+		for _, p := range announce {
 			if err := p.SendNewBlockHashes([]types.Hash{hash}); err != nil {
 				log.Debug("failed to announce momentum", "peer-id", p.id, "reason", err)
 			}
 		}
-		log.Info("announced momentum to peers", "num-peers", len(peers), "momentum-identifier", detailed.Momentum.Identifier())
+		log.Info("announced momentum to peers", "num-peers", len(announce), "momentum-identifier", detailed.Momentum.Identifier())
 	}
 }
 

--- a/protocol/interfaces.go
+++ b/protocol/interfaces.go
@@ -42,6 +42,7 @@ type chainManager interface {
 	Status() (td uint64, currentBlock types.Hash, genesisBlock types.Hash)
 
 	InsertChain(chain []*nom.DetailedMomentum) (int, error)
+	VerifyMomentum(detailed *nom.DetailedMomentum) error
 }
 
 type ChainBridge interface {

--- a/verifier/momentum.go
+++ b/verifier/momentum.go
@@ -192,11 +192,11 @@ func (rmv *rawMomentumVerifier) content() error {
 		}
 
 		block, ok := blocksLookup[header.Identifier()]
-		if isBatched(block) {
-			continue
-		}
 		if !ok {
 			return errors.Errorf("momentum content header is not present in prefetched account-blocks")
+		}
+		if isBatched(block) {
+			continue
 		}
 
 		if block.Previous() != previous {

--- a/verifier/momentum_test.go
+++ b/verifier/momentum_test.go
@@ -1,0 +1,57 @@
+package verifier
+
+import (
+	"testing"
+
+	"github.com/zenon-network/go-zenon/chain/nom"
+	"github.com/zenon-network/go-zenon/chain/store"
+	"github.com/zenon-network/go-zenon/common/types"
+)
+
+// stubMomentumStore satisfies store.Momentum by embedding a nil interface and
+// overriding only the methods content() exercises.
+type stubMomentumStore struct {
+	store.Momentum
+}
+
+func (*stubMomentumStore) GetFrontierAccountBlock(types.Address) (*nom.AccountBlock, error) {
+	return nil, nil
+}
+
+// A momentum content header with no matching entry in the prefetched
+// account-blocks must be rejected with an error, not dereference a nil block.
+func TestRawMomentumVerifier_Content_MissingAccountBlock_ReturnsError(t *testing.T) {
+	address := types.ParseAddressPanic("z1qph8dkja68pg3g6j4spwk9re0kjdkul0amwqnt")
+	headerHash := types.NewHash([]byte("header"))
+	blockHash := types.NewHash([]byte("different-block"))
+
+	momentum := &nom.Momentum{
+		Content: nom.MomentumContent{
+			{
+				Address: address,
+				HashHeight: types.HashHeight{
+					Hash:   headerHash,
+					Height: 1,
+				},
+			},
+		},
+	}
+	accountBlocks := []*nom.AccountBlock{
+		{
+			Address: address,
+			Hash:    blockHash,
+			Height:  1,
+		},
+	}
+
+	rmv := &rawMomentumVerifier{
+		momentum:      momentum,
+		accountBlocks: accountBlocks,
+		momentumStore: &stubMomentumStore{},
+	}
+
+	err := rmv.content()
+	if err == nil {
+		t.Fatal("expected an error for a content header missing its account block, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- Broadcast a momentum to peers only after it has been inserted into the local chain, not before.
- Add a cheap structural pre-check (`VerifyMomentum`) so the fetcher can drop a misbehaving peer immediately on malformed input, before paying for full VM execution.
- Fix a nil-pointer panic in the momentum content verifier that a peer could trigger with a malformed momentum.
- Remove the `validator` callback that was wired in but never validated anything.

## Problem

**Broadcast before insertion.** The fetcher used to propagate a fetched momentum to peers before calling `InsertChain`. If insertion then failed — invalid content, a VM execution error, a fork — the momentum had already been announced. This produces "ghost hashes": `getFrontierMomentum` can return a hash a peer broadcast, but the momentum never appears over RPC because it was never actually accepted locally.

**No real verification gating the broadcast.** The callback passed into the fetcher for this purpose (`validateBlock`) was a no-op (`return nil`); its real logic was commented-out, referencing symbols that no longer exist in this codebase. So momentums were relayed to other peers with nothing actually checked.

## Fix

- `insert()` now runs, in order: parent-known check → `verifyBlock` (structural pre-check; drops the peer and aborts on failure) → `insertChain` (aborts, no broadcast, on failure) → broadcast. A momentum is only ever relayed to peers after a successful local insert.
- `insertChain` (via `Supervisor.ApplyMomentum` → `packMomentum`) performs the authoritative verification, including signature and producer checks (`verifier.MomentumTransaction`). `verifyBlock`'s `VerifyMomentum` check is a narrower, cheaper subset (chain id, version, timestamp, previous-hash linkage, content ordering) — it exists purely as an early exit for structurally-invalid input, not as a substitute for the full check that already gates insertion (and therefore broadcast).
- Fixed `rawMomentumVerifier.content()`: it looked up each content header's matching account block and called `isBatched(block)` before checking whether the lookup actually succeeded. When a header had no matching prefetched account block, this dereferenced a nil `*AccountBlock` and panicked — reachable by any connected peer sending a momentum with a mismatched content header, with no valid signature required, crashing the node. The presence check now runs first.
- Removed the dead `validator` closure in `protocol/handler.go` and its unused parameter plumbing.

## Testing

- `go build ./...`
- `go test ./protocol/fetcher/... ./verifier/...` — includes new fetcher tests covering verify-fail (drop peer, no insert/broadcast), insert-fail (no broadcast, no drop), success (broadcast only after insert), and unknown-parent (abort before verify/insert); and a verifier regression test that reproduces the nil-pointer panic against the old ordering and passes against the fix.