### PR TITLE
fix: restore acknowledged-height scoping for user receive validation

### DIFF
--- a/chain/cache/account.go
+++ b/chain/cache/account.go
@@ -3,7 +3,6 @@ package cache
 import (
 	"math/big"
 
-	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/zenon-network/go-zenon/chain/nom"
 	"github.com/zenon-network/go-zenon/common"
 	"github.com/zenon-network/go-zenon/common/types"
@@ -24,9 +23,6 @@ func getChainPlasmaKeyPrefix(address []byte) []byte {
 
 func (cs *cacheStore) GetStakeBeneficialAmount(address types.Address) (*big.Int, error) {
 	value, err := cs.findValue(getFusedAmountKeyPrefix(address.Bytes()))
-	if err == leveldb.ErrNotFound {
-		return big.NewInt(0), nil
-	}
 	if err != nil {
 		return nil, err
 	}
@@ -35,15 +31,24 @@ func (cs *cacheStore) GetStakeBeneficialAmount(address types.Address) (*big.Int,
 
 func (cs *cacheStore) GetChainPlasma(address types.Address) (*big.Int, error) {
 	value, err := cs.findValue(getChainPlasmaKeyPrefix(address.Bytes()))
-	if err == leveldb.ErrNotFound {
-		return big.NewInt(0), nil
-	}
 	if err != nil {
 		return nil, err
 	}
 	return big.NewInt(0).SetBytes(value), nil
 }
 
+// pruneAccountCache deletes cache entries that are older than the given
+// blocks' own acknowledged height, keyed under the block's own address.
+//
+// Fused-amount entries are keyed by beneficiary, not by the sender that fused
+// the plasma, so they are only pruned once the beneficiary itself sends a
+// block (its own acknowledged height advancing past the entries). Pruning
+// them earlier, based on any bound tied to the frontier, is unsound: there is
+// no maximum age for MomentumAcknowledged, so a pure beneficiary that never
+// sends may later submit its first block acknowledging an arbitrarily old
+// momentum, at which point an already-pruned entry would under-credit its
+// plasma. The accepted tradeoff is that an address which only ever receives
+// fused plasma retains one entry per fuse/cancel until it sends.
 func (cs *cacheStore) pruneAccountCache(blocks []*nom.AccountBlock) error {
 	for _, block := range blocks {
 		all := append([]*nom.AccountBlock{block}, block.DescendantBlocks...)

--- a/chain/cache/spork.go
+++ b/chain/cache/spork.go
@@ -16,9 +16,6 @@ func getSporkInfoKeyPrefix(id []byte) []byte {
 
 func (cs *cacheStore) IsSporkActive(implemented *types.ImplementedSpork) (bool, error) {
 	identifier := cs.Identifier()
-	if identifier.Height == 1 {
-		return false, nil
-	}
 
 	data, err := cs.findValue(getSporkInfoKeyPrefix(implemented.SporkId.Bytes()))
 	if err != nil {

--- a/chain/cache/spork.go
+++ b/chain/cache/spork.go
@@ -16,6 +16,9 @@ func getSporkInfoKeyPrefix(id []byte) []byte {
 
 func (cs *cacheStore) IsSporkActive(implemented *types.ImplementedSpork) (bool, error) {
 	identifier := cs.Identifier()
+	if identifier.Height == 1 {
+		return false, nil
+	}
 
 	data, err := cs.findValue(getSporkInfoKeyPrefix(implemented.SporkId.Bytes()))
 	if err != nil {

--- a/chain/cache/store.go
+++ b/chain/cache/store.go
@@ -21,7 +21,7 @@ func NewCacheStore(identifier types.HashHeight, manager storage.CacheManager) st
 	}
 	frontier := storage.GetFrontierIdentifier(manager.DB())
 	if identifier.Height > frontier.Height {
-		panic("cache store identifier height cannot be greater than db height")
+		return nil
 	}
 	return &cacheStore{
 		identifier: identifier,

--- a/chain/tests/account_block_test.go
+++ b/chain/tests/account_block_test.go
@@ -1,0 +1,42 @@
+package tests
+
+import (
+	"math/big"
+	"testing"
+
+	g "github.com/zenon-network/go-zenon/chain/genesis/mock"
+	"github.com/zenon-network/go-zenon/chain/nom"
+	"github.com/zenon-network/go-zenon/common/types"
+	"github.com/zenon-network/go-zenon/verifier"
+	"github.com/zenon-network/go-zenon/zenon/mock"
+)
+
+// A receive referencing a send confirmed after the receive's own
+// acknowledged momentum must be rejected.
+func TestAccountBlock_ReceiveSendConfirmedAfterAcknowledged(t *testing.T) {
+	z := mock.NewMockZenon(t)
+	defer z.StopPanic()
+
+	z.InsertMomentumsTo(10)
+
+	send := z.InsertSendBlock(&nom.AccountBlock{
+		Address:       g.User1.Address,
+		ToAddress:     g.User2.Address,
+		TokenStandard: types.ZnnTokenStandard,
+		Amount:        big.NewInt(1 * g.Zexp),
+	}, nil, mock.SkipVmChanges)
+
+	// the send is now confirmed at momentum height 11
+	z.InsertNewMomentum()
+
+	m10, err := z.Chain().GetFrontierMomentumStore().GetMomentumByHeight(10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	z.InsertReceiveBlock(send.Header(), &nom.AccountBlock{
+		Address:              g.User2.Address,
+		FromBlockHash:        send.Hash,
+		MomentumAcknowledged: m10.Identifier(),
+	}, verifier.ErrABFromBlockMissing, mock.SkipVmChanges)
+}

--- a/chain/tests/cache_test.go
+++ b/chain/tests/cache_test.go
@@ -183,6 +183,8 @@ func TestCache_RollbackAfterPrune(t *testing.T) {
 	z := mock.NewMockZenon(t)
 	defer z.StopPanic()
 
+	oldFuseExpiration := constants.FuseExpiration
+	t.Cleanup(func() { constants.FuseExpiration = oldFuseExpiration })
 	constants.FuseExpiration = 5
 
 	// g.User1 fuses QSR to g.User6 twice, producing two distinct fused-amount
@@ -248,7 +250,7 @@ func TestCache_RollbackAfterPrune(t *testing.T) {
 	z.InsertNewMomentum() // prunes the fuse1 and fuse2 entries
 
 	pruneIdentifier := z.Chain().GetFrontierCacheStore().Identifier()
-	common.ExpectTrue(t, pruneIdentifier.Height-cancelIdentifier.Height < uint64(cache.GetRollbackCacheSize()))
+	common.ExpectTrue(t, pruneIdentifier.Height-cancelIdentifier.Height <= uint64(cache.GetRollbackCacheSize()))
 
 	// Roll the cache back to before the pruning momentum.
 	insert := z.Chain().AcquireInsert("")

--- a/chain/tests/cache_test.go
+++ b/chain/tests/cache_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	cache "github.com/zenon-network/go-zenon/chain/cache/storage"
 	g "github.com/zenon-network/go-zenon/chain/genesis/mock"
 	"github.com/zenon-network/go-zenon/chain/nom"
 	"github.com/zenon-network/go-zenon/common"
@@ -172,6 +173,115 @@ func TestCache_FusedPlasma(t *testing.T) {
 	amount, err = store.GetStakeBeneficialAmount(g.User6.Address)
 	common.FailIfErr(t, err)
 	common.ExpectAmount(t, amount, common.Big0)
+}
+
+// TestCache_RollbackAfterPrune exercises the prune-then-restore path: fused-amount
+// cache entries get pruned once the beneficiary's own acknowledged height advances
+// past them, and rolling the cache back to a point before that pruning must
+// restore the pruned entries.
+func TestCache_RollbackAfterPrune(t *testing.T) {
+	z := mock.NewMockZenon(t)
+	defer z.StopPanic()
+
+	constants.FuseExpiration = 5
+
+	// g.User1 fuses QSR to g.User6 twice, producing two distinct fused-amount
+	// cache entries for the beneficiary.
+	fuse1 := z.InsertSendBlock(&nom.AccountBlock{
+		Address:       g.User1.Address,
+		ToAddress:     types.PlasmaContract,
+		Data:          definition.ABIPlasma.PackMethodPanic(definition.FuseMethodName, g.User6.Address),
+		TokenStandard: types.QsrTokenStandard,
+		Amount:        big.NewInt(10 * g.Zexp),
+	}, nil, mock.SkipVmChanges)
+	z.InsertNewMomentum() // confirm the first fuse send
+	z.InsertNewMomentum() // confirm the auto-generated contract-receive
+
+	fuse1Identifier := z.Chain().GetFrontierCacheStore().Identifier()
+	amountAfterFuse1, err := z.Chain().GetCacheStore(fuse1Identifier).GetStakeBeneficialAmount(g.User6.Address)
+	common.FailIfErr(t, err)
+	common.ExpectAmount(t, amountAfterFuse1, big.NewInt(10*g.Zexp))
+
+	z.InsertSendBlock(&nom.AccountBlock{
+		Address:       g.User1.Address,
+		ToAddress:     types.PlasmaContract,
+		Data:          definition.ABIPlasma.PackMethodPanic(definition.FuseMethodName, g.User6.Address),
+		TokenStandard: types.QsrTokenStandard,
+		Amount:        big.NewInt(10 * g.Zexp),
+	}, nil, mock.SkipVmChanges)
+	z.InsertNewMomentum() // confirm the second fuse send
+	z.InsertNewMomentum() // confirm the auto-generated contract-receive
+
+	fuse2Identifier := z.Chain().GetFrontierCacheStore().Identifier()
+	amountAfterFuse2, err := z.Chain().GetCacheStore(fuse2Identifier).GetStakeBeneficialAmount(g.User6.Address)
+	common.FailIfErr(t, err)
+	common.ExpectAmount(t, amountAfterFuse2, big.NewInt(20*g.Zexp))
+
+	// let the first fusion expire
+	z.InsertMomentumsTo(fuse1Identifier.Height + constants.FuseExpiration + 1)
+
+	// cancel the first fuse only, leaving the second fusion (and its plasma)
+	// with g.User6, and producing a third fused-amount cache entry for it.
+	z.InsertSendBlock(&nom.AccountBlock{
+		Address:   g.User1.Address,
+		ToAddress: types.PlasmaContract,
+		Data:      definition.ABIPlasma.PackMethodPanic(definition.CancelFuseMethodName, fuse1.Hash),
+	}, nil, mock.SkipVmChanges)
+	z.InsertNewMomentum() // confirm the cancel send
+	z.InsertNewMomentum() // confirm the auto-generated contract-receive (cancel applied)
+
+	cancelIdentifier := z.Chain().GetFrontierCacheStore().Identifier()
+	amountAfterCancel, err := z.Chain().GetCacheStore(cancelIdentifier).GetStakeBeneficialAmount(g.User6.Address)
+	common.FailIfErr(t, err)
+	common.ExpectAmount(t, amountAfterCancel, big.NewInt(10*g.Zexp))
+
+	// g.User6 sends an unrelated block, paid for with the plasma from the
+	// remaining fusion. This advances g.User6's own acknowledged height past
+	// the fuse/cancel entries and drives pruneAccountCache to delete the two
+	// now-expired entries (fuse1, fuse2), keeping only the last one (cancel).
+	z.InsertSendBlock(&nom.AccountBlock{
+		Address:       g.User6.Address,
+		ToAddress:     g.User2.Address,
+		TokenStandard: types.ZeroTokenStandard,
+		Amount:        common.Big0,
+	}, nil, mock.SkipVmChanges)
+	z.InsertNewMomentum() // prunes the fuse1 and fuse2 entries
+
+	pruneIdentifier := z.Chain().GetFrontierCacheStore().Identifier()
+	common.ExpectTrue(t, pruneIdentifier.Height-cancelIdentifier.Height < uint64(cache.GetRollbackCacheSize()))
+
+	// Roll the cache back to before the pruning momentum.
+	insert := z.Chain().AcquireInsert("")
+	err = z.Chain().RollbackCacheTo(insert, cancelIdentifier)
+	insert.Unlock()
+	common.FailIfErr(t, err)
+
+	frontier := z.Chain().GetFrontierCacheStore().Identifier()
+	common.Expect(t, frontier.Height, cancelIdentifier.Height)
+
+	// The two pruned entries must be restored.
+	restoredFuse1, err := z.Chain().GetCacheStore(fuse1Identifier).GetStakeBeneficialAmount(g.User6.Address)
+	common.FailIfErr(t, err)
+	common.ExpectAmount(t, restoredFuse1, amountAfterFuse1)
+
+	restoredFuse2, err := z.Chain().GetCacheStore(fuse2Identifier).GetStakeBeneficialAmount(g.User6.Address)
+	common.FailIfErr(t, err)
+	common.ExpectAmount(t, restoredFuse2, amountAfterFuse2)
+
+	restoredCancel, err := z.Chain().GetCacheStore(cancelIdentifier).GetStakeBeneficialAmount(g.User6.Address)
+	common.FailIfErr(t, err)
+	common.ExpectAmount(t, restoredCancel, amountAfterCancel)
+
+	// Re-apply forward: catch the cache back up to the chain frontier and
+	// confirm the end state is identical to what it was before the rollback.
+	common.FailIfErr(t, z.Chain().Init())
+
+	frontier = z.Chain().GetFrontierCacheStore().Identifier()
+	common.Expect(t, frontier.Height, pruneIdentifier.Height)
+
+	finalCancelAmount, err := z.Chain().GetCacheStore(cancelIdentifier).GetStakeBeneficialAmount(g.User6.Address)
+	common.FailIfErr(t, err)
+	common.ExpectAmount(t, finalCancelAmount, amountAfterCancel)
 }
 
 func TestCache_Rollback(t *testing.T) {

--- a/common/db/interfaces.go
+++ b/common/db/interfaces.go
@@ -26,6 +26,10 @@ type Transaction interface {
 	StealChanges() Patch
 }
 
+// StorageIterator is not guaranteed to support reverse iteration on every
+// backend: the merged backend (mergedIterator, common/db/merged.go) panics on
+// Prev() and Last(). Reverse iteration must only be used on single-backend
+// iterators.
 type StorageIterator interface {
 	Next() bool
 	Prev() bool

--- a/verifier/account_block.go
+++ b/verifier/account_block.go
@@ -354,6 +354,16 @@ func (abv *accountBlockVerifier) fromHash() error {
 		return ErrABFromBlockMissing
 	}
 
+	// the referenced send must have been confirmed at or before the
+	// momentum this block acknowledges
+	confirmationHeight, err := abv.frontierStore.GetBlockConfirmationHeight(abv.block.FromBlockHash)
+	if err != nil {
+		return InternalError(err)
+	}
+	if confirmationHeight > abv.block.MomentumAcknowledged.Height {
+		return ErrABFromBlockMissing
+	}
+
 	if abv.block.Address != sendBlock.ToAddress {
 		// Use the momentum ledger's true frontier height when comparing
 		if abv.frontierStore.Identifier().Height >= ReceiverMismatchEnforcementHeight {

--- a/vm/supervisor.go
+++ b/vm/supervisor.go
@@ -58,6 +58,9 @@ func (s *Supervisor) newUserBlockContext(block *nom.AccountBlock) vm_context.Acc
 	if accountStore == nil {
 		panic(fmt.Sprintf("can't find accountStore for %v %v", block.Address, block.Previous()))
 	}
+	if cacheStore == nil {
+		panic(fmt.Sprintf("can't find cacheStore for %v", block.MomentumAcknowledged))
+	}
 	return vm_context.NewAccountContext(
 		nil,
 		accountStore,
@@ -76,6 +79,9 @@ func (s *Supervisor) newEmbeddedBlockContext(block *nom.AccountBlock) vm_context
 	}
 	if accountStore == nil {
 		panic(fmt.Sprintf("can't find accountStore for %v %v", block.Address, block.Previous()))
+	}
+	if cacheStore == nil {
+		panic(fmt.Sprintf("can't find cacheStore for %v", block.MomentumAcknowledged))
 	}
 	if cache == nil {
 		panic(fmt.Sprintf("can't find cache for %v", block.MomentumAcknowledged))

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -57,7 +57,9 @@ func enoughPlasma(context vm_context.AccountVmContext, block *nom.AccountBlock) 
 	// checking available plasma for blocks with fused plasma
 	if block.FusedPlasma > 0 {
 		available, err := AvailablePlasma(context.CacheStore(), context)
-		common.DealWithErr(err)
+		if err != nil {
+			return err
+		}
 		if available < block.FusedPlasma {
 			return constants.ErrNotEnoughPlasma
 		}
@@ -70,7 +72,9 @@ func enoughPlasma(context vm_context.AccountVmContext, block *nom.AccountBlock) 
 	}
 
 	basePlasma, err := GetBasePlasmaForAccountBlock(context, block)
-	common.DealWithErr(err)
+	if err != nil {
+		return err
+	}
 
 	block.BasePlasma = basePlasma
 


### PR DESCRIPTION
verifier/account_block.go: fromHash() resolved the referenced send via frontierStore, which only checks existence at the current tip. Add a GetBlockConfirmationHeight comparison so a receive is rejected when its send confirmed after the receive's own MomentumAcknowledged height, matching the rollback-based validation this replaces. Adds a regression test pinning the boundary.

chain/tests/cache_test.go: add TestCache_RollbackAfterPrune, exercising the prune-then-rollback-restore path (fuse/cancel across the prune boundary, roll back, assert restoration, re-apply forward for idempotency) that existing tests didn't cover.

Minor hardening in the cache package: document why fused-plasma entries for pure-beneficiary addresses aren't pruned, return nil instead of panicking when NewCacheStore's height is out of range, propagate enoughPlasma's errors instead of DealWithErr, drop dead ErrNotFound branches, remove an unexplained height==1 short-circuit in spork lookup, and note the merged DB iterator's reverse-iteration limitation.