### PR TITLE
fix: address cache-chain review feedback on PR #68

### DIFF
--- a/chain/cache.go
+++ b/chain/cache.go
@@ -60,7 +60,12 @@ func (c *chainCache) update(detailed *nom.DetailedMomentum, changes db.Patch) er
 	momentum := detailed.Momentum
 	c.log.Info("inserting new momentum to chain cache", "identifier", momentum.Identifier())
 	store := c.getFrontierStore()
-	store.ApplyMomentum(detailed, changes)
+	if store == nil {
+		return errors.Errorf("cache frontier store is nil")
+	}
+	if err := store.ApplyMomentum(detailed, changes); err != nil {
+		return err
+	}
 	patch, err := store.Changes()
 	if err != nil {
 		return err

--- a/chain/cache/storage/db.go
+++ b/chain/cache/storage/db.go
@@ -44,6 +44,7 @@ type CacheManager interface {
 
 type cacheManager struct {
 	ldb     *leveldb.DB
+	write   func(*leveldb.Batch) error
 	changes sync.Mutex
 	stopped bool
 }
@@ -54,6 +55,9 @@ func NewCacheDBManager(dataDir string) CacheManager {
 	common.DealWithErr(err)
 	return &cacheManager{
 		ldb: db,
+		write: func(batch *leveldb.Batch) error {
+			return db.Write(batch, nil)
+		},
 	}
 }
 
@@ -93,20 +97,22 @@ func (m *cacheManager) Add(identifier types.HashHeight, patch db.Patch) error {
 	if err := frontierPatch.Replay(patch); err != nil {
 		return err
 	}
-	rollbackPatch := db.RollbackPatch(m.DB(), patch)
-
 	m.changes.Lock()
 	defer m.changes.Unlock()
+	if m.stopped {
+		return leveldb.ErrClosed
+	}
 
-	if err := m.ldb.Put(common.JoinBytes(rollbackByte, common.Uint64ToBytes(identifier.Height)), rollbackPatch.Dump(), nil); err != nil {
+	rollbackPatch := db.RollbackPatch(db.NewLevelDBWrapperWithFullDelete(m.ldb).Subset(storageByte), patch)
+	batch := new(leveldb.Batch)
+	batch.Put(common.JoinBytes(rollbackByte, common.Uint64ToBytes(identifier.Height)), rollbackPatch.Dump())
+	if identifier.Height > rollbackCacheSize {
+		batch.Delete(common.JoinBytes(rollbackByte, common.Uint64ToBytes(identifier.Height-rollbackCacheSize)))
+	}
+	if err := db.AppendPatchToLevelDBBatch(batch, storageByte, patch, true); err != nil {
 		return err
 	}
-	if identifier.Height > rollbackCacheSize {
-		if err := m.ldb.Delete(common.JoinBytes(rollbackByte, common.Uint64ToBytes(identifier.Height-rollbackCacheSize)), nil); err != nil {
-			return err
-		}
-	}
-	if err := db.ApplyPatch(db.NewLevelDBWrapperWithFullDelete(m.ldb).Subset(storageByte), patch); err != nil {
+	if err := m.write(batch); err != nil {
 		return err
 	}
 	// Compact the db manually since the automatic compaction mechanism causes performance issues when throughput increases.
@@ -117,22 +123,24 @@ func (m *cacheManager) Add(identifier types.HashHeight, patch db.Patch) error {
 }
 
 func (m *cacheManager) Pop() error {
-	frontierIdentifier := GetFrontierIdentifier(m.DB())
+	m.changes.Lock()
+	defer m.changes.Unlock()
+	if m.stopped {
+		return leveldb.ErrClosed
+	}
+
+	frontierIdentifier := GetFrontierIdentifier(db.NewLevelDBWrapper(m.ldb).Subset(storageByte))
 	rollbackPatch, err := m.getRollback(frontierIdentifier.Height)
 	if err != nil {
 		return err
 	}
 
-	m.changes.Lock()
-	defer m.changes.Unlock()
-
-	if err := db.ApplyPatch(db.NewLevelDBWrapperWithFullDelete(m.ldb).Subset(storageByte), rollbackPatch); err != nil {
+	batch := new(leveldb.Batch)
+	if err := db.AppendPatchToLevelDBBatch(batch, storageByte, rollbackPatch, true); err != nil {
 		return err
 	}
-	if err := m.ldb.Delete(common.JoinBytes(rollbackByte, common.Uint64ToBytes(frontierIdentifier.Height)), nil); err != nil {
-		return err
-	}
-	return nil
+	batch.Delete(common.JoinBytes(rollbackByte, common.Uint64ToBytes(frontierIdentifier.Height)))
+	return m.write(batch)
 }
 
 func (m *cacheManager) Stop() error {

--- a/chain/cache/storage/db.go
+++ b/chain/cache/storage/db.go
@@ -147,7 +147,12 @@ func (m *cacheManager) Stop() error {
 }
 
 func (m *cacheManager) getRollback(height uint64) (db.Patch, error) {
-	snapshot, _ := m.ldb.GetSnapshot()
+	snapshot, err := m.ldb.GetSnapshot()
+	if err != nil {
+		return nil, err
+	}
+	defer snapshot.Release()
+
 	value, err := snapshot.Get(common.JoinBytes(rollbackByte, common.Uint64ToBytes(height)), nil)
 	if err != nil {
 		return nil, err

--- a/chain/cache/storage/db_test.go
+++ b/chain/cache/storage/db_test.go
@@ -1,8 +1,11 @@
 package storage
 
 import (
+	"errors"
 	"fmt"
 	"testing"
+
+	"github.com/syndtr/goleveldb/leveldb"
 
 	"github.com/zenon-network/go-zenon/common"
 	"github.com/zenon-network/go-zenon/common/db"
@@ -20,6 +23,53 @@ func getMockIdentifier(height uint64) types.HashHeight {
 		Hash:   types.NewHash([]byte(fmt.Sprint(height))),
 		Height: height,
 	}
+}
+
+func TestAddWriteFailureIsAtomic(t *testing.T) {
+	m := NewCacheDBManager(t.TempDir()).(*cacheManager)
+	defer m.Stop()
+
+	common.FailIfErr(t, m.Add(getMockIdentifier(1), getMockPatch([]byte{1})))
+	beforeIdentifier := GetFrontierIdentifier(m.DB())
+	beforeDump := db.DebugDB(m.DB())
+	writeErr := errors.New("write failed")
+	m.write = func(*leveldb.Batch) error {
+		return writeErr
+	}
+
+	if err := m.Add(getMockIdentifier(2), getMockPatch([]byte{2})); !errors.Is(err, writeErr) {
+		t.Fatalf("expected write error, got %v", err)
+	}
+	common.Expect(t, GetFrontierIdentifier(m.DB()), beforeIdentifier)
+	common.ExpectString(t, db.DebugDB(m.DB()), beforeDump)
+
+	has, err := m.ldb.Has(common.JoinBytes(rollbackByte, common.Uint64ToBytes(2)), nil)
+	common.FailIfErr(t, err)
+	common.ExpectTrue(t, !has)
+}
+
+func TestPopWriteFailureIsAtomic(t *testing.T) {
+	m := NewCacheDBManager(t.TempDir()).(*cacheManager)
+	defer m.Stop()
+
+	common.FailIfErr(t, m.Add(getMockIdentifier(1), getMockPatch([]byte{1})))
+	common.FailIfErr(t, m.Add(getMockIdentifier(2), getMockPatch([]byte{2})))
+	beforeIdentifier := GetFrontierIdentifier(m.DB())
+	beforeDump := db.DebugDB(m.DB())
+	writeErr := errors.New("write failed")
+	m.write = func(*leveldb.Batch) error {
+		return writeErr
+	}
+
+	if err := m.Pop(); !errors.Is(err, writeErr) {
+		t.Fatalf("expected write error, got %v", err)
+	}
+	common.Expect(t, GetFrontierIdentifier(m.DB()), beforeIdentifier)
+	common.ExpectString(t, db.DebugDB(m.DB()), beforeDump)
+
+	has, err := m.ldb.Has(common.JoinBytes(rollbackByte, common.Uint64ToBytes(2)), nil)
+	common.FailIfErr(t, err)
+	common.ExpectTrue(t, has)
 }
 
 func TestPop(t *testing.T) {

--- a/chain/momentum_pool.go
+++ b/chain/momentum_pool.go
@@ -25,17 +25,17 @@ type momentumPool struct {
 	changes      sync.Mutex
 }
 
-// ErrCanonicalStateUncertain is returned when a momentum insertion fails and the
-// compensating rollback of the canonical chain also fails, leaving the canonical
-// frontier at an unknown position. Callers must not attempt a cache-only rollback
-// in response and must treat processing as unrecoverable.
+// ErrCanonicalStateUncertain is returned when a failed insertion cannot be
+// compensated or when a multi-step rollback stops after mutating the canonical
+// chain. Callers must not attempt ordinary recovery and must treat processing as
+// unrecoverable.
 type ErrCanonicalStateUncertain struct {
 	Cause       error
 	RollbackErr error
 }
 
 func (e *ErrCanonicalStateUncertain) Error() string {
-	return fmt.Sprintf("canonical chain state uncertain: insertion failed (%v) and canonical rollback failed (%v)", e.Cause, e.RollbackErr)
+	return fmt.Sprintf("canonical chain state uncertain: operation failed (%v); recovery failed (%v)", e.Cause, e.RollbackErr)
 }
 
 func (e *ErrCanonicalStateUncertain) Unwrap() error {
@@ -125,11 +125,22 @@ func (c *momentumPool) RollbackTo(insertLocker sync.Locker, identifier types.Has
 		return errors.Errorf("can't rollback momentums. Expected %v but got %v instead", momentum.Identifier(), identifier)
 	}
 
+	popped := 0
+	rollbackError := func(err error) error {
+		if popped == 0 {
+			return err
+		}
+		return &ErrCanonicalStateUncertain{
+			Cause:       errors.Errorf("canonical rollback to %v stopped after %v successful pop(s)", identifier, popped),
+			RollbackErr: err,
+		}
+	}
+
 	for {
 		store := c.getFrontierStore()
 		frontier, err := store.GetFrontierMomentum()
 		if err != nil {
-			return err
+			return rollbackError(err)
 		}
 
 		if frontier.Height == identifier.Height {
@@ -138,11 +149,12 @@ func (c *momentumPool) RollbackTo(insertLocker sync.Locker, identifier types.Has
 		c.log.Info("rollbacking", "momentum-identifier", frontier.Identifier())
 		detailed, err := store.PrefetchMomentum(frontier)
 		if err != nil {
-			return err
+			return rollbackError(err)
 		}
 		if err := c.chainManager.Pop(); err != nil {
-			return err
+			return rollbackError(err)
 		}
+		popped++
 
 		c.changes.Unlock()
 		c.broadcastDeleteMomentum(detailed)

--- a/chain/momentum_pool.go
+++ b/chain/momentum_pool.go
@@ -42,6 +42,9 @@ func (c *momentumPool) AddMomentumTransaction(insertLocker sync.Locker, transact
 	store := c.getFrontierStore()
 	detailed, err := store.PrefetchMomentum(momentum)
 	if err != nil {
+		if popErr := c.chainManager.Pop(); popErr != nil {
+			c.log.Error("failed to roll back canonical chain after failed momentum insertion", "reason", popErr, "identifier", momentum.Identifier())
+		}
 		return err
 	}
 
@@ -51,6 +54,13 @@ func (c *momentumPool) AddMomentumTransaction(insertLocker sync.Locker, transact
 
 	frontier := c.getFrontierStore()
 	if justNow, unimplemented, err := GotAllActiveSporksImplemented(frontier); err != nil {
+		if popErr := c.chainManager.Pop(); popErr != nil {
+			c.log.Error("failed to roll back canonical chain after failed momentum insertion", "reason", popErr, "identifier", momentum.Identifier())
+		} else {
+			c.changes.Unlock()
+			c.broadcastDeleteMomentum(detailed)
+			c.changes.Lock()
+		}
 		return err
 	} else if unimplemented != nil {
 		c.log.Crit("can't insert momentum because don't have all sporks implemented",

--- a/chain/momentum_pool.go
+++ b/chain/momentum_pool.go
@@ -25,6 +25,34 @@ type momentumPool struct {
 	changes      sync.Mutex
 }
 
+// ErrCanonicalStateUncertain is returned when a momentum insertion fails and the
+// compensating rollback of the canonical chain also fails, leaving the canonical
+// frontier at an unknown position. Callers must not attempt a cache-only rollback
+// in response and must treat processing as unrecoverable.
+type ErrCanonicalStateUncertain struct {
+	Cause       error
+	RollbackErr error
+}
+
+func (e *ErrCanonicalStateUncertain) Error() string {
+	return fmt.Sprintf("canonical chain state uncertain: insertion failed (%v) and canonical rollback failed (%v)", e.Cause, e.RollbackErr)
+}
+
+func (e *ErrCanonicalStateUncertain) Unwrap() error {
+	return e.Cause
+}
+
+// rollbackFailedInsert undoes a canonical Add() after a later validation step failed.
+// If the rollback itself fails, the canonical frontier is in an unknown position
+// relative to the cache and cause is wrapped in ErrCanonicalStateUncertain.
+func (c *momentumPool) rollbackFailedInsert(cause error, identifier types.HashHeight) error {
+	if popErr := c.chainManager.Pop(); popErr != nil {
+		c.log.Error("failed to roll back canonical chain after failed momentum insertion", "reason", popErr, "cause", cause, "identifier", identifier)
+		return &ErrCanonicalStateUncertain{Cause: cause, RollbackErr: popErr}
+	}
+	return cause
+}
+
 func (c *momentumPool) AddMomentumTransaction(insertLocker sync.Locker, transaction *nom.MomentumTransaction) error {
 	c.log.Info("inserting new momentum", "identifier", transaction.Momentum.Identifier())
 	if insertLocker == nil {
@@ -42,27 +70,15 @@ func (c *momentumPool) AddMomentumTransaction(insertLocker sync.Locker, transact
 	store := c.getFrontierStore()
 	detailed, err := store.PrefetchMomentum(momentum)
 	if err != nil {
-		if popErr := c.chainManager.Pop(); popErr != nil {
-			c.log.Error("failed to roll back canonical chain after failed momentum insertion", "reason", popErr, "identifier", momentum.Identifier())
-		}
-		return err
+		return c.rollbackFailedInsert(err, momentum.Identifier())
 	}
 
-	c.changes.Unlock()
-	c.broadcastInsertMomentum(detailed)
-	c.changes.Lock()
-
 	frontier := c.getFrontierStore()
-	if justNow, unimplemented, err := GotAllActiveSporksImplemented(frontier); err != nil {
-		if popErr := c.chainManager.Pop(); popErr != nil {
-			c.log.Error("failed to roll back canonical chain after failed momentum insertion", "reason", popErr, "identifier", momentum.Identifier())
-		} else {
-			c.changes.Unlock()
-			c.broadcastDeleteMomentum(detailed)
-			c.changes.Lock()
-		}
-		return err
-	} else if unimplemented != nil {
+	justNow, unimplemented, err := GotAllActiveSporksImplemented(frontier)
+	if err != nil {
+		return c.rollbackFailedInsert(err, momentum.Identifier())
+	}
+	if unimplemented != nil {
 		c.log.Crit("can't insert momentum because don't have all sporks implemented",
 			"hash", momentum.Hash, "height", momentum.Height, "unimplemented", unimplemented)
 
@@ -76,7 +92,14 @@ func (c *momentumPool) AddMomentumTransaction(insertLocker sync.Locker, transact
 		fmt.Printf("Please upgrade your znnd binary\n")
 		fmt.Printf("znnd is terminating\n")
 		os.Exit(2)
-	} else if justNow != nil {
+	}
+
+	// All post-insert validation succeeded: listeners can now be notified.
+	c.changes.Unlock()
+	c.broadcastInsertMomentum(detailed)
+	c.changes.Lock()
+
+	if justNow != nil {
 		fmt.Printf("\n")
 		fmt.Printf("===== Congratulations! =====\n")
 		fmt.Printf("Just activated spork '%v'\n", justNow.Name)

--- a/chain/momentum_pool_test.go
+++ b/chain/momentum_pool_test.go
@@ -16,14 +16,19 @@ import (
 // exactly when Add and Pop succeed or fail, independently of real chain state.
 type fakeMomentumManagerDB struct {
 	frontierDB db.DB
+	frontiers  []db.DB
 	addErr     error
 	popErr     error
+	popErrAt   int
 
 	addCalls int
 	popCalls int
 }
 
 func (m *fakeMomentumManagerDB) Frontier() db.DB {
+	if len(m.frontiers) > 0 {
+		return m.frontiers[len(m.frontiers)-1]
+	}
 	return m.frontierDB
 }
 func (m *fakeMomentumManagerDB) Get(types.HashHeight) db.DB {
@@ -38,7 +43,13 @@ func (m *fakeMomentumManagerDB) Add(db.Transaction) error {
 }
 func (m *fakeMomentumManagerDB) Pop() error {
 	m.popCalls += 1
-	return m.popErr
+	if m.popErr != nil && (m.popErrAt == 0 || m.popErrAt == m.popCalls) {
+		return m.popErr
+	}
+	if len(m.frontiers) > 1 {
+		m.frontiers = m.frontiers[:len(m.frontiers)-1]
+	}
+	return nil
 }
 func (m *fakeMomentumManagerDB) Stop() error {
 	return nil
@@ -88,6 +99,26 @@ func newFrontierMomentumDB(identifier types.HashHeight) db.DB {
 	common.DealWithErr(err)
 	common.DealWithErr(db.SetFrontier(mem, identifier, data))
 	return mem
+}
+
+func newMomentumFrontiers(height uint64) []db.DB {
+	frontiers := make([]db.DB, 0, height)
+	for frontierHeight := uint64(1); frontierHeight <= height; frontierHeight++ {
+		mem := db.NewMemDB()
+		for momentumHeight := uint64(1); momentumHeight <= frontierHeight; momentumHeight++ {
+			identifier := testHashHeight(momentumHeight)
+			m := &nom.Momentum{
+				Hash:         identifier.Hash,
+				PreviousHash: testHashHeight(momentumHeight - 1).Hash,
+				Height:       momentumHeight,
+			}
+			data, err := m.Serialize()
+			common.DealWithErr(err)
+			common.DealWithErr(db.SetFrontier(mem, identifier, data))
+		}
+		frontiers = append(frontiers, mem)
+	}
+	return frontiers
 }
 
 func testTransaction(content nom.MomentumContent) *nom.MomentumTransaction {
@@ -183,4 +214,44 @@ func TestAddMomentumTransaction_Success(t *testing.T) {
 	common.Expect(t, manager.popCalls, 0)
 	common.Expect(t, listener.inserts, 1)
 	common.Expect(t, listener.deletes, 0)
+}
+
+func TestRollbackToFailureAfterPopIsUnrecoverable(t *testing.T) {
+	manager := &fakeMomentumManagerDB{
+		frontiers: newMomentumFrontiers(3),
+		popErr:    errors.New("second pop failed"),
+		popErrAt:  2,
+	}
+	pool, listener := newTestMomentumPool(manager)
+
+	err := pool.RollbackTo(&sync.Mutex{}, testHashHeight(1))
+
+	var uncertain *ErrCanonicalStateUncertain
+	common.ExpectTrue(t, errors.As(err, &uncertain))
+	common.ExpectTrue(t, uncertain.Cause != nil)
+	common.ExpectTrue(t, uncertain.RollbackErr != nil)
+	common.Expect(t, manager.popCalls, 2)
+	common.Expect(t, listener.inserts, 0)
+	common.Expect(t, listener.deletes, 1)
+	common.Expect(t, db.GetFrontierIdentifier(manager.Frontier()), testHashHeight(2))
+}
+
+func TestRollbackToFirstPopFailureLeavesCanonicalStateCertain(t *testing.T) {
+	popErr := errors.New("first pop failed")
+	manager := &fakeMomentumManagerDB{
+		frontiers: newMomentumFrontiers(2),
+		popErr:    popErr,
+		popErrAt:  1,
+	}
+	pool, listener := newTestMomentumPool(manager)
+
+	err := pool.RollbackTo(&sync.Mutex{}, testHashHeight(1))
+
+	var uncertain *ErrCanonicalStateUncertain
+	common.ExpectTrue(t, errors.Is(err, popErr))
+	common.ExpectTrue(t, !errors.As(err, &uncertain))
+	common.Expect(t, manager.popCalls, 1)
+	common.Expect(t, listener.inserts, 0)
+	common.Expect(t, listener.deletes, 0)
+	common.Expect(t, db.GetFrontierIdentifier(manager.Frontier()), testHashHeight(2))
 }

--- a/chain/momentum_pool_test.go
+++ b/chain/momentum_pool_test.go
@@ -1,0 +1,186 @@
+package chain
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/zenon-network/go-zenon/chain/momentum"
+	"github.com/zenon-network/go-zenon/chain/nom"
+	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/common/db"
+	"github.com/zenon-network/go-zenon/common/types"
+)
+
+// fakeMomentumManagerDB is an injectable db.Manager that lets tests control
+// exactly when Add and Pop succeed or fail, independently of real chain state.
+type fakeMomentumManagerDB struct {
+	frontierDB db.DB
+	addErr     error
+	popErr     error
+
+	addCalls int
+	popCalls int
+}
+
+func (m *fakeMomentumManagerDB) Frontier() db.DB {
+	return m.frontierDB
+}
+func (m *fakeMomentumManagerDB) Get(types.HashHeight) db.DB {
+	return nil
+}
+func (m *fakeMomentumManagerDB) GetPatch(types.HashHeight) db.Patch {
+	return nil
+}
+func (m *fakeMomentumManagerDB) Add(db.Transaction) error {
+	m.addCalls += 1
+	return m.addErr
+}
+func (m *fakeMomentumManagerDB) Pop() error {
+	m.popCalls += 1
+	return m.popErr
+}
+func (m *fakeMomentumManagerDB) Stop() error {
+	return nil
+}
+func (m *fakeMomentumManagerDB) Location() string {
+	return "fake"
+}
+
+// fakeMomentumListener records the events broadcast by a momentumPool.
+type fakeMomentumListener struct {
+	inserts int
+	deletes int
+}
+
+func (l *fakeMomentumListener) InsertMomentum(*nom.DetailedMomentum) {
+	l.inserts += 1
+}
+func (l *fakeMomentumListener) DeleteMomentum(*nom.DetailedMomentum) {
+	l.deletes += 1
+}
+
+func newTestMomentumPool(manager db.Manager) (*momentumPool, *fakeMomentumListener) {
+	pool := &momentumPool{
+		momentumEventManager: newMomentumEventManager(),
+		chainManager:         manager,
+		genesis:              nil,
+		log:                  common.ChainLogger.New("submodule", "test-momentum-pool"),
+	}
+	listener := &fakeMomentumListener{}
+	pool.Register(listener)
+	return pool, listener
+}
+
+// corruptEntryAtHeight writes undecodable bytes at the height entry, so that
+// whichever store reads it back (momentum or account-block) fails to deserialize.
+func corruptEntryAtHeight(target db.DB, identifier types.HashHeight) {
+	common.DealWithErr(db.SetFrontier(target, identifier, []byte{0xFF}))
+}
+
+func newFrontierMomentumDB(identifier types.HashHeight) db.DB {
+	mem := db.NewMemDB()
+	m := &nom.Momentum{
+		Hash:   identifier.Hash,
+		Height: identifier.Height,
+	}
+	data, err := m.Serialize()
+	common.DealWithErr(err)
+	common.DealWithErr(db.SetFrontier(mem, identifier, data))
+	return mem
+}
+
+func testTransaction(content nom.MomentumContent) *nom.MomentumTransaction {
+	return &nom.MomentumTransaction{
+		Momentum: &nom.Momentum{
+			Hash:    types.NewHash(common.Uint64ToBytes(1)),
+			Height:  1,
+			Content: content,
+		},
+	}
+}
+
+func TestAddMomentumTransaction_AddFails(t *testing.T) {
+	manager := &fakeMomentumManagerDB{
+		frontierDB: newFrontierMomentumDB(testHashHeight(0)),
+		addErr:     errors.New("add failed"),
+	}
+	pool, listener := newTestMomentumPool(manager)
+
+	err := pool.AddMomentumTransaction(&sync.Mutex{}, testTransaction(nil))
+
+	common.ExpectTrue(t, err != nil)
+	common.Expect(t, manager.popCalls, 0)
+	common.Expect(t, listener.inserts, 0)
+	common.Expect(t, listener.deletes, 0)
+}
+
+func TestAddMomentumTransaction_PrefetchFailsPopSucceeds(t *testing.T) {
+	frontier := newFrontierMomentumDB(testHashHeight(0))
+	missingAddress := types.Address{}
+	missingHeader := &types.AccountHeader{Address: missingAddress, HashHeight: types.HashHeight{Height: 1}}
+	accountPrefix := common.JoinBytes(momentum.AccountStorePrefix, missingAddress.Bytes())
+	corruptEntryAtHeight(frontier.Subset(accountPrefix), types.HashHeight{Height: 1})
+
+	manager := &fakeMomentumManagerDB{frontierDB: frontier}
+	pool, listener := newTestMomentumPool(manager)
+
+	err := pool.AddMomentumTransaction(&sync.Mutex{}, testTransaction(nom.MomentumContent{missingHeader}))
+
+	common.ExpectTrue(t, err != nil)
+	var uncertain *ErrCanonicalStateUncertain
+	common.ExpectTrue(t, !errors.As(err, &uncertain))
+	common.Expect(t, manager.popCalls, 1)
+	common.Expect(t, listener.inserts, 0)
+	common.Expect(t, listener.deletes, 0)
+}
+
+func TestAddMomentumTransaction_SporkValidationFailsPopSucceeds(t *testing.T) {
+	frontier := newFrontierMomentumDB(testHashHeight(1))
+	corruptEntryAtHeight(frontier, testHashHeight(1))
+
+	manager := &fakeMomentumManagerDB{frontierDB: frontier}
+	pool, listener := newTestMomentumPool(manager)
+
+	err := pool.AddMomentumTransaction(&sync.Mutex{}, testTransaction(nil))
+
+	common.ExpectTrue(t, err != nil)
+	var uncertain *ErrCanonicalStateUncertain
+	common.ExpectTrue(t, !errors.As(err, &uncertain))
+	common.Expect(t, manager.popCalls, 1)
+	common.Expect(t, listener.inserts, 0)
+	common.Expect(t, listener.deletes, 0)
+}
+
+func TestAddMomentumTransaction_PopFailsIsUnrecoverable(t *testing.T) {
+	frontier := newFrontierMomentumDB(testHashHeight(1))
+	corruptEntryAtHeight(frontier, testHashHeight(1))
+
+	manager := &fakeMomentumManagerDB{
+		frontierDB: frontier,
+		popErr:     errors.New("pop failed"),
+	}
+	pool, listener := newTestMomentumPool(manager)
+
+	err := pool.AddMomentumTransaction(&sync.Mutex{}, testTransaction(nil))
+
+	var uncertain *ErrCanonicalStateUncertain
+	common.ExpectTrue(t, errors.As(err, &uncertain))
+	common.ExpectTrue(t, uncertain.Cause != nil)
+	common.ExpectTrue(t, uncertain.RollbackErr != nil)
+	common.Expect(t, manager.popCalls, 1)
+	common.Expect(t, listener.inserts, 0)
+	common.Expect(t, listener.deletes, 0)
+}
+
+func TestAddMomentumTransaction_Success(t *testing.T) {
+	manager := &fakeMomentumManagerDB{frontierDB: newFrontierMomentumDB(testHashHeight(1))}
+	pool, listener := newTestMomentumPool(manager)
+
+	err := pool.AddMomentumTransaction(&sync.Mutex{}, testTransaction(nil))
+
+	common.FailIfErr(t, err)
+	common.Expect(t, manager.popCalls, 0)
+	common.Expect(t, listener.inserts, 1)
+	common.Expect(t, listener.deletes, 0)
+}

--- a/common/db/interfaces.go
+++ b/common/db/interfaces.go
@@ -27,9 +27,9 @@ type Transaction interface {
 }
 
 // StorageIterator is not guaranteed to support reverse iteration on every
-// backend: the merged backend (mergedIterator, common/db/merged.go) panics on
-// Prev() and Last(). Reverse iteration must only be used on single-backend
-// iterators.
+// backend: the merged backend (mergedIterator, common/db/merged.go) reports
+// an error and returns false from Prev() and Last(). Reverse iteration must
+// only be used on single-backend iterators.
 type StorageIterator interface {
 	Next() bool
 	Prev() bool

--- a/common/db/merged.go
+++ b/common/db/merged.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"errors"
+
 	"github.com/syndtr/goleveldb/leveldb"
 	"github.com/syndtr/goleveldb/leveldb/comparer"
 )
@@ -98,10 +100,16 @@ func (mi *mergedIterator) Next() bool {
 	return mi.step()
 }
 func (mi *mergedIterator) Prev() bool {
-	panic("unimplemented")
+	if mi.err == nil {
+		mi.err = errors.New("mergedIterator does not support reverse iteration")
+	}
+	return false
 }
 func (mi *mergedIterator) Last() bool {
-	panic("unimplemented")
+	if mi.err == nil {
+		mi.err = errors.New("mergedIterator does not support reverse iteration")
+	}
+	return false
 }
 func (mi *mergedIterator) Key() []byte {
 	if mi.current == noCurrent || mi.err != nil {

--- a/common/db/patch.go
+++ b/common/db/patch.go
@@ -80,6 +80,25 @@ func (pa *patchApplier) Delete(key []byte) {
 	pa.err = pa.db.Delete(key)
 }
 
+type levelDBBatchApplier struct {
+	batch      *leveldb.Batch
+	prefix     []byte
+	fullDelete bool
+}
+
+func (pa *levelDBBatchApplier) Put(key []byte, value []byte) {
+	pa.batch.Put(common.JoinBytes(pa.prefix, key), common.JoinBytes(existsByte, value))
+}
+
+func (pa *levelDBBatchApplier) Delete(key []byte) {
+	key = common.JoinBytes(pa.prefix, key)
+	if pa.fullDelete {
+		pa.batch.Delete(key)
+	} else {
+		pa.batch.Put(key, []byte{})
+	}
+}
+
 type patchValuePrefixer struct {
 	prefix []byte
 	Patch
@@ -185,6 +204,18 @@ func ApplyPatch(db DB, patch Patch) error {
 	}
 	return pa.err
 }
+
+// AppendPatchToLevelDBBatch adds a logical patch to a raw LevelDB batch. The
+// prefix and delete behavior must match the DB wrapper through which the patch
+// would otherwise be applied.
+func AppendPatchToLevelDBBatch(batch *leveldb.Batch, prefix []byte, patch Patch, fullDelete bool) error {
+	return patch.Replay(&levelDBBatchApplier{
+		batch:      batch,
+		prefix:     prefix,
+		fullDelete: fullDelete,
+	})
+}
+
 func ApplyWithoutOverride(db db, patch Patch) error {
 	pa := &patchApplierWO{
 		db: db,

--- a/common/db/versioned_db.go
+++ b/common/db/versioned_db.go
@@ -189,6 +189,7 @@ type ldbManager struct {
 	l1Cache  *lru.Cache
 	l2Cache  *lru.Cache
 	ldb      *leveldb.DB
+	write    func(*leveldb.Batch) error
 	changes  sync.Mutex
 	stopped  bool
 }
@@ -206,6 +207,9 @@ func NewLevelDBManager(dir string) Manager {
 		l1Cache:  l1Cache,
 		l2Cache:  l2Cache,
 		ldb:      ldb,
+		write: func(batch *leveldb.Batch) error {
+			return ldb.Write(batch, nil)
+		},
 	}
 }
 
@@ -354,40 +358,49 @@ func (m *ldbManager) Add(transaction Transaction) error {
 	}
 
 	rollbackPatch := RollbackPatch(db, patch)
+	batch := new(leveldb.Batch)
+	batch.Put(common.JoinBytes(patchByte, common.Uint64ToBytes(identifier.Height)), patch.Dump())
+	batch.Put(common.JoinBytes(rollbackByte, common.Uint64ToBytes(identifier.Height)), rollbackPatch.Dump())
+	if err := AppendPatchToLevelDBBatch(batch, frontierByte, patch, false); err != nil {
+		return err
+	}
 
 	m.changes.Lock()
 	defer m.changes.Unlock()
+	if m.stopped {
+		return errors.Errorf("can't add transaction to stopped db")
+	}
 
 	frontierIdentifier := GetFrontierIdentifier(db)
-
-	if previous == frontierIdentifier {
-		if err := m.ldb.Put(common.JoinBytes(patchByte, common.Uint64ToBytes(identifier.Height)), patch.Dump(), nil); err != nil {
-			return err
-		}
-		if err := m.ldb.Put(common.JoinBytes(rollbackByte, common.Uint64ToBytes(identifier.Height)), rollbackPatch.Dump(), nil); err != nil {
-			return err
-		}
-		if err := ApplyPatch(NewLevelDBWrapper(m.ldb).Subset(frontierByte), patch); err != nil {
-			return err
-		}
+	if previous != frontierIdentifier {
+		return nil
 	}
-	return nil
+	return m.write(batch)
 }
 func (m *ldbManager) Pop() error {
-	frontierIdentifier := GetFrontierIdentifier(m.Frontier())
-	rollbackPatch := m.getRollback(frontierIdentifier.Height)
-
-	if err := ApplyPatch(NewLevelDBWrapper(m.ldb).Subset(frontierByte), rollbackPatch); err != nil {
-		return err
-	}
-	if err := m.ldb.Delete(common.JoinBytes(patchByte, common.Uint64ToBytes(frontierIdentifier.Height)), nil); err != nil {
-		return err
-	}
-	if err := m.ldb.Delete(common.JoinBytes(rollbackByte, common.Uint64ToBytes(frontierIdentifier.Height)), nil); err != nil {
-		return err
+	m.changes.Lock()
+	defer m.changes.Unlock()
+	if m.stopped {
+		return errors.Errorf("can't pop stopped db")
 	}
 
-	return nil
+	frontierIdentifier := GetFrontierIdentifier(NewLevelDBWrapper(m.ldb).Subset(frontierByte))
+	rollbackData, err := m.ldb.Get(common.JoinBytes(rollbackByte, common.Uint64ToBytes(frontierIdentifier.Height)), nil)
+	if err != nil {
+		return err
+	}
+	rollbackPatch, err := NewPatchFromDump(rollbackData)
+	if err != nil {
+		return err
+	}
+
+	batch := new(leveldb.Batch)
+	if err := AppendPatchToLevelDBBatch(batch, frontierByte, rollbackPatch, false); err != nil {
+		return err
+	}
+	batch.Delete(common.JoinBytes(patchByte, common.Uint64ToBytes(frontierIdentifier.Height)))
+	batch.Delete(common.JoinBytes(rollbackByte, common.Uint64ToBytes(frontierIdentifier.Height)))
+	return m.write(batch)
 }
 func (m *ldbManager) Stop() error {
 	m.changes.Lock()

--- a/common/db/versioned_db_test.go
+++ b/common/db/versioned_db_test.go
@@ -1,9 +1,12 @@
 package db
 
 import (
+	"errors"
 	"fmt"
 	"math/rand"
 	"testing"
+
+	"github.com/syndtr/goleveldb/leveldb"
 
 	"github.com/zenon-network/go-zenon/common"
 	"github.com/zenon-network/go-zenon/common/types"
@@ -62,6 +65,60 @@ func newMockTransaction(seed int64, db DB) *mockTransaction {
 	return &mockTransaction{
 		patch:  changes,
 		commit: ab,
+	}
+}
+
+func TestLevelDBManagerAddWriteFailureIsAtomic(t *testing.T) {
+	m := NewLevelDBManager(t.TempDir()).(*ldbManager)
+	defer m.Stop()
+
+	before := GetFrontierIdentifier(m.Frontier())
+	transaction := newMockTransaction(1, m.Frontier())
+	identifier := transaction.commit.Identifier()
+	writeErr := errors.New("write failed")
+	m.write = func(*leveldb.Batch) error {
+		return writeErr
+	}
+
+	if err := m.Add(transaction); !errors.Is(err, writeErr) {
+		t.Fatalf("expected write error, got %v", err)
+	}
+	common.Expect(t, GetFrontierIdentifier(m.Frontier()), before)
+
+	for _, key := range [][]byte{
+		common.JoinBytes(patchByte, common.Uint64ToBytes(identifier.Height)),
+		common.JoinBytes(rollbackByte, common.Uint64ToBytes(identifier.Height)),
+	} {
+		has, err := m.ldb.Has(key, nil)
+		common.FailIfErr(t, err)
+		common.ExpectTrue(t, !has)
+	}
+}
+
+func TestLevelDBManagerPopWriteFailureIsAtomic(t *testing.T) {
+	m := NewLevelDBManager(t.TempDir()).(*ldbManager)
+	defer m.Stop()
+
+	transaction := newMockTransaction(1, m.Frontier())
+	common.FailIfErr(t, m.Add(transaction))
+	before := GetFrontierIdentifier(m.Frontier())
+	writeErr := errors.New("write failed")
+	m.write = func(*leveldb.Batch) error {
+		return writeErr
+	}
+
+	if err := m.Pop(); !errors.Is(err, writeErr) {
+		t.Fatalf("expected write error, got %v", err)
+	}
+	common.Expect(t, GetFrontierIdentifier(m.Frontier()), before)
+
+	for _, key := range [][]byte{
+		common.JoinBytes(patchByte, common.Uint64ToBytes(before.Height)),
+		common.JoinBytes(rollbackByte, common.Uint64ToBytes(before.Height)),
+	} {
+		has, err := m.ldb.Has(key, nil)
+		common.FailIfErr(t, err)
+		common.ExpectTrue(t, has)
 	}
 }
 

--- a/protocol/broadcaster.go
+++ b/protocol/broadcaster.go
@@ -2,6 +2,9 @@ package protocol
 
 import (
 	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
 
 	"github.com/zenon-network/go-zenon/chain"
 	"github.com/zenon-network/go-zenon/chain/nom"
@@ -39,8 +42,16 @@ func (b *broadcaster) CreateMomentum(momentumTransaction *nom.MomentumTransactio
 	}
 	err = b.chain.AddMomentumTransaction(insert, momentumTransaction)
 	if err != nil {
+		var uncertain *chain.ErrCanonicalStateUncertain
+		if errors.As(err, &uncertain) {
+			insert.Unlock()
+			b.log.Crit("canonical chain state uncertain after failed momentum insertion, can't continue", "reason", err)
+			os.Exit(2)
+		}
 		if rollbackErr := b.chain.RollbackCacheTo(insert, momentumTransaction.Momentum.Previous()); rollbackErr != nil {
-			b.log.Error("failed to roll back cache after failed momentum insertion", "reason", rollbackErr)
+			insert.Unlock()
+			b.log.Crit("cache rollback failed after failed momentum insertion, can't continue", "reason", rollbackErr, "cause", err)
+			os.Exit(2)
 		}
 		insert.Unlock()
 		b.log.Error("failed to insert own momentum", "reason", err)

--- a/protocol/broadcaster.go
+++ b/protocol/broadcaster.go
@@ -38,11 +38,15 @@ func (b *broadcaster) CreateMomentum(momentumTransaction *nom.MomentumTransactio
 		return
 	}
 	err = b.chain.AddMomentumTransaction(insert, momentumTransaction)
-	insert.Unlock()
 	if err != nil {
+		if rollbackErr := b.chain.RollbackCacheTo(insert, momentumTransaction.Momentum.Previous()); rollbackErr != nil {
+			b.log.Error("failed to roll back cache after failed momentum insertion", "reason", rollbackErr)
+		}
+		insert.Unlock()
 		b.log.Error("failed to insert own momentum", "reason", err)
 		return
 	}
+	insert.Unlock()
 
 	store := b.chain.GetFrontierMomentumStore()
 	detailed, err = store.PrefetchMomentum(momentumTransaction.Momentum)

--- a/protocol/chain_bridge.go
+++ b/protocol/chain_bridge.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/pkg/errors"
 
@@ -218,8 +219,14 @@ func (c chainBridge) InsertChain(momentums []*nom.DetailedMomentum) (int, error)
 		}
 		if err := c.chain.AddMomentumTransaction(insert, transaction); err != nil {
 			log.Error("error while inserting momentum", "reason", err, "momentum-identifier", detailed.Momentum.Identifier())
+			var uncertain *chain.ErrCanonicalStateUncertain
+			if errors.As(err, &uncertain) {
+				log.Crit("canonical chain state uncertain after failed momentum insertion, can't continue", "reason", err, "momentum-identifier", detailed.Momentum.Identifier())
+				os.Exit(2)
+			}
 			if rollbackErr := c.chain.RollbackCacheTo(insert, detailed.Momentum.Previous()); rollbackErr != nil {
-				log.Error("error while rolling back cache after failed momentum insertion", "reason", rollbackErr, "momentum-identifier", detailed.Momentum.Identifier())
+				log.Crit("cache rollback failed after failed momentum insertion, can't continue", "reason", rollbackErr, "cause", err, "momentum-identifier", detailed.Momentum.Identifier())
+				os.Exit(2)
 			}
 			return index + start, err
 		}

--- a/protocol/chain_bridge.go
+++ b/protocol/chain_bridge.go
@@ -3,6 +3,7 @@ package protocol
 import (
 	"fmt"
 	"os"
+	"sync"
 
 	"github.com/pkg/errors"
 
@@ -20,6 +21,19 @@ type chainBridge struct {
 	consensus  consensus.Consensus
 	verifier   verifier.Verifier
 	supervisor *vm.Supervisor
+}
+
+func (c chainBridge) rollbackSideChain(insert sync.Locker, identifier types.HashHeight) error {
+	if err := c.chain.RollbackTo(insert, identifier); err != nil {
+		return err
+	}
+	if err := c.chain.RollbackCacheTo(insert, identifier); err != nil {
+		return &chain.ErrCanonicalStateUncertain{
+			Cause:       errors.Errorf("canonical chain rolled back to %v but cache rollback failed", identifier),
+			RollbackErr: err,
+		}
+	}
+	return nil
 }
 
 func NewChainBridge(chain chain.Chain, consensus consensus.Consensus, verifier verifier.Verifier, supervisor *vm.Supervisor) ChainBridge {
@@ -177,14 +191,13 @@ func (c chainBridge) InsertChain(momentums []*nom.DetailedMomentum) (int, error)
 			return 0, errors.Errorf("won't insert side-chain which is not longer")
 		}
 
-		err = c.chain.RollbackTo(insert, target.Identifier())
-		if err != nil {
+		if err := c.rollbackSideChain(insert, target.Identifier()); err != nil {
+			var uncertain *chain.ErrCanonicalStateUncertain
+			if errors.As(err, &uncertain) {
+				log.Crit("chain state uncertain after failed side-chain rollback, can't continue", "reason", err, "target", target.Identifier())
+				os.Exit(2)
+			}
 			return 0, errors.Errorf("unable to rollback to %v. Reason:%v", target.Identifier(), err)
-		}
-
-		err = c.chain.RollbackCacheTo(insert, target.Identifier())
-		if err != nil {
-			return 0, errors.Errorf("unable to rollback cache to %v. Reason:%v", target.Identifier(), err)
 		}
 	}
 

--- a/protocol/chain_bridge.go
+++ b/protocol/chain_bridge.go
@@ -218,6 +218,9 @@ func (c chainBridge) InsertChain(momentums []*nom.DetailedMomentum) (int, error)
 		}
 		if err := c.chain.AddMomentumTransaction(insert, transaction); err != nil {
 			log.Error("error while inserting momentum", "reason", err, "momentum-identifier", detailed.Momentum.Identifier())
+			if rollbackErr := c.chain.RollbackCacheTo(insert, detailed.Momentum.Previous()); rollbackErr != nil {
+				log.Error("error while rolling back cache after failed momentum insertion", "reason", rollbackErr, "momentum-identifier", detailed.Momentum.Identifier())
+			}
 			return index + start, err
 		}
 	}

--- a/protocol/chain_bridge_test.go
+++ b/protocol/chain_bridge_test.go
@@ -1,0 +1,66 @@
+package protocol
+
+import (
+	"errors"
+	"sync"
+	"testing"
+
+	"github.com/zenon-network/go-zenon/chain"
+	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/common/types"
+)
+
+type rollbackTestChain struct {
+	chain.Chain
+	rollbackErr      error
+	cacheRollbackErr error
+	rollbackCalls    int
+	cacheCalls       int
+}
+
+func (c *rollbackTestChain) RollbackTo(sync.Locker, types.HashHeight) error {
+	c.rollbackCalls++
+	return c.rollbackErr
+}
+
+func (c *rollbackTestChain) RollbackCacheTo(sync.Locker, types.HashHeight) error {
+	c.cacheCalls++
+	return c.cacheRollbackErr
+}
+
+func TestRollbackSideChainCacheFailureIsUnrecoverable(t *testing.T) {
+	testChain := &rollbackTestChain{cacheRollbackErr: errors.New("cache rollback failed")}
+	bridge := chainBridge{chain: testChain}
+
+	err := bridge.rollbackSideChain(&sync.Mutex{}, types.HashHeight{Height: 1})
+
+	var uncertain *chain.ErrCanonicalStateUncertain
+	common.ExpectTrue(t, errors.As(err, &uncertain))
+	common.ExpectTrue(t, uncertain.Cause != nil)
+	common.ExpectTrue(t, uncertain.RollbackErr != nil)
+	common.Expect(t, testChain.rollbackCalls, 1)
+	common.Expect(t, testChain.cacheCalls, 1)
+}
+
+func TestRollbackSideChainCanonicalFailureSkipsCache(t *testing.T) {
+	rollbackErr := errors.New("canonical rollback failed")
+	testChain := &rollbackTestChain{rollbackErr: rollbackErr}
+	bridge := chainBridge{chain: testChain}
+
+	err := bridge.rollbackSideChain(&sync.Mutex{}, types.HashHeight{Height: 1})
+
+	common.ExpectTrue(t, errors.Is(err, rollbackErr))
+	common.Expect(t, testChain.rollbackCalls, 1)
+	common.Expect(t, testChain.cacheCalls, 0)
+}
+
+func TestRollbackSideChainSuccess(t *testing.T) {
+	testChain := &rollbackTestChain{}
+	bridge := chainBridge{chain: testChain}
+
+	err := bridge.rollbackSideChain(&sync.Mutex{}, types.HashHeight{Height: 1})
+
+	common.FailIfErr(t, err)
+	common.Expect(t, testChain.rollbackCalls, 1)
+	common.Expect(t, testChain.cacheCalls, 1)
+}


### PR DESCRIPTION
Propagate the ApplyMomentum error in chain/cache.go instead of discarding it, and guard against a nil frontier store.

Return false with an iterator error from mergedIterator.Prev/Last instead of panicking, since reverse iteration is unsupported on the merged backend.

Roll the cache back to the previous momentum when
AddMomentumTransaction fails after UpdateCache succeeded, closing the atomicity gap between cache and canonical chain in both remote insertion (chain_bridge.go) and local momentum creation (broadcaster.go).

Check the GetSnapshot error and release the snapshot in cacheManager.getRollback to stop leaking LevelDB snapshots on rollback.