### PR TITLE
fix: reinstate Libp2pSpork in ImplementedSporksMap

### DIFF
--- a/common/types/spork.go
+++ b/common/types/spork.go
@@ -40,6 +40,7 @@ var (
 		AcceleratorSpork.SporkId:        true,
 		HtlcSpork.SporkId:               true,
 		BridgeAndLiquiditySpork.SporkId: true,
+		Libp2pSpork.SporkId:             true,
 		DynamicPlasmaSpork.SporkId:      true,
 	}
 )


### PR DESCRIPTION
Libp2pSpork was dropped from the map in an earlier rebase, so GotAllActiveSporksImplemented would flag an activated libp2p spork as unimplemented and halt the node.