### PR TITLE
fix: lilp2p & Dynamic Plasma PR 

### DIFF
--- a/chain/account_pool.go
+++ b/chain/account_pool.go
@@ -153,7 +153,7 @@ func higherPricedBlock(plasma dp.DynamicPlasma, a, b *nom.AccountBlock) error {
 // replacement that content selection would then rank below the block it
 // just evicted. An exact price tie is resolved here by smallest hash, the
 // fork-resolution rule documented on the AccountPool interface
-// (chain/interface.go:53-55), deliberately independent of the content
+// (chain/interface.go), deliberately independent of the content
 // selector's larger-hash tie-break: the two answer different questions —
 // which block survives a fork vs. which block is emitted first. Pre-
 // activation (or if the frontier momentum store can't answer, e.g. in

--- a/chain/account_pool.go
+++ b/chain/account_pool.go
@@ -130,23 +130,46 @@ func (ap *accountPool) canRollback(block *nom.AccountBlock) error {
 	return nil
 }
 
+// higherPricedBlock reports whether a should replace b under dynamic-plasma
+// pricing. An exact price tie is resolved by smallest hash so that nodes
+// seeing the two blocks in different orders converge on the same one, the
+// rule documented on the AccountPool interface.
+func higherPricedBlock(plasma dp.DynamicPlasma, a, b *nom.AccountBlock) error {
+	err := plasma.HigherPrice(a, b)
+	if err == dp.ErrBlockPriceSame {
+		if bytes.Compare(a.Hash.Bytes()[:], b.Hash.Bytes()[:]) > -1 {
+			return ErrHashTieBreak
+		}
+		return nil
+	}
+	return err
+}
+
 // higherPriority reports whether a should replace b as the pool's block
 // at their shared height. Once dynamic plasma is active, momentum
-// content selection ranks blocks by dp.DynamicPlasma.HigherPrice (see
-// pillar/content_selector.go), so replacement must use the same rule —
-// otherwise the pool can accept a replacement that content selection
-// would then rank below the block it just evicted, or reject one it
-// would have preferred. Pre-activation (or if the frontier momentum
-// store can't answer, e.g. in genesis construction), momentum content
-// selection still uses the legacy TotalPlasma/BasePlasma ratio, so that
-// remains the fallback.
+// content selection ranks blocks by the same price rule,
+// dp.DynamicPlasma.HigherPrice (see pillar/content_selector.go), so
+// replacement must use it too — otherwise the pool can accept a
+// replacement that content selection would then rank below the block it
+// just evicted. An exact price tie is resolved here by smallest hash, the
+// fork-resolution rule documented on the AccountPool interface
+// (chain/interface.go:53-55), deliberately independent of the content
+// selector's larger-hash tie-break: the two answer different questions —
+// which block survives a fork vs. which block is emitted first. Pre-
+// activation (or if the frontier momentum store can't answer, e.g. in
+// genesis construction), momentum content selection still uses the legacy
+// TotalPlasma/BasePlasma ratio, so that remains the fallback.
 func (ap *accountPool) higherPriority(a, b *nom.AccountBlock) error {
 	if store := ap.stable.GetFrontierMomentumStore(); store != nil {
-		if active, err := store.IsSporkActive(types.DynamicPlasmaSpork); err == nil && active {
-			if previous, err := store.GetFrontierMomentum(); err == nil {
-				if config, err := store.GetPlasmaVariables(); err == nil {
-					return dp.NewDynamicPlasma(previous, config).HigherPrice(a, b)
-				}
+		if active, err := store.IsSporkActive(types.DynamicPlasmaSpork); err != nil {
+			ap.log.Debug("using legacy plasma-ratio comparator", "reason", err)
+		} else if active {
+			if previous, err := store.GetFrontierMomentum(); err != nil {
+				ap.log.Debug("using legacy plasma-ratio comparator", "reason", err)
+			} else if config, err := store.GetPlasmaVariables(); err != nil {
+				ap.log.Debug("using legacy plasma-ratio comparator", "reason", err)
+			} else {
+				return higherPricedBlock(dp.NewDynamicPlasma(previous, config), a, b)
 			}
 		}
 	}

--- a/chain/account_pool.go
+++ b/chain/account_pool.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zenon-network/go-zenon/common"
 	"github.com/zenon-network/go-zenon/common/db"
 	"github.com/zenon-network/go-zenon/common/types"
+	"github.com/zenon-network/go-zenon/dp"
 )
 
 var (
@@ -33,6 +34,7 @@ var (
 
 type Stable interface {
 	GetStableAccountDB(address types.Address) db.DB
+	GetFrontierMomentumStore() store.Momentum
 }
 
 type accountManager struct {
@@ -128,7 +130,27 @@ func (ap *accountPool) canRollback(block *nom.AccountBlock) error {
 	return nil
 }
 
-func higherPriority(a, b *nom.AccountBlock) error {
+// higherPriority reports whether a should replace b as the pool's block
+// at their shared height. Once dynamic plasma is active, momentum
+// content selection ranks blocks by dp.DynamicPlasma.HigherPrice (see
+// pillar/content_selector.go), so replacement must use the same rule —
+// otherwise the pool can accept a replacement that content selection
+// would then rank below the block it just evicted, or reject one it
+// would have preferred. Pre-activation (or if the frontier momentum
+// store can't answer, e.g. in genesis construction), momentum content
+// selection still uses the legacy TotalPlasma/BasePlasma ratio, so that
+// remains the fallback.
+func (ap *accountPool) higherPriority(a, b *nom.AccountBlock) error {
+	if store := ap.stable.GetFrontierMomentumStore(); store != nil {
+		if active, err := store.IsSporkActive(types.DynamicPlasmaSpork); err == nil && active {
+			if previous, err := store.GetFrontierMomentum(); err == nil {
+				if config, err := store.GetPlasmaVariables(); err == nil {
+					return dp.NewDynamicPlasma(previous, config).HigherPrice(a, b)
+				}
+			}
+		}
+	}
+
 	if a.TotalPlasma*b.BasePlasma < b.TotalPlasma*a.BasePlasma {
 		return ErrPlasmaRatioIsWorse
 	} else if a.TotalPlasma*b.BasePlasma == b.TotalPlasma*a.BasePlasma && bytes.Compare(a.Hash.Bytes()[:], b.Hash.Bytes()[:]) > -1 {
@@ -165,15 +187,17 @@ func (ap *accountPool) addAccountBlockTransaction(transaction *nom.AccountBlockT
 	frontier := ap.getFrontierAccountStore(address)
 	frontierIdentifier := frontier.Identifier()
 
-	// check uncommitted plasma amount
-	if !forceAdd && !types.IsEmbeddedAddress(address) {
-		if err := ap.checkUncommittedBlocksCount(address); err != nil {
-			return err
-		}
-	}
-
 	// fast-forward insert on top of chain
 	if previous == frontierIdentifier {
+		// check uncommitted plasma amount. Only applies to fast-forward
+		// inserts: a rollback/replacement doesn't lengthen the pending
+		// chain, and an already-inserted duplicate is idempotent —
+		// neither should be rejected just because the account is at cap.
+		if !forceAdd && !types.IsEmbeddedAddress(address) {
+			if err := ap.checkUncommittedBlocksCount(address); err != nil {
+				return err
+			}
+		}
 		log.Info("fast-forward inserting account-block")
 		return ap.getAccountManager(address).Add(transaction)
 	}
@@ -192,7 +216,7 @@ func (ap *accountPool) addAccountBlockTransaction(transaction *nom.AccountBlockT
 	if err := ap.canRollback(block); err != nil {
 		return err
 	}
-	if err := higherPriority(block, trueBlock); !forceAdd && err != nil {
+	if err := ap.higherPriority(block, trueBlock); !forceAdd && err != nil {
 		log.Info("failed to insert account-block-transaction", "reason", err, "frontier-identifier", frontierIdentifier)
 		return err
 	}
@@ -376,12 +400,6 @@ func (ap *accountPool) getUncommittedAccountBlocksByAddress(address types.Addres
 	return blocks
 }
 
-func (ap *accountPool) CheckUncommittedBlocksCount(address types.Address) error {
-	ap.changes.Lock()
-	defer ap.changes.Unlock()
-
-	return ap.checkUncommittedBlocksCount(address)
-}
 func (ap *accountPool) checkUncommittedBlocksCount(address types.Address) error {
 	frontier, err := ap.getFrontierAccountStore(address).Frontier()
 	if err != nil {

--- a/chain/account_pool.go
+++ b/chain/account_pool.go
@@ -80,6 +80,22 @@ type accountPool struct {
 	stable   Stable
 	managers map[types.Address]*accountManager
 	changes  sync.Mutex
+
+	// plasma is the dynamic-plasma pricing context derived from the
+	// committed frontier momentum, or nil while the dynamic-plasma spork
+	// is inactive or the momentum store cannot answer. It only changes
+	// when the frontier momentum does, so it is refreshed once per
+	// committed (or rolled-back) momentum rather than recomputed on every
+	// contested insert.
+	//
+	// plasmaMu guards the field alone: it is never held across a store
+	// read or across ap.changes, so it is a leaf lock. Every production
+	// writer (momentum insert/rollback) and reader (higherPriority) runs
+	// under chain.insert already, so plasmaMu is what keeps that invariant
+	// enforced rather than assumed — including for direct unit-test use of
+	// the pool, and for -race.
+	plasma   dp.DynamicPlasma
+	plasmaMu sync.Mutex
 }
 
 func (ap *accountPool) getAccountManager(address types.Address) *accountManager {
@@ -156,22 +172,17 @@ func higherPricedBlock(plasma dp.DynamicPlasma, a, b *nom.AccountBlock) error {
 // (chain/interface.go), deliberately independent of the content
 // selector's larger-hash tie-break: the two answer different questions —
 // which block survives a fork vs. which block is emitted first. Pre-
-// activation (or if the frontier momentum store can't answer, e.g. in
-// genesis construction), momentum content selection still uses the legacy
+// activation, the comparator uses the pricing context cached from the
+// committed frontier momentum; while that context is empty (dynamic
+// plasma inactive, or the momentum store could not answer — genesis
+// construction, for one) momentum content selection still uses the legacy
 // TotalPlasma/BasePlasma ratio, so that remains the fallback.
 func (ap *accountPool) higherPriority(a, b *nom.AccountBlock) error {
-	if store := ap.stable.GetFrontierMomentumStore(); store != nil {
-		if active, err := store.IsSporkActive(types.DynamicPlasmaSpork); err != nil {
-			ap.log.Debug("using legacy plasma-ratio comparator", "reason", err)
-		} else if active {
-			if previous, err := store.GetFrontierMomentum(); err != nil {
-				ap.log.Debug("using legacy plasma-ratio comparator", "reason", err)
-			} else if config, err := store.GetPlasmaVariables(); err != nil {
-				ap.log.Debug("using legacy plasma-ratio comparator", "reason", err)
-			} else {
-				return higherPricedBlock(dp.NewDynamicPlasma(previous, config), a, b)
-			}
-		}
+	ap.plasmaMu.Lock()
+	plasma := ap.plasma
+	ap.plasmaMu.Unlock()
+	if plasma != nil {
+		return higherPricedBlock(plasma, a, b)
 	}
 
 	if a.TotalPlasma*b.BasePlasma < b.TotalPlasma*a.BasePlasma {
@@ -305,7 +316,52 @@ func (ap *accountPool) getFrontierAccountStore(address types.Address) store.Acco
 	return account.NewAccountStore(address, ap.getAccountManager(address).db.Frontier())
 }
 
+// refreshDynamicPlasma recomputes the pricing context from the committed
+// frontier momentum. Called on every momentum insert and rollback, and
+// once at chain start-up.
+func (ap *accountPool) refreshDynamicPlasma() {
+	plasma := ap.computeDynamicPlasma()
+	ap.plasmaMu.Lock()
+	ap.plasma = plasma
+	ap.plasmaMu.Unlock()
+}
+
+// computeDynamicPlasma returns the pricing context for the committed
+// frontier momentum, or nil when dynamic plasma is inactive or the
+// momentum store cannot answer. A store that cannot answer is logged at
+// Warn: it means pool replacement falls back to the legacy plasma-ratio
+// comparator while momentum content selection keeps ranking by price, so
+// the pool can keep a block content selection would rank below the one it
+// evicted.
+func (ap *accountPool) computeDynamicPlasma() dp.DynamicPlasma {
+	store := ap.stable.GetFrontierMomentumStore()
+	if store == nil {
+		return nil
+	}
+	active, err := store.IsSporkActive(types.DynamicPlasmaSpork)
+	if err != nil {
+		ap.log.Warn("using legacy plasma-ratio comparator", "reason", err)
+		return nil
+	}
+	if !active {
+		return nil
+	}
+	previous, err := store.GetFrontierMomentum()
+	if err != nil {
+		ap.log.Warn("using legacy plasma-ratio comparator", "reason", err)
+		return nil
+	}
+	config, err := store.GetPlasmaVariables()
+	if err != nil {
+		ap.log.Warn("using legacy plasma-ratio comparator", "reason", err)
+		return nil
+	}
+	return dp.NewDynamicPlasma(previous, config)
+}
+
 func (ap *accountPool) InsertMomentum(detailed *nom.DetailedMomentum) {
+	ap.refreshDynamicPlasma()
+
 	ap.changes.Lock()
 	defer ap.changes.Unlock()
 
@@ -314,6 +370,8 @@ func (ap *accountPool) InsertMomentum(detailed *nom.DetailedMomentum) {
 	}
 }
 func (ap *accountPool) DeleteMomentum(*nom.DetailedMomentum) {
+	ap.refreshDynamicPlasma()
+
 	ap.changes.Lock()
 	defer ap.changes.Unlock()
 

--- a/chain/account_pool.go
+++ b/chain/account_pool.go
@@ -171,12 +171,12 @@ func higherPricedBlock(plasma dp.DynamicPlasma, a, b *nom.AccountBlock) error {
 // fork-resolution rule documented on the AccountPool interface
 // (chain/interface.go), deliberately independent of the content
 // selector's larger-hash tie-break: the two answer different questions —
-// which block survives a fork vs. which block is emitted first. Pre-
-// activation, the comparator uses the pricing context cached from the
-// committed frontier momentum; while that context is empty (dynamic
-// plasma inactive, or the momentum store could not answer — genesis
-// construction, for one) momentum content selection still uses the legacy
-// TotalPlasma/BasePlasma ratio, so that remains the fallback.
+// which block survives a fork vs. which block is emitted first. The
+// comparator uses the pricing context cached from the committed frontier
+// momentum; while that context is empty (dynamic plasma inactive, or the
+// momentum store could not answer — genesis construction, for one) momentum
+// content selection still uses the legacy TotalPlasma/BasePlasma ratio, so
+// that remains the fallback.
 func (ap *accountPool) higherPriority(a, b *nom.AccountBlock) error {
 	ap.plasmaMu.Lock()
 	plasma := ap.plasma

--- a/chain/account_pool_test.go
+++ b/chain/account_pool_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/zenon-network/go-zenon/common"
 	"github.com/zenon-network/go-zenon/common/db"
 	"github.com/zenon-network/go-zenon/common/types"
+	"github.com/zenon-network/go-zenon/dp"
+	"github.com/zenon-network/go-zenon/vm/embedded/definition"
 )
 
 type fakeStable struct{}
@@ -201,4 +203,24 @@ func testHashHeight(height uint64) types.HashHeight {
 		Hash:   types.NewHash(common.Uint64ToBytes(height)),
 		Height: height,
 	}
+}
+
+func TestHigherPricedBlock_TieBreaksOnSmallestHash(t *testing.T) {
+	plasma := dp.NewDynamicPlasma(&nom.Momentum{Version: 2, NextFusionPrice: 1000, NextWorkPrice: 1000}, &definition.PlasmaVariables{})
+
+	smallerHash := &nom.AccountBlock{BasePlasma: 21000, FusedPlasma: 21000}
+	smallerHash.Hash = types.Hash{0}
+	largerHash := &nom.AccountBlock{BasePlasma: 21000, FusedPlasma: 21000}
+	largerHash.Hash = types.Hash{1}
+
+	// Smaller hash wins the tie: a replaces b.
+	common.FailIfErr(t, higherPricedBlock(plasma, smallerHash, largerHash))
+
+	// Larger hash loses the tie: a does not replace b.
+	common.ExpectError(t, higherPricedBlock(plasma, largerHash, smallerHash), ErrHashTieBreak)
+
+	// An unambiguously cheaper block passes the price result through
+	// unchanged; the tie-break never fires.
+	cheaper := &nom.AccountBlock{BasePlasma: 21000, FusedPlasma: 100}
+	common.ExpectError(t, higherPricedBlock(plasma, cheaper, largerHash), dp.ErrBlockPriceWorse)
 }

--- a/chain/account_pool_test.go
+++ b/chain/account_pool_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/zenon-network/go-zenon/chain/nom"
+	"github.com/zenon-network/go-zenon/chain/store"
 	"github.com/zenon-network/go-zenon/common"
 	"github.com/zenon-network/go-zenon/common/db"
 	"github.com/zenon-network/go-zenon/common/types"
@@ -13,6 +14,13 @@ type fakeStable struct{}
 
 func (fakeStable) GetStableAccountDB(types.Address) db.DB {
 	return db.NewMemDB()
+}
+
+// GetFrontierMomentumStore returns nil so higherPriority falls back to
+// the legacy ratio comparator; these tests don't exercise dynamic
+// plasma activation.
+func (fakeStable) GetFrontierMomentumStore() store.Momentum {
+	return nil
 }
 
 // A never-committed account has no stable frontier, so its uncommitted block
@@ -40,6 +48,73 @@ func TestAccountPool_checkUncommittedBlocksCount_FreshAccount(t *testing.T) {
 	}
 
 	common.ExpectTrue(t, ap.checkUncommittedBlocksCount(address) != nil)
+}
+
+// The uncommitted-block cap must only gate inserts that lengthen the
+// pending chain (fast-forward). A same-height replacement (rollback) or
+// a resubmission of an already-inserted block must still be accepted
+// while the account sits at the cap, since neither grows the
+// uncommitted chain.
+func TestAccountPool_ReplacementAndDuplicateAcceptedAtCap(t *testing.T) {
+	// First byte 0 (types.UserAddrByte) so IsEmbeddedAddress is false and
+	// addAccountBlockTransaction's uncommitted-block-count guard actually
+	// applies — unlike the sibling FreshAccount test above, this test
+	// exercises that guard through addAccountBlockTransaction itself, not
+	// just checkUncommittedBlocksCount directly.
+	address := types.Address{0, 1}
+	ap := newAccountPool(fakeStable{})
+	manager := ap.getAccountManager(address)
+
+	previousHash := types.ZeroHash
+	var block500 *nom.AccountBlock
+	for height := uint64(1); height <= MaxUncommittedBlocksPerAccount; height++ {
+		block := &nom.AccountBlock{
+			Address:      address,
+			BlockType:    nom.BlockTypeUserSend,
+			Height:       height,
+			PreviousHash: previousHash,
+			TotalPlasma:  100,
+			BasePlasma:   100,
+		}
+		block.Hash = block.ComputeHash()
+		common.FailIfErr(t, manager.Add(&nom.AccountBlockTransaction{
+			Block:   block,
+			Changes: db.NewPatch(),
+		}))
+		previousHash = block.Hash
+		block500 = block
+	}
+
+	// Sanity: the account is genuinely at the cap for fast-forward inserts.
+	common.ExpectTrue(t, ap.checkUncommittedBlocksCount(address) != nil)
+
+	// Resubmitting the already-inserted frontier block must stay
+	// idempotent rather than error out because the account is at cap.
+	duplicate := &nom.AccountBlockTransaction{Block: block500.Copy(), Changes: db.NewPatch()}
+	common.FailIfErr(t, ap.addAccountBlockTransaction(duplicate, false))
+
+	// A same-height, higher-priced replacement (distinct hash via Data,
+	// same previous/height as block500) must be accepted through the
+	// rollback path: it doesn't grow the uncommitted chain, so the cap
+	// must not block it.
+	replacement := &nom.AccountBlock{
+		Address:      address,
+		BlockType:    nom.BlockTypeUserSend,
+		Height:       MaxUncommittedBlocksPerAccount,
+		PreviousHash: block500.PreviousHash,
+		Data:         []byte{1},
+		TotalPlasma:  200, // higher TotalPlasma/BasePlasma ratio than block500 wins higherPriority
+		BasePlasma:   100,
+	}
+	replacement.Hash = replacement.ComputeHash()
+	common.FailIfErr(t, ap.addAccountBlockTransaction(&nom.AccountBlockTransaction{
+		Block:   replacement,
+		Changes: db.NewPatch(),
+	}, false))
+
+	frontier, err := ap.getFrontierAccountStore(address).Frontier()
+	common.FailIfErr(t, err)
+	common.ExpectTrue(t, frontier != nil && frontier.Identifier() == replacement.Identifier())
 }
 
 func TestAccountPool_filterBlocksToCommit(t *testing.T) {

--- a/chain/account_pool_test.go
+++ b/chain/account_pool_test.go
@@ -18,9 +18,9 @@ func (fakeStable) GetStableAccountDB(types.Address) db.DB {
 	return db.NewMemDB()
 }
 
-// GetFrontierMomentumStore returns nil so higherPriority falls back to
-// the legacy ratio comparator; these tests don't exercise dynamic
-// plasma activation.
+// GetFrontierMomentumStore returns nil so the pool's pricing context stays
+// empty and higherPriority falls back to the legacy ratio comparator;
+// these tests don't exercise dynamic plasma activation.
 func (fakeStable) GetFrontierMomentumStore() store.Momentum {
 	return nil
 }
@@ -223,4 +223,32 @@ func TestHigherPricedBlock_TieBreaksOnSmallestHash(t *testing.T) {
 	// unchanged; the tie-break never fires.
 	cheaper := &nom.AccountBlock{BasePlasma: 21000, FusedPlasma: 100}
 	common.ExpectError(t, higherPricedBlock(plasma, cheaper, largerHash), dp.ErrBlockPriceWorse)
+}
+
+// TestAccountPool_higherPriorityUsesCachedDynamicPlasma verifies that
+// higherPriority is driven by the pool's cached pricing context, not by a
+// fresh store read: fakeStable's store is nil, yet the price comparator
+// still runs while the cache is set, and stops running once it is cleared.
+func TestAccountPool_higherPriorityUsesCachedDynamicPlasma(t *testing.T) {
+	ap := newAccountPool(fakeStable{}) // its store is nil: no store answer available
+	ap.plasma = dp.NewDynamicPlasma(
+		&nom.Momentum{Version: 2, NextFusionPrice: 1000, NextWorkPrice: 1000},
+		&definition.PlasmaVariables{},
+	)
+
+	cheap := &nom.AccountBlock{BasePlasma: 21000, FusedPlasma: 100}
+	cheap.Hash = types.Hash{1}
+	rich := &nom.AccountBlock{BasePlasma: 21000, FusedPlasma: 21000}
+	rich.Hash = types.Hash{0}
+
+	// With the cache set, the price comparator ran even though fakeStable
+	// has no store.
+	common.ExpectError(t, ap.higherPriority(cheap, rich), dp.ErrBlockPriceWorse)
+
+	// With the cache cleared, both blocks have TotalPlasma == 0, so the
+	// legacy branch's ratio comparison is an equality and resolves on the
+	// hash tie-break, which cheap.Hash{1} > rich.Hash{0} makes
+	// deterministic.
+	ap.plasma = nil
+	common.ExpectError(t, ap.higherPriority(cheap, rich), ErrHashTieBreak)
 }

--- a/chain/account_pool_test.go
+++ b/chain/account_pool_test.go
@@ -252,3 +252,20 @@ func TestAccountPool_higherPriorityUsesCachedDynamicPlasma(t *testing.T) {
 	ap.plasma = nil
 	common.ExpectError(t, ap.higherPriority(cheap, rich), ErrHashTieBreak)
 }
+
+// TestAccountPool_MomentumEventsRefreshDynamicPlasma verifies that
+// InsertMomentum and DeleteMomentum both refresh the pool's cached pricing
+// context by calling refreshDynamicPlasma, not just that higherPriority
+// consults the cache once it is populated.
+func TestAccountPool_MomentumEventsRefreshDynamicPlasma(t *testing.T) {
+	ap := newAccountPool(fakeStable{}) // nil store: any refresh must clear the cache
+	stale := dp.NewDynamicPlasma(&nom.Momentum{Version: 2, NextFusionPrice: 1000, NextWorkPrice: 1000}, &definition.PlasmaVariables{})
+
+	ap.plasma = stale
+	ap.InsertMomentum(&nom.DetailedMomentum{Momentum: &nom.Momentum{}})
+	common.Expect(t, ap.plasma == nil, true)
+
+	ap.plasma = stale
+	ap.DeleteMomentum(nil)
+	common.Expect(t, ap.plasma == nil, true)
+}

--- a/chain/chain.go
+++ b/chain/chain.go
@@ -59,6 +59,11 @@ func (c *chain) Init() error {
 	}
 	types.SporkAddress = c.genesis.GetSporkAddress()
 	c.Register(c.accountPool)
+	// Prime the pool's pricing context from the committed frontier so the
+	// first contested insert after start-up is priced the same way as one
+	// arriving after the next momentum, rather than falling back to the
+	// legacy comparator until then.
+	c.accountPool.refreshDynamicPlasma()
 
 	frontierStore := c.GetFrontierMomentumStore()
 	frontier, err := frontierStore.GetFrontierMomentum()

--- a/chain/genesis/account_block.go
+++ b/chain/genesis/account_block.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/zenon-network/go-zenon/chain"
 	"github.com/zenon-network/go-zenon/chain/nom"
+	"github.com/zenon-network/go-zenon/chain/store"
 	"github.com/zenon-network/go-zenon/common"
 	"github.com/zenon-network/go-zenon/common/db"
 	"github.com/zenon-network/go-zenon/common/types"
@@ -18,6 +19,14 @@ type mockStable struct {
 
 func (m *mockStable) GetStableAccountDB(address types.Address) db.DB {
 	return db.NewMemDB()
+}
+
+// GetFrontierMomentumStore returns nil: genesis constructs the very
+// first account blocks before any momentum exists, so there is no spork
+// state to consult. accountPool.higherPriority falls back to the legacy
+// ratio comparator whenever this is nil.
+func (m *mockStable) GetFrontierMomentumStore() store.Momentum {
+	return nil
 }
 
 func newGenesisAccountBlocks(cfg *GenesisConfig) chain.AccountPool {

--- a/chain/interface.go
+++ b/chain/interface.go
@@ -63,8 +63,6 @@ type AccountPool interface {
 	GetNewMomentumContent() []*nom.AccountBlock
 	GetAllUncommittedAccountBlocks() []*nom.AccountBlock
 	GetUncommittedAccountBlocksByAddress(address types.Address) []*nom.AccountBlock
-
-	CheckUncommittedBlocksCount(address types.Address) error
 }
 
 type ChainCache interface {

--- a/chain/tests/account_pool_test.go
+++ b/chain/tests/account_pool_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/zenon-network/go-zenon/chain"
 	g "github.com/zenon-network/go-zenon/chain/genesis/mock"
 	"github.com/zenon-network/go-zenon/chain/nom"
 	"github.com/zenon-network/go-zenon/common"
@@ -114,7 +115,7 @@ func TestAccountPool_Priority(t *testing.T) {
 	common.Expect(t, len(uncommitted), 1)
 	common.ExpectString(t, uncommitted[0].Hash.String(), highPriorityBlock.Hash.String())
 
-	z.InsertSendBlock(lowPriorityBlock, nil, mock.SkipVmChanges)
+	z.InsertSendBlockRejected(lowPriorityBlock, chain.ErrPlasmaRatioIsWorse)
 
 	uncommitted = z.Chain().GetAllUncommittedAccountBlocks()
 	common.Expect(t, len(uncommitted), 1)

--- a/common/types/spork.go
+++ b/common/types/spork.go
@@ -25,15 +25,15 @@ var (
 	// for the existing pattern).
 
 	// Libp2pSpork gates the activation of the libp2p networking stack.
-    // Until this spork's EnforcementHeight is reached on a node's local
-    // chain, the legacy (devp2p/RLPX) backend is in use; at activation,
-    // every node atomically switches to the libp2p backend.
+	// Until this spork's EnforcementHeight is reached on a node's local
+	// chain, the legacy (devp2p/RLPX) backend is in use; at activation,
+	// every node atomically switches to the libp2p backend.
 	Libp2pSpork = NewImplementedSpork("0000000000000000000000000000000000000000000000000000000000000001")
 
 	// DynamicPlasmaSpork gates the activation of the dynamic plasma pricing
-    // model. Until this spork's EnforcementHeight is reached, the legacy
-    // fixed-price plasma model is in use; at activation, momentums switch
-    // to version 2 with adaptive fusion/work prices.
+	// model. Until this spork's EnforcementHeight is reached, the legacy
+	// fixed-price plasma model is in use; at activation, momentums switch
+	// to version 2 with adaptive fusion/work prices.
 	DynamicPlasmaSpork = NewImplementedSpork("0000000000000000000000000000000000000000000000000000000000000002")
 
 	ImplementedSporksMap = map[Hash]bool{

--- a/dp/dp.go
+++ b/dp/dp.go
@@ -164,26 +164,28 @@ func (dp *dynamicPlasma) ValidPrice(block *nom.AccountBlock) bool {
 	floor.Mul(floor, new(big.Int).SetUint64(dp.workPrice))
 	floor.Mul(floor, new(big.Int).SetUint64(block.BasePlasma))
 
-	value := new(big.Int).Add(
-		new(big.Int).Mul(new(big.Int).SetUint64(block.FusedPlasma), new(big.Int).SetUint64(dp.workPrice)),
-		new(big.Int).Mul(new(big.Int).SetUint64(DifficultyToPlasma(block.Difficulty)), new(big.Int).SetUint64(dp.fusionPrice)),
-	)
+	value := dp.priceValue(block)
 	value.Mul(value, new(big.Int).SetUint64(constants.AccountBlockBasePlasma))
 
 	return value.Cmp(floor) >= 0
 }
 
-func (dp *dynamicPlasma) HigherPrice(a, b *nom.AccountBlock) error {
-	aValue := new(big.Int).Add(
-		new(big.Int).Mul(new(big.Int).SetUint64(a.FusedPlasma), new(big.Int).SetUint64(dp.workPrice)),
-		new(big.Int).Mul(new(big.Int).SetUint64(DifficultyToPlasma(a.Difficulty)), new(big.Int).SetUint64(dp.fusionPrice)),
+// priceValue is a block's plasma priced against the current resource
+// prices: fused plasma valued at the work price, PoW plasma at the fusion
+// price. Computed in big.Int because either product can exceed MaxUint64
+// at large prices. Returns a fresh value the caller may mutate.
+func (dp *dynamicPlasma) priceValue(block *nom.AccountBlock) *big.Int {
+	return new(big.Int).Add(
+		new(big.Int).Mul(new(big.Int).SetUint64(block.FusedPlasma), new(big.Int).SetUint64(dp.workPrice)),
+		new(big.Int).Mul(new(big.Int).SetUint64(DifficultyToPlasma(block.Difficulty)), new(big.Int).SetUint64(dp.fusionPrice)),
 	)
+}
+
+func (dp *dynamicPlasma) HigherPrice(a, b *nom.AccountBlock) error {
+	aValue := dp.priceValue(a)
 	aRatio := aValue.Mul(aValue, new(big.Int).SetUint64(b.BasePlasma))
 
-	bValue := new(big.Int).Add(
-		new(big.Int).Mul(new(big.Int).SetUint64(b.FusedPlasma), new(big.Int).SetUint64(dp.workPrice)),
-		new(big.Int).Mul(new(big.Int).SetUint64(DifficultyToPlasma(b.Difficulty)), new(big.Int).SetUint64(dp.fusionPrice)),
-	)
+	bValue := dp.priceValue(b)
 	bRatio := bValue.Mul(bValue, new(big.Int).SetUint64(a.BasePlasma))
 
 	switch aRatio.Cmp(bRatio) {
@@ -200,8 +202,16 @@ func (dp *dynamicPlasma) Config() *definition.PlasmaVariables {
 	return dp.config
 }
 
+// MaxContractBlocks is the per-momentum contract-block cap implied by a
+// plasma configuration. Package-level because the momentum verifier needs
+// this bound to sanity-check content size before it has a DynamicPlasma
+// instance to ask.
+func MaxContractBlocks(config *definition.PlasmaVariables) uint64 {
+	return config.MaxBasePlasmaInMomentum / constants.EmbeddedSimplePlasma
+}
+
 func (dp *dynamicPlasma) MaxContractBlocksInMomentum() uint64 {
-	return dp.config.MaxBasePlasmaInMomentum / constants.EmbeddedSimplePlasma
+	return MaxContractBlocks(dp.config)
 }
 
 func NewDynamicPlasma(context *nom.Momentum, config *definition.PlasmaVariables) DynamicPlasma {

--- a/dp/dp.go
+++ b/dp/dp.go
@@ -1,6 +1,7 @@
 package dp
 
 import (
+	"math"
 	"math/big"
 
 	"github.com/pkg/errors"
@@ -148,8 +149,26 @@ func (dp *dynamicPlasma) ValidPrice(block *nom.AccountBlock) bool {
 	if types.IsEmbeddedAddress(block.Address) {
 		return true
 	}
+
+	// Computed via big.Int and saturated at MaxUint64 rather than in raw
+	// uint64: AccountBlockBasePlasma * fusionPrice can exceed MaxUint64
+	// when fusionPrice is large, and a silent uint64 overflow here would
+	// wrap the minimum-price floor down to a small value, defeating the
+	// check exactly when it matters most. Saturating instead makes an
+	// overflowed floor reject virtually everything (fail closed) rather
+	// than admit anything (fail open).
+	minFusedPlasmaBig := new(big.Int).Mul(
+		new(big.Int).SetUint64(constants.AccountBlockBasePlasma),
+		new(big.Int).SetUint64(dp.fusionPrice),
+	)
+	minFusedPlasmaBig.Div(minFusedPlasmaBig, new(big.Int).SetUint64(PriceScaleFactor))
+	minFusedPlasma := uint64(math.MaxUint64)
+	if minFusedPlasmaBig.IsUint64() {
+		minFusedPlasma = minFusedPlasmaBig.Uint64()
+	}
+
 	minimumPricedBlock := &nom.AccountBlock{
-		FusedPlasma: constants.AccountBlockBasePlasma * dp.fusionPrice / PriceScaleFactor,
+		FusedPlasma: minFusedPlasma,
 		Difficulty:  0,
 		BasePlasma:  constants.AccountBlockBasePlasma,
 	}

--- a/dp/dp.go
+++ b/dp/dp.go
@@ -1,7 +1,6 @@
 package dp
 
 import (
-	"math"
 	"math/big"
 
 	"github.com/pkg/errors"
@@ -150,30 +149,28 @@ func (dp *dynamicPlasma) ValidPrice(block *nom.AccountBlock) bool {
 		return true
 	}
 
-	// Computed via big.Int and saturated at MaxUint64 rather than in raw
-	// uint64: AccountBlockBasePlasma * fusionPrice can exceed MaxUint64
-	// when fusionPrice is large, and a silent uint64 overflow here would
-	// wrap the minimum-price floor down to a small value, defeating the
-	// check exactly when it matters most. Saturating instead makes an
-	// overflowed floor reject virtually everything (fail closed) rather
-	// than admit anything (fail open).
-	minFusedPlasmaBig := new(big.Int).Mul(
+	// The block's price is compared against the floor set by a
+	// minimum-priced block. The minimum fused plasma is itself an integer
+	// quantity, AccountBlockBasePlasma * fusionPrice / PriceScaleFactor, so
+	// the PriceScaleFactor division is applied before the multiplications --
+	// that integer is the floor consensus is defined against. The
+	// comparison is done in big.Int because AccountBlockBasePlasma *
+	// fusionPrice can exceed MaxUint64 at large fusionPrice.
+	floor := new(big.Int).Mul(
 		new(big.Int).SetUint64(constants.AccountBlockBasePlasma),
 		new(big.Int).SetUint64(dp.fusionPrice),
 	)
-	minFusedPlasmaBig.Div(minFusedPlasmaBig, new(big.Int).SetUint64(PriceScaleFactor))
-	minFusedPlasma := uint64(math.MaxUint64)
-	if minFusedPlasmaBig.IsUint64() {
-		minFusedPlasma = minFusedPlasmaBig.Uint64()
-	}
+	floor.Div(floor, new(big.Int).SetUint64(PriceScaleFactor))
+	floor.Mul(floor, new(big.Int).SetUint64(dp.workPrice))
+	floor.Mul(floor, new(big.Int).SetUint64(block.BasePlasma))
 
-	minimumPricedBlock := &nom.AccountBlock{
-		FusedPlasma: minFusedPlasma,
-		Difficulty:  0,
-		BasePlasma:  constants.AccountBlockBasePlasma,
-	}
-	err := dp.HigherPrice(block, minimumPricedBlock)
-	return err == nil || err == ErrBlockPriceSame
+	value := new(big.Int).Add(
+		new(big.Int).Mul(new(big.Int).SetUint64(block.FusedPlasma), new(big.Int).SetUint64(dp.workPrice)),
+		new(big.Int).Mul(new(big.Int).SetUint64(DifficultyToPlasma(block.Difficulty)), new(big.Int).SetUint64(dp.fusionPrice)),
+	)
+	value.Mul(value, new(big.Int).SetUint64(constants.AccountBlockBasePlasma))
+
+	return value.Cmp(floor) >= 0
 }
 
 func (dp *dynamicPlasma) HigherPrice(a, b *nom.AccountBlock) error {

--- a/dp/dp_test.go
+++ b/dp/dp_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/zenon-network/go-zenon/chain/nom"
 	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/vm/constants"
 	"github.com/zenon-network/go-zenon/vm/embedded/definition"
 )
 
@@ -139,6 +140,42 @@ func TestWorseBlockPrice(t *testing.T) {
 		BasePlasma:  42000,
 	}
 	common.ExpectError(t, dp.HigherPrice(a, b), ErrBlockPriceWorse)
+}
+
+func TestValidPrice(t *testing.T) {
+	dp := &dynamicPlasma{fusionPrice: 1000, workPrice: 1000}
+
+	atMinimum := &nom.AccountBlock{
+		FusedPlasma: constants.AccountBlockBasePlasma * dp.fusionPrice / PriceScaleFactor,
+		Difficulty:  0,
+		BasePlasma:  constants.AccountBlockBasePlasma,
+	}
+	common.ExpectTrue(t, dp.ValidPrice(atMinimum))
+
+	belowMinimum := &nom.AccountBlock{
+		FusedPlasma: atMinimum.FusedPlasma - 1,
+		Difficulty:  0,
+		BasePlasma:  constants.AccountBlockBasePlasma,
+	}
+	common.ExpectTrue(t, !dp.ValidPrice(belowMinimum))
+}
+
+// fusionPrice is chosen so the naive uint64 computation
+// AccountBlockBasePlasma * fusionPrice / PriceScaleFactor overflows and
+// wraps to exactly zero (21000 * 2^61 is an exact multiple of 2^64),
+// which would silently drop the minimum-price floor to zero and let a
+// completely free block through. The big.Int + saturation fix must
+// instead treat the floor as effectively unreachable and reject it.
+func TestValidPrice_OverflowSaturatesInsteadOfWrappingToZero(t *testing.T) {
+	const extremeFusionPrice = uint64(1) << 61
+	dp := &dynamicPlasma{fusionPrice: extremeFusionPrice, workPrice: 1000}
+
+	freeBlock := &nom.AccountBlock{
+		FusedPlasma: 0,
+		Difficulty:  0,
+		BasePlasma:  constants.AccountBlockBasePlasma,
+	}
+	common.ExpectTrue(t, !dp.ValidPrice(freeBlock))
 }
 
 func TestComputeBasePlasma_WeightsByOppositeResourcePrice(t *testing.T) {

--- a/dp/dp_test.go
+++ b/dp/dp_test.go
@@ -161,12 +161,12 @@ func TestValidPrice(t *testing.T) {
 }
 
 // fusionPrice is chosen so the naive uint64 computation
-// AccountBlockBasePlasma * fusionPrice / PriceScaleFactor overflows and
-// wraps to exactly zero (21000 * 2^61 is an exact multiple of 2^64),
-// which would silently drop the minimum-price floor to zero and let a
-// completely free block through. The big.Int + saturation fix must
-// instead treat the floor as effectively unreachable and reject it.
-func TestValidPrice_OverflowSaturatesInsteadOfWrappingToZero(t *testing.T) {
+// AccountBlockBasePlasma * fusionPrice / PriceScaleFactor overflows
+// (21000 * 2^61 exceeds MaxUint64), which is exactly why the floor is
+// computed in big.Int: the exact floor at this fusionPrice is 21,000 PoW
+// plasma, and the comparison holds that floor precisely rather than
+// clamping it down to a saturated (and here, unreachable) value.
+func TestValidPrice_ExtremeFusionPriceHoldsTheFloor(t *testing.T) {
 	const extremeFusionPrice = uint64(1) << 61
 	dp := &dynamicPlasma{fusionPrice: extremeFusionPrice, workPrice: 1000}
 
@@ -176,6 +176,22 @@ func TestValidPrice_OverflowSaturatesInsteadOfWrappingToZero(t *testing.T) {
 		BasePlasma:  constants.AccountBlockBasePlasma,
 	}
 	common.ExpectTrue(t, !dp.ValidPrice(freeBlock))
+
+	belowFloor, _ := GetDifficultyForPlasma(10000)
+	belowFloorBlock := &nom.AccountBlock{
+		FusedPlasma: 0,
+		Difficulty:  belowFloor,
+		BasePlasma:  constants.AccountBlockBasePlasma,
+	}
+	common.ExpectTrue(t, !dp.ValidPrice(belowFloorBlock))
+
+	atFloor, _ := GetDifficultyForPlasma(21000)
+	atFloorBlock := &nom.AccountBlock{
+		FusedPlasma: 0,
+		Difficulty:  atFloor,
+		BasePlasma:  constants.AccountBlockBasePlasma,
+	}
+	common.ExpectTrue(t, dp.ValidPrice(atFloorBlock))
 }
 
 func TestComputeBasePlasma_WeightsByOppositeResourcePrice(t *testing.T) {

--- a/p2p/legacy/nat/nat.go
+++ b/p2p/legacy/nat/nat.go
@@ -54,12 +54,12 @@ type Interface interface {
 // The following formats are currently accepted.
 // Note that mechanism names are not case-sensitive.
 //
-//     "" or "none"         return nil
-//     "extip:77.12.33.4"   will assume the local machine is reachable on the given IP
-//     "any"                uses the first auto-detected mechanism
-//     "upnp"               uses the Universal Plug and Play protocol
-//     "pmp"                uses NAT-PMP with an auto-detected gateway address
-//     "pmp:192.168.0.1"    uses NAT-PMP with the given gateway address
+//	"" or "none"         return nil
+//	"extip:77.12.33.4"   will assume the local machine is reachable on the given IP
+//	"any"                uses the first auto-detected mechanism
+//	"upnp"               uses the Universal Plug and Play protocol
+//	"pmp"                uses NAT-PMP with an auto-detected gateway address
+//	"pmp:192.168.0.1"    uses NAT-PMP with the given gateway address
 func Parse(spec string) (Interface, error) {
 	var (
 		parts = strings.SplitN(spec, ":", 2)

--- a/p2p/legacy/peer.go
+++ b/p2p/legacy/peer.go
@@ -338,7 +338,7 @@ func (p *Peer) getProto(code uint64) (*protoRW, error) {
 
 type protoRW struct {
 	p2p.Protocol
-	in     chan p2p.Msg        // receices read messages
+	in     chan p2p.Msg    // receices read messages
 	closed <-chan struct{} // receives when peer is shutting down
 	wstart <-chan struct{} // receives when write may start
 	werr   chan<- error    // for write results

--- a/p2p/legacy/server.go
+++ b/p2p/legacy/server.go
@@ -173,7 +173,7 @@ type conn struct {
 	flags connFlag
 	cont  chan error      // The run loop uses cont to signal errors to setupConn.
 	id    discover.NodeID // valid after the encryption handshake
-	caps  []p2p.Cap           // valid after the protocol handshake
+	caps  []p2p.Cap       // valid after the protocol handshake
 	name  string          // valid after the protocol handshake
 }
 

--- a/p2p/libp2p/peerdb.go
+++ b/p2p/libp2p/peerdb.go
@@ -142,10 +142,12 @@ func (d *peerDB) recordDialFail(id peer.ID) {
 	d.put(id, rec)
 }
 
-// subnetKey buckets addrs by IPv4 /24 or IPv6 /48, the same granularity
-// libp2p's own peerdiversity filter uses, so seeds() can spread
-// candidates across sources rather than let one subnet dominate. Empty
-// for a peer with no parseable IP address.
+// subnetKey buckets a peer's addresses into a group so seeds() can spread
+// candidates across sources rather than let one source dominate a round:
+// IPv4 by /16 prefix (the granularity libp2p's own peerdiversity filter
+// uses), IPv6 by /48 prefix, and every peer whose addresses carry no
+// literal IP into one shared DNS group. Peers with no address information
+// at all share the empty key and form a group of their own.
 func subnetKey(addrs []ma.Multiaddr) string {
 	for _, a := range addrs {
 		ip, _, err := parseMultiaddrIPPort(a)
@@ -153,10 +155,24 @@ func subnetKey(addrs []ma.Multiaddr) string {
 			continue
 		}
 		if ip4 := ip.To4(); ip4 != nil {
-			return fmt.Sprintf("4:%d.%d.%d", ip4[0], ip4[1], ip4[2])
+			return fmt.Sprintf("4:%d.%d", ip4[0], ip4[1])
 		}
 		if ip16 := ip.To16(); ip16 != nil {
 			return fmt.Sprintf("6:%x", ip16[:6])
+		}
+	}
+	// DNS-only peers all share one key rather than being keyed by their
+	// hostname: the stored addresses are self-advertised (identify), so a
+	// hostname-derived key would let one source mint a fresh group — and
+	// therefore a fresh slot per round — for every identity it cycles
+	// through the handshake. One shared key caps all of them at one slot
+	// per round, while still keeping them out of the "no address
+	// information at all" group.
+	for _, a := range addrs {
+		for _, proto := range []int{ma.P_DNS, ma.P_DNS4, ma.P_DNS6, ma.P_DNSADDR} {
+			if _, err := a.ValueForProtocol(proto); err == nil {
+				return "dns"
+			}
 		}
 	}
 	return ""

--- a/p2p/libp2p/peerdb.go
+++ b/p2p/libp2p/peerdb.go
@@ -2,6 +2,7 @@ package libp2p
 
 import (
 	"encoding/json"
+	"fmt"
 	"sort"
 	"sync"
 	"time"
@@ -37,6 +38,15 @@ const (
 	// peerDBCleanupCycle is how often the server's cleanup loop calls
 	// expire() on a running node; expire also runs once at open.
 	peerDBCleanupCycle = 1 * time.Hour
+
+	// peerDBMaxRecords bounds the total number of stored peer records,
+	// enforced by expire(). Without it, an attacker cheaply cycling
+	// ephemeral peer identities through the handshake could grow the
+	// on-disk database without bound. Enforced during the existing
+	// expire() pass (hourly, plus once at open) rather than per-insert,
+	// so a normal recordConnected call stays a single get+put and the
+	// database can only temporarily exceed the cap for up to one cycle.
+	peerDBMaxRecords = 2000
 )
 
 // peerDB is the Zenon-owned, LevelDB-backed record of peers this node
@@ -132,11 +142,37 @@ func (d *peerDB) recordDialFail(id peer.ID) {
 	d.put(id, rec)
 }
 
-// seeds returns up to n warm-bootstrap candidates, most recently seen
-// first, skipping records that are expired, failed-out, or have no
-// usable addresses. Records that don't parse as ours (e.g. leftovers
-// from the pstoreds schema this database replaced) are deleted on
-// sight, so a pre-existing directory self-cleans.
+// subnetKey buckets addrs by IPv4 /24 or IPv6 /48, the same granularity
+// libp2p's own peerdiversity filter uses, so seeds() can spread
+// candidates across sources rather than let one subnet dominate. Empty
+// for a peer with no parseable IP address.
+func subnetKey(addrs []ma.Multiaddr) string {
+	for _, a := range addrs {
+		ip, _, err := parseMultiaddrIPPort(a)
+		if err != nil || ip == nil {
+			continue
+		}
+		if ip4 := ip.To4(); ip4 != nil {
+			return fmt.Sprintf("4:%d.%d.%d", ip4[0], ip4[1], ip4[2])
+		}
+		if ip16 := ip.To16(); ip16 != nil {
+			return fmt.Sprintf("6:%x", ip16[:6])
+		}
+	}
+	return ""
+}
+
+// seeds returns up to n warm-bootstrap candidates, skipping records
+// that are expired, failed-out, or have no usable addresses. Records
+// that don't parse as ours (e.g. leftovers from the pstoreds schema
+// this database replaced) are deleted on sight, so a pre-existing
+// directory self-cleans.
+//
+// Candidates are grouped by subnet (see subnetKey) and selected
+// round-robin across groups, most-recently-seen group first, rather
+// than taking a pure recency-ranked prefix — so a source that cycles
+// many identities through the handshake can occupy at most one slot per
+// round instead of owning the whole seed list.
 func (d *peerDB) seeds(n int) []peer.AddrInfo {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -173,36 +209,80 @@ func (d *peerDB) seeds(n int) []peer.AddrInfo {
 	}
 
 	sort.Slice(cands, func(i, j int) bool { return cands[i].lastSeen > cands[j].lastSeen })
-	if n > 0 && len(cands) > n {
-		cands = cands[:n]
+
+	// Group by subnet, preserving each group's most-recently-seen-first
+	// order and the recency order of groups themselves (first sighting
+	// in the already-sorted cands slice).
+	groups := make(map[string][]candidate)
+	var groupOrder []string
+	for _, c := range cands {
+		key := subnetKey(c.info.Addrs)
+		if _, ok := groups[key]; !ok {
+			groupOrder = append(groupOrder, key)
+		}
+		groups[key] = append(groups[key], c)
 	}
-	out := make([]peer.AddrInfo, len(cands))
-	for i, c := range cands {
-		out[i] = c.info
+
+	var out []peer.AddrInfo
+	for {
+		if n > 0 && len(out) >= n {
+			break
+		}
+		progressed := false
+		for _, key := range groupOrder {
+			if n > 0 && len(out) >= n {
+				break
+			}
+			remaining := groups[key]
+			if len(remaining) == 0 {
+				continue
+			}
+			out = append(out, remaining[0].info)
+			groups[key] = remaining[1:]
+			progressed = true
+		}
+		if !progressed {
+			break
+		}
 	}
 	return out
 }
 
 // expire deletes records that are older than peerDBMaxAge, failed out,
-// or unparseable. Called once at open and then on the server's
-// peerDBCleanupCycle ticker.
+// or unparseable, then evicts the oldest-lastSeen survivors down to
+// peerDBMaxRecords if the database is still over that cap. Called once
+// at open and then on the server's peerDBCleanupCycle ticker.
 func (d *peerDB) expire() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
+	type kept struct {
+		key      []byte
+		lastSeen int64
+	}
+	var survivors []kept
+
 	cutoff := d.now().Add(-peerDBMaxAge).Unix()
 	iter := d.db.NewIterator(nil, nil)
-	defer iter.Release()
 	for iter.Next() {
 		var rec peerDBRecord
 		if err := json.Unmarshal(iter.Value(), &rec); err == nil &&
 			rec.Version == peerDBVersion &&
 			rec.LastSeen >= cutoff &&
 			rec.FailCount <= peerDBMaxFailCount {
+			survivors = append(survivors, kept{key: append([]byte(nil), iter.Key()...), lastSeen: rec.LastSeen})
 			continue
 		}
 		key := append([]byte(nil), iter.Key()...)
 		_ = d.db.Delete(key, nil)
+	}
+	iter.Release()
+
+	if len(survivors) > peerDBMaxRecords {
+		sort.Slice(survivors, func(i, j int) bool { return survivors[i].lastSeen < survivors[j].lastSeen })
+		for _, s := range survivors[:len(survivors)-peerDBMaxRecords] {
+			_ = d.db.Delete(s.key, nil)
+		}
 	}
 }
 

--- a/p2p/libp2p/peerdb_test.go
+++ b/p2p/libp2p/peerdb_test.go
@@ -257,7 +257,7 @@ func TestPeerDBExpireCapsRecordCount(t *testing.T) {
 
 // TestPeerDBSeedsDiversifyAcrossSubnets verifies seeds() doesn't let a
 // single subnet dominate a limited result: many recently-seen peers
-// from one /24 must not crowd out an older peer from a different
+// from one /16 must not crowd out an older peer from a different
 // subnet entirely.
 func TestPeerDBSeedsDiversifyAcrossSubnets(t *testing.T) {
 	d, err := openPeerDB(filepath.Join(t.TempDir(), "peerdb"))
@@ -294,6 +294,32 @@ func TestPeerDBSeedsDiversifyAcrossSubnets(t *testing.T) {
 	}
 	if !found {
 		t.Fatalf("seeds(5) excluded the only peer from a different subnet: %v", limited)
+	}
+}
+
+// TestSubnetKeyGroups verifies the granularity subnetKey buckets
+// addresses at: IPv4 by /16, and DNS-only peers sharing one group
+// regardless of the hostname they advertise.
+func TestSubnetKeyGroups(t *testing.T) {
+	a := subnetKey([]ma.Multiaddr{mustAddr(t, "/ip4/10.0.0.1/tcp/35995")})
+	b := subnetKey([]ma.Multiaddr{mustAddr(t, "/ip4/10.0.5.9/tcp/35995")})
+	if a != b {
+		t.Fatalf("expected same /16 to share a key: %q != %q", a, b)
+	}
+
+	c := subnetKey([]ma.Multiaddr{mustAddr(t, "/ip4/203.0.113.1/tcp/35995")})
+	if a == c {
+		t.Fatalf("expected different /16s to have different keys, both %q", a)
+	}
+
+	dnsA := subnetKey([]ma.Multiaddr{mustAddr(t, "/dns4/seed.example.com/tcp/35995")})
+	dnsB := subnetKey([]ma.Multiaddr{mustAddr(t, "/dns4/other.example.com/tcp/35995")})
+	if dnsA != dnsB {
+		t.Fatalf("expected DNS-only peers to share a key regardless of hostname: %q != %q", dnsA, dnsB)
+	}
+
+	if dnsA == subnetKey(nil) {
+		t.Fatalf("expected the DNS key to differ from the no-address key")
 	}
 }
 

--- a/p2p/libp2p/peerdb_test.go
+++ b/p2p/libp2p/peerdb_test.go
@@ -214,6 +214,89 @@ func TestPeerDBEmptyAddrsKeepExisting(t *testing.T) {
 	}
 }
 
+// TestPeerDBExpireCapsRecordCount verifies expire() evicts the
+// oldest-lastSeen records once the database holds more than
+// peerDBMaxRecords, rather than letting it grow without bound.
+func TestPeerDBExpireCapsRecordCount(t *testing.T) {
+	d, err := openPeerDB(filepath.Join(t.TempDir(), "peerdb"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	clock := time.Now()
+	d.now = func() time.Time { return clock }
+
+	const extra = 10
+	var newest []peer.ID
+	for i := 0; i < peerDBMaxRecords+extra; i++ {
+		pid := testPeerID(t)
+		d.recordConnected(pid, []ma.Multiaddr{mustAddr(t, fmt.Sprintf("/ip4/10.%d.%d.%d/tcp/35995", (i>>16)&0xff, (i>>8)&0xff, i&0xff))})
+		if i >= extra {
+			newest = append(newest, pid)
+		}
+		clock = clock.Add(time.Second)
+	}
+
+	d.expire()
+
+	seeds := d.seeds(0)
+	if len(seeds) != peerDBMaxRecords {
+		t.Fatalf("len(seeds) after expire = %d, want %d", len(seeds), peerDBMaxRecords)
+	}
+	present := make(map[peer.ID]bool, len(seeds))
+	for _, s := range seeds {
+		present[s.ID] = true
+	}
+	for _, pid := range newest {
+		if !present[pid] {
+			t.Fatalf("expire() evicted a newer record (%s) while over cap", pid)
+		}
+	}
+}
+
+// TestPeerDBSeedsDiversifyAcrossSubnets verifies seeds() doesn't let a
+// single subnet dominate a limited result: many recently-seen peers
+// from one /24 must not crowd out an older peer from a different
+// subnet entirely.
+func TestPeerDBSeedsDiversifyAcrossSubnets(t *testing.T) {
+	d, err := openPeerDB(filepath.Join(t.TempDir(), "peerdb"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Close()
+
+	clock := time.Now()
+	d.now = func() time.Time { return clock }
+
+	// One peer from a distinct subnet, seen first (oldest).
+	outsider := testPeerID(t)
+	d.recordConnected(outsider, []ma.Multiaddr{mustAddr(t, "/ip4/203.0.113.1/tcp/35995")})
+	clock = clock.Add(time.Minute)
+
+	// Many more-recently-seen peers all from the same /24, as an
+	// attacker cycling identities from one source would produce.
+	for i := 0; i < 20; i++ {
+		pid := testPeerID(t)
+		d.recordConnected(pid, []ma.Multiaddr{mustAddr(t, fmt.Sprintf("/ip4/10.0.0.%d/tcp/35995", i+1))})
+		clock = clock.Add(time.Minute)
+	}
+
+	limited := d.seeds(5)
+	if len(limited) != 5 {
+		t.Fatalf("len(seeds(5)) = %d, want 5", len(limited))
+	}
+	found := false
+	for _, s := range limited {
+		if s.ID == outsider {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("seeds(5) excluded the only peer from a different subnet: %v", limited)
+	}
+}
+
 // waitForPeers polls until srv has at least n connected peers.
 func waitForPeers(t *testing.T, srv *Server, n int, timeout time.Duration) {
 	t.Helper()

--- a/p2p/libp2p/server.go
+++ b/p2p/libp2p/server.go
@@ -95,6 +95,7 @@ type Server struct {
 	PrivateKey *ecdsa.PrivateKey
 
 	// MaxPeers is the maximum number of peers that can be connected.
+	// Zero or negative defaults to p2p.DefaultMaxPeers.
 	MaxPeers int
 
 	// MinConnectedPeers is the minimum number of peers that can be connected.
@@ -186,13 +187,13 @@ type Server struct {
 	ourHandshake *protoHandshake
 	delpeer      chan *Peer
 	loopWG       sync.WaitGroup
-	pendingCount int32 // atomic; tracks peers in handshake phase
 
 	// pendingPeers tracks, by remote peer.ID string, which peers
 	// currently have an in-flight inbound handshake. Guarded by peerMu.
-	// Caps each remote peer.ID at one concurrent pending handshake so a
-	// single connection can't open many streams to monopolize the
-	// global pendingCount budget (see handleStream).
+	// Caps each remote peer.ID at one concurrent pending handshake (via
+	// the map key) and the pool as a whole at MaxPendingPeers (via
+	// len(pendingPeers)), so a single connection can't open many streams
+	// to monopolize the global budget (see handleStream).
 	pendingPeers map[string]struct{}
 
 	// discoveryWG tracks dhtDiscoveryLoop and the refresh goroutines it
@@ -451,6 +452,22 @@ func (srv *Server) Start() (err error) {
 		return fmt.Errorf("Server.PrivateKey must be set to a non-nil key")
 	}
 
+	// Zero or negative means "use the preset", matching the semantics
+	// node/defaults.go applies when the field is absent from
+	// config.json. p2p/config.go documents the zero-default for
+	// MaxPendingPeers only, while MaxPeers is specified as "must be
+	// greater than zero" — but an unnormalized MaxPeers of zero makes
+	// every len(srv.peerMap) >= srv.MaxPeers check true, so the server
+	// would accept no peers at all. Normalizing here applies the preset
+	// to that field too; this is a behaviour change for MaxPeers, not
+	// only a defensive guard.
+	if srv.MaxPeers <= 0 {
+		srv.MaxPeers = p2p.DefaultMaxPeers
+	}
+	if srv.MaxPendingPeers <= 0 {
+		srv.MaxPendingPeers = p2p.DefaultMaxPendingPeers
+	}
+
 	srv.ctx, srv.cancel = context.WithCancel(context.Background())
 	srv.peerMap = make(map[string]*Peer)
 	srv.dialing = make(map[string]struct{})
@@ -503,26 +520,16 @@ func (srv *Server) Start() (err error) {
 		opts = append(opts, libp2p.NATPortMap())
 	}
 
-	// Bound raw libp2p connections by the same limits MaxPeers/
-	// MaxPendingPeers apply to adopted Zenon peers. Without this,
-	// libp2p's own defaults (160/192 connections, 1-minute grace period)
-	// are the only cap, which lets connections that never open the
-	// Zenon stream consume the connection budget uncontested, and lets
-	// libp2p's trimmer evict adopted Zenon peers (untagged) before
-	// short-lived attacker connections (still inside the grace period).
-	// Grace is kept equal to handshakeTimeout: adopted peers are
-	// Protect()-tagged well before that on any healthy handshake, so
-	// once it elapses an un-adopted connection is a legitimate trim
-	// candidate.
-	maxPeers := srv.MaxPeers
-	if maxPeers <= 0 {
-		maxPeers = p2p.DefaultMaxPeers
-	}
-	pendingLimit := srv.MaxPendingPeers
-	if pendingLimit <= 0 {
-		pendingLimit = p2p.DefaultMaxPendingPeers
-	}
-	connMgr, err := connmgr.NewConnManager(maxPeers, maxPeers+pendingLimit, connmgr.WithGracePeriod(handshakeTimeout))
+	// BasicConnMgr trims connections down toward the low watermark once
+	// the grace period has elapsed; it never refuses an incoming
+	// connection, so the watermarks below are a trim target rather than
+	// a hard cap. Peers Protect()-tagged at adoption are exempt from
+	// trimming, so the live connection count can exceed the high
+	// watermark. Low is MaxPeers, high is MaxPeers + MaxPendingPeers,
+	// and grace is handshakeTimeout, so that once the grace period
+	// elapses an un-adopted connection is a legitimate trim candidate
+	// while adopted peers (already protected) are not.
+	connMgr, err := connmgr.NewConnManager(srv.MaxPeers, srv.MaxPeers+srv.MaxPendingPeers, connmgr.WithGracePeriod(handshakeTimeout))
 	if err != nil {
 		return fmt.Errorf("create connection manager: %w", err)
 	}
@@ -741,19 +748,24 @@ func (srv *Server) handleStream(s network.Stream) {
 	remotePeer := s.Conn().RemotePeer()
 	peerKey := remotePeer.String()
 
-	// Cap concurrent pending handshakes per remote peer.ID at one. The
-	// global MaxPendingPeers counter below is process-wide, so without
-	// this a single connection could open many streams that never
-	// complete the handshake and hold every global pending slot by
+	// Cap concurrent pending handshakes two ways, in one atomic step: at
+	// most one per remote peer.ID (so a single connection can't open many
+	// streams that never complete the handshake and hold many slots by
 	// itself; capping per-peer forces an attacker to spend a distinct
-	// peer identity (and, combined with the connection manager, a
-	// distinct connection) per held slot.
+	// peer identity — and, combined with the connection manager, a
+	// distinct connection — per held slot), and at most MaxPendingPeers
+	// across the whole pool.
 	//
 	// Reset only the duplicate stream, not the underlying connection —
 	// the first stream's handshake may be legitimately in flight on the
 	// same connection, and ClosePeer would kill it too.
 	srv.peerMu.Lock()
 	if _, exists := srv.pendingPeers[peerKey]; exists {
+		srv.peerMu.Unlock()
+		s.Reset()
+		return
+	}
+	if len(srv.pendingPeers) >= srv.MaxPendingPeers {
 		srv.peerMu.Unlock()
 		s.Reset()
 		return
@@ -765,23 +777,6 @@ func (srv *Server) handleStream(s network.Stream) {
 		delete(srv.pendingPeers, peerKey)
 		srv.peerMu.Unlock()
 	}()
-
-	// Enforce MaxPendingPeers. Zero or negative falls back to
-	// p2p.DefaultMaxPendingPeers, the same preset node/defaults.go
-	// applies when an operator's config.json omits the field, per the
-	// documented "zero defaults to preset" semantics in p2p/config.go —
-	// rather than disabling the pending-handshake throttle.
-	limit := srv.MaxPendingPeers
-	if limit <= 0 {
-		limit = p2p.DefaultMaxPendingPeers
-	}
-	pending := atomic.AddInt32(&srv.pendingCount, 1)
-	if int(pending) > limit {
-		atomic.AddInt32(&srv.pendingCount, -1)
-		s.Reset()
-		return
-	}
-	defer atomic.AddInt32(&srv.pendingCount, -1)
 
 	// Slowloris protection lives entirely in StreamRW: every ReadMsg /
 	// WriteMsg call sets its own per-message deadline. There used to be
@@ -797,13 +792,21 @@ func (srv *Server) handleStream(s network.Stream) {
 	if err != nil {
 		common.P2PLogger.Debug(fmt.Sprintf("proto handshake failed with %s: %v", remotePeer, err))
 		s.Reset()
-		// This connection's only stream just failed to complete the
-		// handshake (the per-peer pending guard above rules out a
-		// concurrent legitimate stream on the same connection), so
-		// closing it is safe. Forces a fresh connection — and therefore
-		// a fresh pending-handshake slot — for the next attempt, rather
-		// than letting the same connection retry indefinitely.
-		_ = srv.host.Network().ClosePeer(remotePeer)
+		// Network().ClosePeer(id) is peer-scoped: it tears down every
+		// connection to that peer. It is therefore only safe when this
+		// peer has no adopted session and no dial in flight — otherwise
+		// resetting the failed stream is the whole remedy, since closing
+		// would also tear down the connection carrying the adopted
+		// session or our own outbound handshake. When neither holds,
+		// closing forces a fresh connection (and a fresh
+		// pending-handshake slot) on the next attempt.
+		srv.peerMu.RLock()
+		_, adopted := srv.peerMap[peerKey]
+		_, dialing := srv.dialing[peerKey]
+		srv.peerMu.RUnlock()
+		if !adopted && !dialing {
+			_ = srv.host.Network().ClosePeer(remotePeer)
+		}
 		return
 	}
 
@@ -816,7 +819,12 @@ func (srv *Server) handleStream(s network.Stream) {
 	// alive, which lets an unrelated libp2p peer (e.g. a stray IPFS node
 	// that resolved one of our bootstrap entries) sit on a connection
 	// slot without ever speaking Zenon protocol. ClosePeer() forces the
-	// host to tear that down so the FD / yamux session is reclaimed.
+	// host to tear that down so the FD / yamux session is reclaimed. An
+	// adopted peer has already passed all of these checks, so ClosePeer
+	// here can't fire for one; and if this connection is also our own
+	// outbound dial in flight, closing it costs at most a retry, since a
+	// peer that fails these checks on our inbound stream would fail them
+	// identically on the dialer's own side.
 	remoteID := phs.ID
 	expectedID, err := nodeIDFromPeerID(remotePeer)
 	if err != nil {
@@ -859,24 +867,17 @@ func (srv *Server) handleStream(s network.Stream) {
 		return
 	}
 
-	// Atomically check max peers, duplicate, and insert to eliminate the
-	// TOCTOU race that two concurrent handleStream calls would otherwise create.
+	// Atomically check shutdown, duplicate, max peers, and insert to
+	// eliminate the TOCTOU race that two concurrent handleStream calls
+	// would otherwise create. Duplicate is checked before max peers so an
+	// already-adopted peer's extra stream is always Reset rather than
+	// closed, even when the server is at capacity.
 	p := newPeerFromStream(rw, s, remoteID, phs.Caps, phs.Name, srv.Protocols)
 	srv.peerMu.Lock()
 	if srv.shuttingDown {
 		srv.peerMu.Unlock()
 		common.P2PLogger.Debug("server shutting down, rejecting connection")
 		s.Reset()
-		_ = srv.host.Network().ClosePeer(remotePeer)
-		return
-	}
-	if len(srv.peerMap) >= srv.MaxPeers {
-		srv.peerMu.Unlock()
-		common.P2PLogger.Debug("max peers reached, rejecting connection")
-		s.Reset()
-		// Same as above: drop the host-level connection so MaxPeers is
-		// actually a bound on libp2p resources, not just on adopted
-		// Zenon streams.
 		_ = srv.host.Network().ClosePeer(remotePeer)
 		return
 	}
@@ -888,6 +889,17 @@ func (srv *Server) handleStream(s network.Stream) {
 		// already-adopted stream from the first concurrent handler,
 		// and closing it would terminate that healthy peer.
 		s.Reset()
+		return
+	}
+	if len(srv.peerMap) >= srv.MaxPeers {
+		srv.peerMu.Unlock()
+		common.P2PLogger.Debug("max peers reached, rejecting connection")
+		s.Reset()
+		// The duplicate check above already ruled out an adopted peer,
+		// so dropping the host-level connection here is safe: it makes
+		// MaxPeers a bound on libp2p resources, not just on adopted
+		// Zenon streams.
+		_ = srv.host.Network().ClosePeer(remotePeer)
 		return
 	}
 	srv.peerMap[remotePeer.String()] = p
@@ -1059,23 +1071,17 @@ func (srv *Server) dialPeer(info peer.AddrInfo) error {
 		srv.testDialAdoptHook()
 	}
 
-	// Final atomic check-and-insert under lock to prevent races with concurrent
-	// inbound connections or other dialPeer calls for the same peer.
+	// Final atomic check-and-insert under lock to prevent races with
+	// concurrent inbound connections or other dialPeer calls for the same
+	// peer. Duplicate is checked before max peers so an already-adopted
+	// peer (adopted inbound mid-dial) never has its connection closed by
+	// the MaxPeers branch.
 	srv.peerMu.Lock()
 	if srv.shuttingDown {
 		srv.peerMu.Unlock()
 		s.Reset()
 		_ = srv.host.Network().ClosePeer(info.ID)
 		return errServerStopped
-	}
-	if len(srv.peerMap) >= srv.MaxPeers {
-		srv.peerMu.Unlock()
-		s.Reset()
-		// We never adopted a stream to this peer, so closing the host
-		// connection is safe and keeps MaxPeers bounding actual libp2p
-		// resources rather than just adopted streams.
-		_ = srv.host.Network().ClosePeer(info.ID)
-		return fmt.Errorf("max peers reached")
 	}
 	if _, exists := srv.peerMap[info.ID.String()]; exists {
 		srv.peerMu.Unlock()
@@ -1084,6 +1090,16 @@ func (srv *Server) dialPeer(info peer.AddrInfo) error {
 		// with the already-adopted stream for this peer, and closing
 		// it would terminate that legitimate connection.
 		return fmt.Errorf("duplicate peer %s", info.ID)
+	}
+	if len(srv.peerMap) >= srv.MaxPeers {
+		srv.peerMu.Unlock()
+		s.Reset()
+		// The duplicate check above already ruled out an adopted peer,
+		// so closing the host connection here is safe and keeps MaxPeers
+		// bounding actual libp2p resources rather than just adopted
+		// streams.
+		_ = srv.host.Network().ClosePeer(info.ID)
+		return fmt.Errorf("max peers reached")
 	}
 	srv.peerMap[info.ID.String()] = p
 	// loopWG.Add happens inside the same peerMu critical section as the

--- a/p2p/libp2p/server.go
+++ b/p2p/libp2p/server.go
@@ -766,6 +766,13 @@ func (srv *Server) handleStream(s network.Stream) {
 	// the first stream's handshake may be legitimately in flight on the
 	// same connection, and ClosePeer would kill it too.
 	srv.peerMu.Lock()
+	// The slot is held for as long as the first stream's handshake runs,
+	// bounded by handshakeTimeout, so a peer whose first stream stalls
+	// cannot be re-admitted from a second stream until that deadline
+	// expires. Displacing the older stream instead would mean keying
+	// pendingPeers by (peer.ID, stream) — or tracking the stream so a
+	// newcomer can reset it and take the slot — which is more machinery
+	// than a bounded few-second delay warrants.
 	if _, exists := srv.pendingPeers[peerKey]; exists {
 		srv.peerMu.Unlock()
 		s.Reset()
@@ -924,12 +931,16 @@ func (srv *Server) handleStream(s network.Stream) {
 	// shuttingDown check above so it can never race Stop()'s
 	// loopWG.Wait() (see the shuttingDown field doc).
 	srv.loopWG.Add(1)
-	srv.peerMu.Unlock()
-
-	// Protect the connection so libp2p's connection-manager trimmer
-	// never closes it to make room for unrelated connections; unset in
-	// runPeer when the peer disconnects.
+	// Protect the connection in the same critical section that adopts the
+	// peer, so it is never a trim candidate for the connection manager
+	// between being adopted and being protected — the grace period is
+	// handshakeTimeout, so a peer adopted near the end of it would
+	// otherwise be trimmable in that window. Protect is a tag-map insert
+	// under the connection manager's own lock with no callbacks or
+	// notifiees, so it cannot re-enter anything that takes peerMu.
+	// Unset in runPeer when the peer disconnects.
 	srv.host.ConnManager().Protect(remotePeer, zenonPeerProtectTag)
+	srv.peerMu.Unlock()
 
 	// Inbound adoption: identify may not have learned the peer's
 	// listen addresses yet, in which case this records lastSeen only
@@ -1124,12 +1135,10 @@ func (srv *Server) dialPeer(info peer.AddrInfo) error {
 	// shuttingDown check above so it can never race Stop()'s
 	// loopWG.Wait() (see the shuttingDown field doc).
 	srv.loopWG.Add(1)
-	srv.peerMu.Unlock()
-
-	// Protect the connection so libp2p's connection-manager trimmer
-	// never closes it to make room for unrelated connections; unset in
-	// runPeer when the peer disconnects.
+	// Protect under peerMu for the same reason as in handleStream; unset
+	// in runPeer when the peer disconnects.
 	srv.host.ConnManager().Protect(info.ID, zenonPeerProtectTag)
+	srv.peerMu.Unlock()
 
 	// Outbound adoption: the dialed addresses are known-dialable, so
 	// pass them along in case identify hasn't populated the peerstore

--- a/p2p/libp2p/server.go
+++ b/p2p/libp2p/server.go
@@ -459,8 +459,7 @@ func (srv *Server) Start() (err error) {
 	// greater than zero" — but an unnormalized MaxPeers of zero makes
 	// every len(srv.peerMap) >= srv.MaxPeers check true, so the server
 	// would accept no peers at all. Normalizing here applies the preset
-	// to that field too; this is a behaviour change for MaxPeers, not
-	// only a defensive guard.
+	// to that field too.
 	if srv.MaxPeers <= 0 {
 		srv.MaxPeers = p2p.DefaultMaxPeers
 	}

--- a/p2p/libp2p/server.go
+++ b/p2p/libp2p/server.go
@@ -43,6 +43,7 @@ import (
 	"github.com/zenon-network/go-zenon/p2p/discover"
 
 	"github.com/libp2p/go-libp2p/p2p/muxer/yamux"
+	"github.com/libp2p/go-libp2p/p2p/net/connmgr"
 	"github.com/libp2p/go-libp2p/p2p/security/noise"
 	libp2ptcp "github.com/libp2p/go-libp2p/p2p/transport/tcp"
 )
@@ -52,6 +53,20 @@ const (
 	protoID              = "/znn/eth/1"
 	frameReadTimeout     = 30 * time.Second
 	frameWriteTimeout    = 20 * time.Second
+
+	// handshakeTimeout bounds the pre-adoption protocol handshake read,
+	// separately from the steady-state frameReadTimeout. The remote is
+	// unauthenticated at this point, so the deadline is kept short
+	// (matching the legacy backend's handshakeTimeout) to limit how long
+	// a stalled peer can occupy a pending-handshake slot.
+	handshakeTimeout = 5 * time.Second
+
+	// zenonPeerProtectTag marks an adopted Zenon peer's connection as
+	// protected in the libp2p connection manager, so libp2p's trimmer
+	// never closes it to make room for unrelated (e.g. DHT-only or
+	// never-adopted) connections. Applied on adoption, removed when the
+	// peer disconnects.
+	zenonPeerProtectTag = "zenon-peer"
 
 	// Exponential-backoff parameters for the peerMaintenanceLoop's
 	// bootstrap-redial path. The schedule (in seconds, before jitter) is
@@ -172,6 +187,13 @@ type Server struct {
 	delpeer      chan *Peer
 	loopWG       sync.WaitGroup
 	pendingCount int32 // atomic; tracks peers in handshake phase
+
+	// pendingPeers tracks, by remote peer.ID string, which peers
+	// currently have an in-flight inbound handshake. Guarded by peerMu.
+	// Caps each remote peer.ID at one concurrent pending handshake so a
+	// single connection can't open many streams to monopolize the
+	// global pendingCount budget (see handleStream).
+	pendingPeers map[string]struct{}
 
 	// discoveryWG tracks dhtDiscoveryLoop and the refresh goroutines it
 	// spawns via triggerDHTRefresh, separately from loopWG. Stop() must
@@ -432,6 +454,7 @@ func (srv *Server) Start() (err error) {
 	srv.ctx, srv.cancel = context.WithCancel(context.Background())
 	srv.peerMap = make(map[string]*Peer)
 	srv.dialing = make(map[string]struct{})
+	srv.pendingPeers = make(map[string]struct{})
 	srv.backoffs = make(map[string]*dialBackoff)
 	srv.delpeer = make(chan *Peer, 16)
 	srv.peerMu.Lock()
@@ -479,6 +502,31 @@ func (srv *Server) Start() (err error) {
 	if srv.NATPortMap {
 		opts = append(opts, libp2p.NATPortMap())
 	}
+
+	// Bound raw libp2p connections by the same limits MaxPeers/
+	// MaxPendingPeers apply to adopted Zenon peers. Without this,
+	// libp2p's own defaults (160/192 connections, 1-minute grace period)
+	// are the only cap, which lets connections that never open the
+	// Zenon stream consume the connection budget uncontested, and lets
+	// libp2p's trimmer evict adopted Zenon peers (untagged) before
+	// short-lived attacker connections (still inside the grace period).
+	// Grace is kept equal to handshakeTimeout: adopted peers are
+	// Protect()-tagged well before that on any healthy handshake, so
+	// once it elapses an un-adopted connection is a legitimate trim
+	// candidate.
+	maxPeers := srv.MaxPeers
+	if maxPeers <= 0 {
+		maxPeers = p2p.DefaultMaxPeers
+	}
+	pendingLimit := srv.MaxPendingPeers
+	if pendingLimit <= 0 {
+		pendingLimit = p2p.DefaultMaxPendingPeers
+	}
+	connMgr, err := connmgr.NewConnManager(maxPeers, maxPeers+pendingLimit, connmgr.WithGracePeriod(handshakeTimeout))
+	if err != nil {
+		return fmt.Errorf("create connection manager: %w", err)
+	}
+	opts = append(opts, libp2p.ConnectionManager(connMgr))
 
 	// Peer database (optional).
 	//
@@ -690,6 +738,34 @@ func (srv *Server) peerdbCleanupLoop() {
 
 // handleStream is called when a remote peer opens a stream to us.
 func (srv *Server) handleStream(s network.Stream) {
+	remotePeer := s.Conn().RemotePeer()
+	peerKey := remotePeer.String()
+
+	// Cap concurrent pending handshakes per remote peer.ID at one. The
+	// global MaxPendingPeers counter below is process-wide, so without
+	// this a single connection could open many streams that never
+	// complete the handshake and hold every global pending slot by
+	// itself; capping per-peer forces an attacker to spend a distinct
+	// peer identity (and, combined with the connection manager, a
+	// distinct connection) per held slot.
+	//
+	// Reset only the duplicate stream, not the underlying connection —
+	// the first stream's handshake may be legitimately in flight on the
+	// same connection, and ClosePeer would kill it too.
+	srv.peerMu.Lock()
+	if _, exists := srv.pendingPeers[peerKey]; exists {
+		srv.peerMu.Unlock()
+		s.Reset()
+		return
+	}
+	srv.pendingPeers[peerKey] = struct{}{}
+	srv.peerMu.Unlock()
+	defer func() {
+		srv.peerMu.Lock()
+		delete(srv.pendingPeers, peerKey)
+		srv.peerMu.Unlock()
+	}()
+
 	// Enforce MaxPendingPeers. Zero or negative falls back to
 	// p2p.DefaultMaxPendingPeers, the same preset node/defaults.go
 	// applies when an operator's config.json omits the field, per the
@@ -715,13 +791,19 @@ func (srv *Server) handleStream(s network.Stream) {
 	// calls re-arm the deadline.
 
 	rw := NewStreamRW(s)
-	remotePeer := s.Conn().RemotePeer()
 
 	// Run protocol handshake
 	phs, err := srv.doProtoHandshake(rw)
 	if err != nil {
 		common.P2PLogger.Debug(fmt.Sprintf("proto handshake failed with %s: %v", remotePeer, err))
 		s.Reset()
+		// This connection's only stream just failed to complete the
+		// handshake (the per-peer pending guard above rules out a
+		// concurrent legitimate stream on the same connection), so
+		// closing it is safe. Forces a fresh connection — and therefore
+		// a fresh pending-handshake slot — for the next attempt, rather
+		// than letting the same connection retry indefinitely.
+		_ = srv.host.Network().ClosePeer(remotePeer)
 		return
 	}
 
@@ -815,6 +897,11 @@ func (srv *Server) handleStream(s network.Stream) {
 	srv.loopWG.Add(1)
 	srv.peerMu.Unlock()
 
+	// Protect the connection so libp2p's connection-manager trimmer
+	// never closes it to make room for unrelated connections; unset in
+	// runPeer when the peer disconnects.
+	srv.host.ConnManager().Protect(remotePeer, zenonPeerProtectTag)
+
 	// Inbound adoption: identify may not have learned the peer's
 	// listen addresses yet, in which case this records lastSeen only
 	// and the disconnect-time refresh in runPeer fills the addresses.
@@ -834,10 +921,13 @@ func (srv *Server) doProtoHandshake(rw *StreamRW) (*protoHandshake, error) {
 		errc <- p2p.Send(rw, handshakeMsg, srv.ourHandshake)
 	}()
 
-	// Read remote handshake. ReadMsgLimited enforces baseProtocolMaxMsgSize
-	// before allocating a payload buffer, so an unauthenticated peer can't
-	// force a large allocation by declaring an oversized frame.
-	msg, err := rw.ReadMsgLimited(baseProtocolMaxMsgSize)
+	// Read remote handshake. ReadMsgLimitedTimeout enforces
+	// baseProtocolMaxMsgSize before allocating a payload buffer, so an
+	// unauthenticated peer can't force a large allocation by declaring
+	// an oversized frame, and bounds the wait at handshakeTimeout rather
+	// than the steady-state frameReadTimeout so a stalled remote can't
+	// hold a pending-handshake slot for the full 30s.
+	msg, err := rw.ReadMsgLimitedTimeout(baseProtocolMaxMsgSize, handshakeTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("read handshake: %w", err)
 	}
@@ -1001,6 +1091,11 @@ func (srv *Server) dialPeer(info peer.AddrInfo) error {
 	// loopWG.Wait() (see the shuttingDown field doc).
 	srv.loopWG.Add(1)
 	srv.peerMu.Unlock()
+
+	// Protect the connection so libp2p's connection-manager trimmer
+	// never closes it to make room for unrelated connections; unset in
+	// runPeer when the peer disconnects.
+	srv.host.ConnManager().Protect(info.ID, zenonPeerProtectTag)
 
 	// Outbound adoption: the dialed addresses are known-dialable, so
 	// pass them along in case identify hasn't populated the peerstore
@@ -1358,6 +1453,10 @@ func (srv *Server) runPeer(p *Peer) {
 	// addresses.
 	if pid := p.remotePeer(); pid != "" {
 		srv.recordPeerConnected(pid)
+		// Remove the connection-manager protection granted on adoption;
+		// the connection is being torn down either way, but this avoids
+		// leaving a stale tag if the underlying connection is reused.
+		srv.host.ConnManager().Unprotect(pid, zenonPeerProtectTag)
 	}
 
 	// Notify the cleanup loop. If the context is already done (server is

--- a/p2p/libp2p/server.go
+++ b/p2p/libp2p/server.go
@@ -95,7 +95,7 @@ type Server struct {
 	PrivateKey *ecdsa.PrivateKey
 
 	// MaxPeers is the maximum number of peers that can be connected.
-	// Zero or negative defaults to p2p.DefaultMaxPeers.
+	// Must be greater than zero; Start() returns an error otherwise.
 	MaxPeers int
 
 	// MinConnectedPeers is the minimum number of peers that can be connected.
@@ -234,6 +234,14 @@ type Server struct {
 	// dial. Test-only; always nil in production (same pattern as
 	// testStartHook).
 	testDialAdoptHook func()
+
+	// testCloseDecisionHook, when non-nil, is invoked by handleStream's
+	// handshake-failure path once it has decided whether to close the
+	// peer, with closed reporting whether ClosePeer was called. It runs
+	// with peerMu held, so it must not block or take peerMu (TryLock is
+	// fine, it never blocks). Test-only; always nil in production (same
+	// pattern as testStartHook).
+	testCloseDecisionHook func(closed bool)
 }
 
 // dialBackoff carries per-peer state for exponential-backoff redialing.
@@ -452,16 +460,15 @@ func (srv *Server) Start() (err error) {
 		return fmt.Errorf("Server.PrivateKey must be set to a non-nil key")
 	}
 
-	// Zero or negative means "use the preset", matching the semantics
-	// node/defaults.go applies when the field is absent from
-	// config.json. p2p/config.go documents the zero-default for
-	// MaxPendingPeers only, while MaxPeers is specified as "must be
-	// greater than zero" — but an unnormalized MaxPeers of zero makes
-	// every len(srv.peerMap) >= srv.MaxPeers check true, so the server
-	// would accept no peers at all. Normalizing here applies the preset
-	// to that field too.
+	// Every capacity check is len(srv.peerMap) >= srv.MaxPeers, so a
+	// non-positive value would accept no peers at all. The legacy backend
+	// reads zero as "accept only trusted/static peers"; this backend has
+	// no equivalent mode, so a non-positive value is a configuration
+	// error rather than something to reinterpret. The switcher rejects it
+	// before either backend starts; this check keeps a directly-embedded
+	// Server from silently running on the 60-peer preset instead.
 	if srv.MaxPeers <= 0 {
-		srv.MaxPeers = p2p.DefaultMaxPeers
+		return fmt.Errorf("Server.MaxPeers must be > 0 (got %d)", srv.MaxPeers)
 	}
 	if srv.MaxPendingPeers <= 0 {
 		srv.MaxPendingPeers = p2p.DefaultMaxPendingPeers
@@ -799,13 +806,23 @@ func (srv *Server) handleStream(s network.Stream) {
 		// session or our own outbound handshake. When neither holds,
 		// closing forces a fresh connection (and a fresh
 		// pending-handshake slot) on the next attempt.
-		srv.peerMu.RLock()
+		//
+		// The close runs in the same peerMu critical section as the
+		// check: adoption (both paths) and dial reservation happen under
+		// peerMu, so nothing for this peer.ID can appear between the
+		// decision and the teardown.
+		srv.peerMu.Lock()
 		_, adopted := srv.peerMap[peerKey]
 		_, dialing := srv.dialing[peerKey]
-		srv.peerMu.RUnlock()
+		closed := false
 		if !adopted && !dialing {
 			_ = srv.host.Network().ClosePeer(remotePeer)
+			closed = true
 		}
+		if srv.testCloseDecisionHook != nil {
+			srv.testCloseDecisionHook(closed)
+		}
+		srv.peerMu.Unlock()
 		return
 	}
 
@@ -891,14 +908,15 @@ func (srv *Server) handleStream(s network.Stream) {
 		return
 	}
 	if len(srv.peerMap) >= srv.MaxPeers {
-		srv.peerMu.Unlock()
-		common.P2PLogger.Debug("max peers reached, rejecting connection")
-		s.Reset()
 		// The duplicate check above already ruled out an adopted peer,
 		// so dropping the host-level connection here is safe: it makes
 		// MaxPeers a bound on libp2p resources, not just on adopted
-		// Zenon streams.
+		// Zenon streams. Closing under peerMu keeps the check and the
+		// teardown atomic against a concurrent adoption.
 		_ = srv.host.Network().ClosePeer(remotePeer)
+		srv.peerMu.Unlock()
+		common.P2PLogger.Debug("max peers reached, rejecting connection")
+		s.Reset()
 		return
 	}
 	srv.peerMap[remotePeer.String()] = p
@@ -1091,13 +1109,14 @@ func (srv *Server) dialPeer(info peer.AddrInfo) error {
 		return fmt.Errorf("duplicate peer %s", info.ID)
 	}
 	if len(srv.peerMap) >= srv.MaxPeers {
-		srv.peerMu.Unlock()
-		s.Reset()
 		// The duplicate check above already ruled out an adopted peer,
 		// so closing the host connection here is safe and keeps MaxPeers
 		// bounding actual libp2p resources rather than just adopted
-		// streams.
+		// streams. Closing under peerMu keeps the check and the teardown
+		// atomic against a concurrent adoption.
 		_ = srv.host.Network().ClosePeer(info.ID)
+		srv.peerMu.Unlock()
+		s.Reset()
 		return fmt.Errorf("max peers reached")
 	}
 	srv.peerMap[info.ID.String()] = p

--- a/p2p/libp2p/server_test.go
+++ b/p2p/libp2p/server_test.go
@@ -771,3 +771,191 @@ func TestStopRejectsInFlightDialAdoption(t *testing.T) {
 		t.Fatalf("PeerCount = %d after Stop() rejected the in-flight adoption, want 0", n)
 	}
 }
+
+// TestFailedHandshakeClosesUnadoptedPeerUnderLock pins that an inbound
+// handshake failure from a peer with no adopted session and no dial in
+// flight closes the underlying connection, and that the close decision
+// is made with peerMu held — the atomicity fix 1 relies on to prevent a
+// concurrent adoption from being killed by ClosePeer.
+func TestFailedHandshakeClosesUnadoptedPeerUnderLock(t *testing.T) {
+	keyA, keyB := mustGenKey(t), mustGenKey(t)
+	portA := freePortTCP(t)
+
+	srvA := &Server{
+		PrivateKey: keyA,
+		Name:       "close-decision-target",
+		MaxPeers:   8,
+		NoDial:     true,
+		ListenAddr: fmt.Sprintf("127.0.0.1:%d", portA),
+	}
+
+	type decision struct{ closed, lockHeld bool }
+	decisions := make(chan decision, 4)
+	srvA.testCloseDecisionHook = func(closed bool) {
+		// peerMu must be held here — that is what makes the decision and
+		// the close atomic against a concurrent adoption.
+		held := !srvA.peerMu.TryLock()
+		if !held {
+			srvA.peerMu.Unlock()
+		}
+		decisions <- decision{closed: closed, lockHeld: held}
+	}
+
+	if err := srvA.Start(); err != nil {
+		t.Fatalf("start A: %v", err)
+	}
+	defer srvA.Stop()
+
+	srvB := &Server{
+		PrivateKey: keyB,
+		Name:       "close-decision-attacker",
+		MaxPeers:   8,
+		NoDial:     true,
+		ListenAddr: "127.0.0.1:0",
+	}
+	if err := srvB.Start(); err != nil {
+		t.Fatalf("start B: %v", err)
+	}
+	defer srvB.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	infoA := peer.AddrInfo{ID: srvA.host.ID(), Addrs: srvA.host.Addrs()}
+	if err := srvB.host.Connect(ctx, infoA); err != nil {
+		t.Fatalf("B connect to A: %v", err)
+	}
+
+	s, err := srvB.host.NewStream(ctx, srvA.host.ID(), protocol.ID(protoID))
+	if err != nil {
+		t.Fatalf("open stream: %v", err)
+	}
+	defer s.Reset()
+	if err := p2p.Send(NewStreamRW(s), pingMsg, struct{}{}); err != nil {
+		t.Fatalf("send ping: %v", err)
+	}
+
+	select {
+	case d := <-decisions:
+		if !d.closed {
+			t.Fatal("close decision = false, want true")
+		}
+		if !d.lockHeld {
+			t.Fatal("close decision made without peerMu held")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for close decision")
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if got := srvA.host.Network().Connectedness(srvB.host.ID()); got != network.Connected {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("Connectedness(B) still Connected after %s", 5*time.Second)
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+}
+
+// TestFailedHandshakeSkipsCloseWhileDialInFlight pins that a dial in
+// flight for the same peer.ID vetoes the close decision, and that the
+// session that dial goes on to adopt survives.
+func TestFailedHandshakeSkipsCloseWhileDialInFlight(t *testing.T) {
+	keyA, keyB := mustGenKey(t), mustGenKey(t)
+	portA := freePortTCP(t)
+
+	srvA := &Server{
+		PrivateKey: keyA,
+		Name:       "dial-in-flight-target",
+		MaxPeers:   8,
+		NoDial:     true,
+		ListenAddr: fmt.Sprintf("127.0.0.1:%d", portA),
+	}
+
+	inAdopt := make(chan struct{})
+	release := make(chan struct{})
+	srvA.testDialAdoptHook = func() {
+		close(inAdopt)
+		<-release
+	}
+	decisions := make(chan bool, 4)
+	srvA.testCloseDecisionHook = func(closed bool) {
+		decisions <- closed
+	}
+
+	srvB := &Server{
+		PrivateKey: keyB,
+		Name:       "dial-in-flight-dialer",
+		MaxPeers:   8,
+		NoDial:     true,
+		ListenAddr: "127.0.0.1:0",
+	}
+	if err := srvB.Start(); err != nil {
+		t.Fatalf("start B: %v", err)
+	}
+	defer srvB.Stop()
+
+	if err := srvA.Start(); err != nil {
+		t.Fatalf("start A: %v", err)
+	}
+	defer srvA.Stop()
+
+	infoB := peer.AddrInfo{ID: srvB.host.ID(), Addrs: srvB.host.Addrs()}
+	dialErrCh := make(chan error, 1)
+	go func() {
+		dialErrCh <- srvA.dialPeer(infoB)
+	}()
+
+	select {
+	case <-inAdopt:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for dial goroutine to reach the adoption hook")
+	}
+
+	// A's dial already established the host-level connection, so no
+	// Connect is needed here.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	s, err := srvB.host.NewStream(ctx, srvA.host.ID(), protocol.ID(protoID))
+	if err != nil {
+		t.Fatalf("open stream from B to A: %v", err)
+	}
+	defer s.Reset()
+	if err := p2p.Send(NewStreamRW(s), pingMsg, struct{}{}); err != nil {
+		t.Fatalf("send ping: %v", err)
+	}
+
+	select {
+	case closed := <-decisions:
+		if closed {
+			t.Fatal("close decision = true while a dial was in flight for the same peer, want false")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for close decision")
+	}
+
+	close(release)
+
+	select {
+	case err := <-dialErrCh:
+		if err != nil {
+			t.Fatalf("dialPeer error = %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for dialPeer to return")
+	}
+
+	if got := srvA.PeerCount(); got != 1 {
+		t.Fatalf("PeerCount = %d, want 1", got)
+	}
+	srvA.peerMu.RLock()
+	_, adopted := srvA.peerMap[srvB.host.ID().String()]
+	srvA.peerMu.RUnlock()
+	if !adopted {
+		t.Fatal("B is not in A's peerMap")
+	}
+	if got := srvA.host.Network().Connectedness(srvB.host.ID()); got != network.Connected {
+		t.Fatalf("Connectedness(B) = %v, want Connected", got)
+	}
+}

--- a/p2p/libp2p/server_test.go
+++ b/p2p/libp2p/server_test.go
@@ -23,6 +23,7 @@ import (
 	ma "github.com/multiformats/go-multiaddr"
 
 	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/p2p"
 )
 
 // syncBuffer is a concurrency-safe bytes.Buffer for capturing log
@@ -464,6 +465,158 @@ func TestPendingHandshakeCapPerPeer(t *testing.T) {
 	// never occupied more than one pending slot.
 	dialUntilConnected(t, srvB, infoA, 2*time.Second)
 	waitForPeerCount(t, srvA, 1, 2*time.Second)
+}
+
+// TestAdoptedPeerSurvivesFailedSecondHandshake pins that a second stream
+// from an already-adopted peer whose handshake fails is reset on its
+// own; the adopted session and the underlying connection survive.
+func TestAdoptedPeerSurvivesFailedSecondHandshake(t *testing.T) {
+	keyA, keyB := mustGenKey(t), mustGenKey(t)
+	portA := freePortTCP(t)
+
+	srvA := &Server{
+		PrivateKey: keyA,
+		Name:       "second-handshake-target",
+		MaxPeers:   8,
+		NoDial:     true,
+		ListenAddr: fmt.Sprintf("127.0.0.1:%d", portA),
+	}
+	if err := srvA.Start(); err != nil {
+		t.Fatalf("start A: %v", err)
+	}
+	defer srvA.Stop()
+
+	srvB := &Server{
+		PrivateKey: keyB,
+		Name:       "second-handshake-dialer",
+		MaxPeers:   8,
+		NoDial:     true,
+		ListenAddr: "127.0.0.1:0",
+	}
+	if err := srvB.Start(); err != nil {
+		t.Fatalf("start B: %v", err)
+	}
+	defer srvB.Stop()
+
+	infoA := peer.AddrInfo{ID: srvA.host.ID(), Addrs: srvA.host.Addrs()}
+	dialUntilConnected(t, srvB, infoA, 10*time.Second)
+	waitForPeerCount(t, srvA, 1, 10*time.Second)
+
+	// Open a second stream on the same connection and send a
+	// non-handshake code, so A's doProtoHandshake fails fast.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	s, err := srvB.host.NewStream(ctx, srvA.host.ID(), protocol.ID(protoID))
+	if err != nil {
+		t.Fatalf("open second stream: %v", err)
+	}
+	defer s.Reset()
+	if err := p2p.Send(NewStreamRW(s), pingMsg, struct{}{}); err != nil {
+		t.Fatalf("send ping on second stream: %v", err)
+	}
+
+	time.Sleep(time.Second)
+
+	if got := srvA.PeerCount(); got != 1 {
+		t.Fatalf("PeerCount = %d, want 1", got)
+	}
+	srvA.peerMu.RLock()
+	_, adopted := srvA.peerMap[srvB.host.ID().String()]
+	srvA.peerMu.RUnlock()
+	if !adopted {
+		t.Fatal("B is no longer in A's peerMap")
+	}
+	if got := srvA.host.Network().Connectedness(srvB.host.ID()); got != network.Connected {
+		t.Fatalf("Connectedness(B) = %v, want Connected", got)
+	}
+}
+
+// TestDuplicateStreamAtCapacityIsResetNotClosed pins that a duplicate
+// stream from an already-adopted peer is reset while the peer is at
+// capacity; the adopted session and the underlying connection survive.
+func TestDuplicateStreamAtCapacityIsResetNotClosed(t *testing.T) {
+	keyA, keyB := mustGenKey(t), mustGenKey(t)
+	portA := freePortTCP(t)
+
+	srvA := &Server{
+		PrivateKey: keyA,
+		Name:       "dup-stream-target",
+		MaxPeers:   1,
+		NoDial:     true,
+		ListenAddr: fmt.Sprintf("127.0.0.1:%d", portA),
+	}
+	if err := srvA.Start(); err != nil {
+		t.Fatalf("start A: %v", err)
+	}
+	defer srvA.Stop()
+
+	srvB := &Server{
+		PrivateKey: keyB,
+		Name:       "dup-stream-dialer",
+		MaxPeers:   8,
+		NoDial:     true,
+		ListenAddr: "127.0.0.1:0",
+	}
+	if err := srvB.Start(); err != nil {
+		t.Fatalf("start B: %v", err)
+	}
+	defer srvB.Stop()
+
+	infoA := peer.AddrInfo{ID: srvA.host.ID(), Addrs: srvA.host.Addrs()}
+	dialUntilConnected(t, srvB, infoA, 10*time.Second)
+	waitForPeerCount(t, srvA, 1, 10*time.Second)
+
+	// Open a second stream and complete A's handshake on it manually, so
+	// the duplicate is caught only by the final peerMap check.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	s, err := srvB.host.NewStream(ctx, srvA.host.ID(), protocol.ID(protoID))
+	if err != nil {
+		t.Fatalf("open second stream: %v", err)
+	}
+	defer s.Reset()
+
+	rw := NewStreamRW(s)
+	if err := p2p.Send(rw, handshakeMsg, &protoHandshake{
+		Version: baseProtocolVersion,
+		Name:    "dup-stream-dialer",
+		ID:      PubkeyToNodeID(&keyB.PublicKey),
+	}); err != nil {
+		t.Fatalf("send handshake on second stream: %v", err)
+	}
+
+	// Some read on the reset stream must error — A's own handshake reply
+	// may or may not be drained first depending on timing.
+	readErr := make(chan error, 1)
+	go func() {
+		if _, err := rw.ReadMsg(); err != nil {
+			readErr <- err
+			return
+		}
+		_, err := rw.ReadMsg()
+		readErr <- err
+	}()
+	select {
+	case err := <-readErr:
+		if err == nil {
+			t.Fatal("expected a read error on the reset duplicate stream")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the duplicate stream to be reset")
+	}
+
+	if got := srvA.PeerCount(); got != 1 {
+		t.Fatalf("PeerCount = %d, want 1", got)
+	}
+	srvA.peerMu.RLock()
+	_, adopted := srvA.peerMap[srvB.host.ID().String()]
+	srvA.peerMu.RUnlock()
+	if !adopted {
+		t.Fatal("B is no longer in A's peerMap")
+	}
+	if got := srvA.host.Network().Connectedness(srvB.host.ID()); got != network.Connected {
+		t.Fatalf("Connectedness(B) = %v, want Connected", got)
+	}
 }
 
 // TestStopWaitsForInFlightDHTRefreshBeforeClosingDHT pins the lifecycle

--- a/p2p/libp2p/server_test.go
+++ b/p2p/libp2p/server_test.go
@@ -2,6 +2,7 @@ package libp2p
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"errors"
 	"fmt"
@@ -15,7 +16,10 @@ import (
 
 	ethcrypto "github.com/ethereum/go-ethereum/crypto"
 	"github.com/inconshreveable/log15"
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/core/protocol"
 	ma "github.com/multiformats/go-multiaddr"
 
 	"github.com/zenon-network/go-zenon/common"
@@ -361,6 +365,105 @@ func TestDHTDiscoveryConnectsIndirectPeer(t *testing.T) {
 	if !found {
 		t.Fatalf("C connected to %d peers but not to B (%s) specifically", srvC.PeerCount(), pidB)
 	}
+}
+
+// TestPendingHandshakeCapPerPeer verifies that a single remote peer
+// opening many concurrent streams that never complete the protocol
+// handshake can occupy at most one pending-handshake slot. Without the
+// per-peer cap, one connection opening MaxPendingPeers stalled streams
+// would consume the entire global pending budget and deny every other
+// inbound handshake for up to the handshake read deadline.
+//
+// Topology: A listens with MaxPendingPeers=2. An "attacker" — a raw
+// libp2p host, not a Zenon Server — connects to A and opens 5 streams
+// on the Zenon protocol without ever writing a handshake, holding them
+// open. A legitimate peer B then dials A concurrently and must still
+// complete its handshake and be adopted: if the attacker's streams had
+// consumed more than one pending slot, B's own handshake attempt would
+// be rejected until the attacker's streams time out.
+func TestPendingHandshakeCapPerPeer(t *testing.T) {
+	keyA, keyB, keyAttacker := mustGenKey(t), mustGenKey(t), mustGenKey(t)
+	portA := freePortTCP(t)
+
+	srvA := &Server{
+		PrivateKey:      keyA,
+		Name:            "pending-cap-target",
+		MaxPeers:        8,
+		MaxPendingPeers: 2,
+		NoDial:          true,
+		ListenAddr:      fmt.Sprintf("127.0.0.1:%d", portA),
+	}
+	if err := srvA.Start(); err != nil {
+		t.Fatalf("start A: %v", err)
+	}
+	defer srvA.Stop()
+
+	infoA := peer.AddrInfo{ID: srvA.host.ID(), Addrs: srvA.host.Addrs()}
+
+	attackerPriv, err := ECDSAToLibp2pPrivKey(keyAttacker)
+	if err != nil {
+		t.Fatalf("attacker key: %v", err)
+	}
+	attackerHost, err := libp2p.New(libp2p.Identity(attackerPriv), libp2p.NoListenAddrs)
+	if err != nil {
+		t.Fatalf("attacker host: %v", err)
+	}
+	defer attackerHost.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := attackerHost.Connect(ctx, infoA); err != nil {
+		t.Fatalf("attacker connect: %v", err)
+	}
+
+	const attackerStreams = 5 // > MaxPendingPeers, all stalled indefinitely
+	var streams []network.Stream
+	for i := 0; i < attackerStreams; i++ {
+		s, err := attackerHost.NewStream(ctx, infoA.ID, protocol.ID(protoID))
+		if err != nil {
+			t.Fatalf("attacker stream %d: %v", i, err)
+		}
+		// go-libp2p negotiates the protocol lazily once a "preferred
+		// protocol" is cached for the peer (i.e. every stream after the
+		// first): NewStream returns immediately without writing
+		// anything, so the server never even sees the stream until
+		// something is written. A single byte forces that flush (and
+		// leaves the handshake frame incomplete, so the server's read
+		// still stalls until the handshake deadline).
+		if _, err := s.Write([]byte{0}); err != nil {
+			t.Fatalf("attacker stream %d write: %v", i, err)
+		}
+		streams = append(streams, s)
+	}
+	defer func() {
+		for _, s := range streams {
+			_ = s.Reset()
+		}
+	}()
+
+	// Let A's handleStream goroutines register the attacker's streams as
+	// pending before checking whether a legitimate peer can still get in.
+	time.Sleep(500 * time.Millisecond)
+
+	srvB := &Server{
+		PrivateKey: keyB,
+		Name:       "pending-cap-legit-peer",
+		MaxPeers:   8,
+		NoDial:     true,
+		ListenAddr: "127.0.0.1:0",
+	}
+	if err := srvB.Start(); err != nil {
+		t.Fatalf("start B: %v", err)
+	}
+	defer srvB.Stop()
+
+	// Budget well under handshakeTimeout: if the attacker's stalled
+	// streams had exhausted the pending budget (no per-peer cap), B's
+	// dial attempts would all be rejected until those streams time out
+	// at handshakeTimeout, so this window only succeeds if the attacker
+	// never occupied more than one pending slot.
+	dialUntilConnected(t, srvB, infoA, 2*time.Second)
+	waitForPeerCount(t, srvA, 1, 2*time.Second)
 }
 
 // TestStopWaitsForInFlightDHTRefreshBeforeClosingDHT pins the lifecycle

--- a/p2p/libp2p/stream_rw.go
+++ b/p2p/libp2p/stream_rw.go
@@ -41,7 +41,7 @@ func NewStreamRW(s network.Stream) *StreamRW {
 // declared size exceeds maxMessageSize before allocating a payload
 // buffer for it.
 func (rw *StreamRW) ReadMsg() (p2p.Msg, error) {
-	return rw.readMsg(maxMessageSize)
+	return rw.readMsg(maxMessageSize, frameReadTimeout)
 }
 
 // ReadMsgLimited reads a message from the stream like ReadMsg, but
@@ -50,14 +50,23 @@ func (rw *StreamRW) ReadMsg() (p2p.Msg, error) {
 // where the remote hasn't been authenticated yet, so the cap can be
 // tighter than the post-handshake maxMessageSize.
 func (rw *StreamRW) ReadMsgLimited(maxSize uint32) (p2p.Msg, error) {
-	return rw.readMsg(maxSize)
+	return rw.readMsg(maxSize, frameReadTimeout)
 }
 
-func (rw *StreamRW) readMsg(maxSize uint32) (p2p.Msg, error) {
+// ReadMsgLimitedTimeout is ReadMsgLimited with an explicit read
+// deadline, rather than the steady-state frameReadTimeout. Used for the
+// pre-adoption handshake read, which should time out much sooner than a
+// live peer's frame reads so a stalled, unauthenticated remote can't
+// hold a pending-handshake slot for the full steady-state timeout.
+func (rw *StreamRW) ReadMsgLimitedTimeout(maxSize uint32, timeout time.Duration) (p2p.Msg, error) {
+	return rw.readMsg(maxSize, timeout)
+}
+
+func (rw *StreamRW) readMsg(maxSize uint32, timeout time.Duration) (p2p.Msg, error) {
 	rw.rmu.Lock()
 	defer rw.rmu.Unlock()
 
-	rw.stream.SetReadDeadline(time.Now().Add(frameReadTimeout))
+	rw.stream.SetReadDeadline(time.Now().Add(timeout))
 	defer rw.stream.SetReadDeadline(time.Time{})
 
 	// Read 8-byte header

--- a/p2p/libp2p/stream_rw.go
+++ b/p2p/libp2p/stream_rw.go
@@ -44,20 +44,13 @@ func (rw *StreamRW) ReadMsg() (p2p.Msg, error) {
 	return rw.readMsg(maxMessageSize, frameReadTimeout)
 }
 
-// ReadMsgLimited reads a message from the stream like ReadMsg, but
-// rejects a frame whose declared size exceeds maxSize before allocating
-// a payload buffer for it. Used on the pre-adoption handshake path,
-// where the remote hasn't been authenticated yet, so the cap can be
-// tighter than the post-handshake maxMessageSize.
-func (rw *StreamRW) ReadMsgLimited(maxSize uint32) (p2p.Msg, error) {
-	return rw.readMsg(maxSize, frameReadTimeout)
-}
-
-// ReadMsgLimitedTimeout is ReadMsgLimited with an explicit read
-// deadline, rather than the steady-state frameReadTimeout. Used for the
-// pre-adoption handshake read, which should time out much sooner than a
-// live peer's frame reads so a stalled, unauthenticated remote can't
-// hold a pending-handshake slot for the full steady-state timeout.
+// ReadMsgLimitedTimeout reads a message from the stream, rejecting a
+// frame whose declared size exceeds maxSize before allocating a payload
+// buffer for it, under an explicit read deadline rather than the
+// steady-state frameReadTimeout. Used for the pre-adoption handshake
+// read, which should time out much sooner than a live peer's frame reads
+// so a stalled, unauthenticated remote can't hold a pending-handshake
+// slot for the full steady-state timeout.
 func (rw *StreamRW) ReadMsgLimitedTimeout(maxSize uint32, timeout time.Duration) (p2p.Msg, error) {
 	return rw.readMsg(maxSize, timeout)
 }

--- a/p2p/switcher/server.go
+++ b/p2p/switcher/server.go
@@ -48,7 +48,7 @@ type Server struct {
 	// ---- shared config ----
 	PrivateKey        *ecdsa.PrivateKey
 	Name              string
-	MaxPeers          int
+	MaxPeers          int // must be > 0; Start() rejects anything else
 	MinConnectedPeers int
 	MaxPendingPeers   int
 	ListenAddr        string // "host:port"
@@ -122,6 +122,17 @@ func (srv *Server) Start() error {
 	if srv.stopCh != nil {
 		return errors.New("switcher: server already started")
 	}
+
+	// Both backends treat this as a hard capacity bound and the libp2p
+	// backend's every capacity check is len(peerMap) >= MaxPeers, so a
+	// non-positive value means "accept nothing". Reject it here, before
+	// either backend starts, rather than at the spork swap — by then the
+	// legacy backend is already down and a start failure would leave the
+	// node with no listener.
+	if srv.MaxPeers <= 0 {
+		return fmt.Errorf("switcher: MaxPeers must be > 0 (got %d)", srv.MaxPeers)
+	}
+
 	srv.stopCh = make(chan struct{})
 
 	libp2pActive := false

--- a/p2p/switcher/server_test.go
+++ b/p2p/switcher/server_test.go
@@ -208,11 +208,9 @@ func waitForCondition(t *testing.T, timeout time.Duration, desc string, cond fun
 // Original regression tests (real backends)
 // ──────────────────────────────────────────────────────────────────────
 
-// TestStopPreActivation_Bug1 verifies that Stop() does not deadlock
-// when called before the spork activates. This was Bug 1: the watcher
-// read srv.stopCh directly; after Stop() closed and nilled it, the
-// select on a nil channel blocked forever.
-func TestStopPreActivation_Bug1(t *testing.T) {
+// TestStopDoesNotDeadlockBeforeActivation verifies that Stop() does not
+// deadlock when called before the spork activates.
+func TestStopDoesNotDeadlockBeforeActivation(t *testing.T) {
 	oracle := &fakeOracle{active: false}
 	srv := newTestServer(t, oracle)
 
@@ -231,14 +229,13 @@ func TestStopPreActivation_Bug1(t *testing.T) {
 	case <-done:
 		// success
 	case <-time.After(5 * time.Second):
-		t.Fatal("Stop() deadlocked — Bug 1 regression")
+		t.Fatal("Stop() deadlocked before activation")
 	}
 }
 
-// TestStopDuringSwap_Bug2 verifies that if Stop() races with swap(),
-// the libp2p backend is not started after Stop() returns. This was
-// Bug 2: swap() didn't check stopCh before starting libp2p.
-func TestStopDuringSwap_Bug2(t *testing.T) {
+// TestStopDuringSwapDoesNotLeakBackend verifies that if Stop() races
+// with swap(), the libp2p backend is not started after Stop() returns.
+func TestStopDuringSwapDoesNotLeakBackend(t *testing.T) {
 	oracle := &fakeOracle{active: false}
 	srv := newTestServer(t, oracle)
 
@@ -261,7 +258,7 @@ func TestStopDuringSwap_Bug2(t *testing.T) {
 	case <-done:
 		// success
 	case <-time.After(5 * time.Second):
-		t.Fatal("Stop() deadlocked during swap — Bug 2 regression")
+		t.Fatal("Stop() deadlocked during swap")
 	}
 
 	// After Stop, no backend should be active.
@@ -270,10 +267,10 @@ func TestStopDuringSwap_Bug2(t *testing.T) {
 	}
 }
 
-// TestNilOracle_Bug3 verifies that Start() does not launch the
-// activation watcher when Oracle is nil, which would panic on the
-// first tick.
-func TestNilOracle_Bug3(t *testing.T) {
+// TestStartWithNilOracleDoesNotLaunchWatcher verifies that Start() does
+// not launch the activation watcher when Oracle is nil, which would
+// panic on the first tick.
+func TestStartWithNilOracleDoesNotLaunchWatcher(t *testing.T) {
 	srv := &Server{
 		PrivateKey: testKey(t),
 		Name:       "test-node",

--- a/p2p/switcher/server_test.go
+++ b/p2p/switcher/server_test.go
@@ -769,6 +769,25 @@ func TestLegacyStartFails(t *testing.T) {
 	srv.Stop()
 }
 
+// TestStartRejectsNonPositiveMaxPeers verifies that Start() rejects a
+// non-positive MaxPeers before either backend starts.
+func TestStartRejectsNonPositiveMaxPeers(t *testing.T) {
+	oracle := &fakeOracle{active: false}
+	srv, legacyMock, libp2pMock := newMockServer(t, oracle)
+	srv.MaxPeers = 0
+
+	if err := srv.Start(); err == nil {
+		t.Fatal("Start() should return error when MaxPeers <= 0, got nil")
+	}
+
+	if legacyMock.isStarted() {
+		t.Fatal("legacy backend should not be started when MaxPeers is rejected")
+	}
+	if libp2pMock.isStarted() {
+		t.Fatal("libp2p backend should not be started when MaxPeers is rejected")
+	}
+}
+
 // TestSporkAlreadyActive_Mock verifies that when the oracle reports
 // the spork as already active at startup, the libp2p backend is
 // started directly (legacy is never touched).

--- a/pillar/content_selector.go
+++ b/pillar/content_selector.go
@@ -21,11 +21,44 @@ func (cs *contentSelector) Content(blocks []*nom.AccountBlock) []*nom.AccountBlo
 	return cs.filterBlocksToCommit(cs.sortBlocksByPriority(blocks))
 }
 
+// sortBlocksByPriority orders blocks by grouping them by address first
+// (each group internally ordered by height, lowest first), then ordering
+// the groups themselves by the price of each group's lowest-height
+// block. Comparing whole groups rather than individual blocks pairwise
+// keeps the comparator a total order: a per-block comparator that mixes
+// a same-address height rule with a cross-address price rule is not
+// transitive (address X's cheap low-height block and expensive
+// high-height block can each individually out- or under-rank a third
+// address' block priced between them), and sort.SliceStable can resolve
+// that into an order that separates a block from its own ancestor —
+// leaving a gap in that address's chain that the producer's own
+// chain-order check then rejects the whole momentum for.
 func (cs *contentSelector) sortBlocksByPriority(blocks []*nom.AccountBlock) []*nom.AccountBlock {
-	sort.SliceStable(blocks, func(i, j int) bool {
-		return cs.higherPriority(blocks[i], blocks[j])
+	groups := make(map[types.Address][]*nom.AccountBlock, len(blocks))
+	order := make([]types.Address, 0, len(blocks))
+	for _, block := range blocks {
+		if _, ok := groups[block.Address]; !ok {
+			order = append(order, block.Address)
+		}
+		groups[block.Address] = append(groups[block.Address], block)
+	}
+
+	for _, address := range order {
+		group := groups[address]
+		sort.SliceStable(group, func(i, j int) bool {
+			return group[i].Height < group[j].Height
+		})
+	}
+
+	sort.SliceStable(order, func(i, j int) bool {
+		return cs.higherGroupPriority(groups[order[i]][0], groups[order[j]][0])
 	})
-	return blocks
+
+	result := make([]*nom.AccountBlock, 0, len(blocks))
+	for _, address := range order {
+		result = append(result, groups[address]...)
+	}
+	return result
 }
 
 func (cs *contentSelector) filterBlocksToCommit(blocks []*nom.AccountBlock) []*nom.AccountBlock {
@@ -78,24 +111,20 @@ func (cs *contentSelector) filterBlocksToCommit(blocks []*nom.AccountBlock) []*n
 	return toCommit
 }
 
-// Determines the higher priority between two account blocks. Anwsers the question:
-// "Does account block A have a higher priority than account block B?"
+// higherGroupPriority determines whether the address group led by block
+// a should be ordered before the address group led by block b (a and b
+// are always each group's lowest-height block, per sortBlocksByPriority).
 // The following rules are applied:
-// 1. Contract blocks always have the higher priority.
-// 2. When comparing two user blocks from the same address, the block with a lower height has higher priority.
-// 3. When comparing two user blocks from different addresses, the block with a higher block price has higher priority.
-// 4. If blocks are of equal priority price-wise then a block hash comparison will determine which block gets higher priority.
-func (cs *contentSelector) higherPriority(a, b *nom.AccountBlock) bool {
+// 1. Contract-address groups always have the higher priority.
+// 2. Otherwise, the group whose leading block has a higher block price has higher priority.
+// 3. If leading blocks are of equal price then a block hash comparison determines priority.
+func (cs *contentSelector) higherGroupPriority(a, b *nom.AccountBlock) bool {
 	if types.IsEmbeddedAddress(b.Address) {
 		return false
 	}
 
 	if types.IsEmbeddedAddress(a.Address) {
 		return true
-	}
-
-	if a.Address == b.Address {
-		return a.Height < b.Height
 	}
 
 	err := cs.plasma.HigherPrice(a, b)

--- a/pillar/content_selector.go
+++ b/pillar/content_selector.go
@@ -2,6 +2,7 @@ package pillar
 
 import (
 	"bytes"
+	"container/heap"
 	"sort"
 
 	"github.com/zenon-network/go-zenon/chain/nom"
@@ -22,17 +23,18 @@ func (cs *contentSelector) Content(blocks []*nom.AccountBlock) []*nom.AccountBlo
 }
 
 // sortBlocksByPriority orders blocks by grouping them by address first
-// (each group internally ordered by height, lowest first), then ordering
-// the groups themselves by the price of each group's lowest-height
-// block. Comparing whole groups rather than individual blocks pairwise
-// keeps the comparator a total order: a per-block comparator that mixes
-// a same-address height rule with a cross-address price rule is not
-// transitive (address X's cheap low-height block and expensive
-// high-height block can each individually out- or under-rank a third
-// address' block priced between them), and sort.SliceStable can resolve
-// that into an order that separates a block from its own ancestor —
-// leaving a gap in that address's chain that the producer's own
-// chain-order check then rejects the whole momentum for.
+// (each group internally ordered by height, lowest first, so a block
+// never precedes its own ancestor — a gap would make the producer's own
+// chain-order check reject the whole momentum). Embedded-address groups
+// are emitted first, whole and contiguous, in first-seen order, which is
+// what filterBlocksToCommit's contractBatch accumulation requires: it
+// would mix addresses into a single batch if contract groups
+// interleaved. The remaining (user) groups are merged by price across
+// addresses via a k-way merge over each group's current head, so a
+// block's price is compared only against other addresses' current heads
+// — never against a lower-priority block from its own chain — while the
+// per-address ancestor-before-descendant order is preserved by
+// construction.
 func (cs *contentSelector) sortBlocksByPriority(blocks []*nom.AccountBlock) []*nom.AccountBlock {
 	groups := make(map[types.Address][]*nom.AccountBlock, len(blocks))
 	order := make([]types.Address, 0, len(blocks))
@@ -50,15 +52,67 @@ func (cs *contentSelector) sortBlocksByPriority(blocks []*nom.AccountBlock) []*n
 		})
 	}
 
-	sort.SliceStable(order, func(i, j int) bool {
-		return cs.higherGroupPriority(groups[order[i]][0], groups[order[j]][0])
-	})
-
 	result := make([]*nom.AccountBlock, 0, len(blocks))
+
+	var userGroups []*addressGroup
 	for _, address := range order {
-		result = append(result, groups[address]...)
+		group := groups[address]
+		if types.IsEmbeddedAddress(address) {
+			result = append(result, group...)
+			continue
+		}
+		userGroups = append(userGroups, &addressGroup{blocks: group, order: len(userGroups)})
 	}
+
+	gh := &groupHeap{cs: cs, groups: userGroups}
+	heap.Init(gh)
+	for gh.Len() > 0 {
+		group := gh.groups[0]
+		result = append(result, group.blocks[group.pos])
+		group.pos++
+		if group.pos == len(group.blocks) {
+			heap.Pop(gh)
+		} else {
+			heap.Fix(gh, 0)
+		}
+	}
+
 	return result
+}
+
+// addressGroup is a single address' height-ordered blocks, tracked by the
+// k-way merge in sortBlocksByPriority.
+type addressGroup struct {
+	blocks []*nom.AccountBlock
+	pos    int
+	order  int // first-seen index; the stable tie-break
+}
+
+// groupHeap is a min-heap keyed by each group's current head price (via
+// compareBlockPriority), so the highest-priced head is always at the root.
+type groupHeap struct {
+	cs     *contentSelector
+	groups []*addressGroup
+}
+
+func (h *groupHeap) Len() int { return len(h.groups) }
+func (h *groupHeap) Less(i, j int) bool {
+	a, b := h.groups[i], h.groups[j]
+	if c := h.cs.compareBlockPriority(a.blocks[a.pos], b.blocks[b.pos]); c != 0 {
+		return c > 0
+	}
+	return a.order < b.order
+}
+func (h *groupHeap) Swap(i, j int) { h.groups[i], h.groups[j] = h.groups[j], h.groups[i] }
+func (h *groupHeap) Push(x interface{}) {
+	h.groups = append(h.groups, x.(*addressGroup))
+}
+func (h *groupHeap) Pop() interface{} {
+	old := h.groups
+	n := len(old)
+	item := old[n-1]
+	h.groups = old[:n-1]
+	return item
 }
 
 func (cs *contentSelector) filterBlocksToCommit(blocks []*nom.AccountBlock) []*nom.AccountBlock {
@@ -111,27 +165,19 @@ func (cs *contentSelector) filterBlocksToCommit(blocks []*nom.AccountBlock) []*n
 	return toCommit
 }
 
-// higherGroupPriority determines whether the address group led by block
-// a should be ordered before the address group led by block b (a and b
-// are always each group's lowest-height block, per sortBlocksByPriority).
-// The following rules are applied:
-// 1. Contract-address groups always have the higher priority.
-// 2. Otherwise, the group whose leading block has a higher block price has higher priority.
-// 3. If leading blocks are of equal price then a block hash comparison determines priority.
-func (cs *contentSelector) higherGroupPriority(a, b *nom.AccountBlock) bool {
-	if types.IsEmbeddedAddress(b.Address) {
-		return false
+// compareBlockPriority returns a positive value when a should be emitted
+// before b, negative when after, and zero when the two are
+// indistinguishable. Higher-priced blocks come first; an exact price tie is
+// broken by the larger block hash.
+func (cs *contentSelector) compareBlockPriority(a, b *nom.AccountBlock) int {
+	switch err := cs.plasma.HigherPrice(a, b); err {
+	case nil:
+		return 1
+	case dp.ErrBlockPriceSame:
+		return bytes.Compare(a.Hash.Bytes()[:], b.Hash.Bytes()[:])
+	default:
+		return -1
 	}
-
-	if types.IsEmbeddedAddress(a.Address) {
-		return true
-	}
-
-	err := cs.plasma.HigherPrice(a, b)
-	if err == dp.ErrBlockPriceSame && bytes.Compare(a.Hash.Bytes()[:], b.Hash.Bytes()[:]) > 0 {
-		return true
-	}
-	return err == nil
 }
 
 func NewMomentumContentSelector(plasma dp.DynamicPlasma) ContentSelector {

--- a/pillar/content_selector_test.go
+++ b/pillar/content_selector_test.go
@@ -164,3 +164,38 @@ func TestContent_sortBlocksByPriority(t *testing.T) {
 		{Height: 2, BlockType: nom.BlockTypeUserSend, BasePlasma: 21000, FusedPlasma: 21000, Address: address2},
 	}))
 }
+
+// A cheap low-height block and an expensive high-height block from the
+// same address must never be separated by a third address' block priced
+// between them: a per-block comparator that mixes a same-address height
+// rule with a cross-address price rule admits exactly this cycle
+// (x1 < x2 by height, x2 < y by price, y < x1 by price), which a stable
+// sort over individual blocks can resolve into an order with x2 before
+// x1 - a gap in address X's chain that the producer's own chain-order
+// check would then reject the whole momentum for.
+func TestContent_sortBlocksByPriority_NoGapAcrossThirdAddress(t *testing.T) {
+	addressX := types.ParseAddressPanic("z1qzal6c5s9rjnnxd2z7dvdhjxpmmj4fmw56a0mz")
+	addressY := types.ParseAddressPanic("z1qqfmjdays57w488sta69ykc2ey7r6d0q9wdvtj")
+
+	previousMomentum := &nom.Momentum{NextFusionPrice: 1000, NextWorkPrice: 1000, Version: 2}
+	cs := &contentSelector{
+		plasma: dp.NewDynamicPlasma(previousMomentum, nil),
+	}
+
+	x1 := &nom.AccountBlock{Height: 1, BlockType: nom.BlockTypeUserSend, BasePlasma: 21000, FusedPlasma: 21000, Address: addressX}
+	x2 := &nom.AccountBlock{Height: 2, BlockType: nom.BlockTypeUserSend, BasePlasma: 21000, FusedPlasma: 21002, Address: addressX}
+	y := &nom.AccountBlock{Height: 1, BlockType: nom.BlockTypeUserSend, BasePlasma: 21000, FusedPlasma: 21001, Address: addressY}
+
+	sorted := cs.sortBlocksByPriority([]*nom.AccountBlock{x2, y, x1})
+
+	indexOf := func(target *nom.AccountBlock) int {
+		for i, b := range sorted {
+			if b == target {
+				return i
+			}
+		}
+		t.Fatalf("block at height %d for %v missing from sorted output", target.Height, target.Address)
+		return -1
+	}
+	common.ExpectTrue(t, indexOf(x1) < indexOf(x2))
+}

--- a/pillar/content_selector_test.go
+++ b/pillar/content_selector_test.go
@@ -199,3 +199,22 @@ func TestContent_sortBlocksByPriority_NoGapAcrossThirdAddress(t *testing.T) {
 	}
 	common.ExpectTrue(t, indexOf(x1) < indexOf(x2))
 }
+
+// A block outranks another address' block on its own price, while its own
+// ancestors still precede it.
+func TestContent_sortBlocksByPriority_PremiumHeadDoesNotEscortFloorPricedTail(t *testing.T) {
+	addressX := types.ParseAddressPanic("z1qzal6c5s9rjnnxd2z7dvdhjxpmmj4fmw56a0mz")
+	addressY := types.ParseAddressPanic("z1qqfmjdays57w488sta69ykc2ey7r6d0q9wdvtj")
+
+	previousMomentum := &nom.Momentum{NextFusionPrice: 1000, NextWorkPrice: 1000, Version: 2}
+	cs := &contentSelector{
+		plasma: dp.NewDynamicPlasma(previousMomentum, nil),
+	}
+
+	x1 := &nom.AccountBlock{Height: 1, BlockType: nom.BlockTypeUserSend, BasePlasma: 21000, FusedPlasma: 42000, Address: addressX}
+	x2 := &nom.AccountBlock{Height: 2, BlockType: nom.BlockTypeUserSend, BasePlasma: 21000, FusedPlasma: 21000, Address: addressX}
+	x3 := &nom.AccountBlock{Height: 3, BlockType: nom.BlockTypeUserSend, BasePlasma: 21000, FusedPlasma: 21000, Address: addressX}
+	y := &nom.AccountBlock{Height: 1, BlockType: nom.BlockTypeUserSend, BasePlasma: 21000, FusedPlasma: 31500, Address: addressY}
+
+	common.ExpectTrue(t, reflect.DeepEqual(cs.sortBlocksByPriority([]*nom.AccountBlock{x1, x2, x3, y}), []*nom.AccountBlock{x1, y, x2, x3}))
+}

--- a/pillar/worker.go
+++ b/pillar/worker.go
@@ -140,7 +140,10 @@ func (w *worker) work(task common.TaskResolver, e consensus.ProducerEvent) {
 				w.log.Error("unable to generate receive block for contract", "reason", err)
 				return
 			}
-			w.broadcaster.CreateAccountBlock(transaction)
+			if err := w.broadcaster.CreateAccountBlock(transaction); err != nil {
+				w.log.Error("unable to insert autoreceive block for contract", "reason", err)
+				return
+			}
 			w.log.Info("created autoreceive-block", "identifier", transaction.Block.Header())
 
 			one = true

--- a/pillar/worker.go
+++ b/pillar/worker.go
@@ -141,8 +141,8 @@ func (w *worker) work(task common.TaskResolver, e consensus.ProducerEvent) {
 				return
 			}
 			if err := w.broadcaster.CreateAccountBlock(transaction); err != nil {
-				w.log.Error("unable to insert autoreceive block for contract", "reason", err)
-				return
+				w.log.Error("unable to insert autoreceive block for contract", "contract-address", contractAddress, "reason", err)
+				continue
 			}
 			w.log.Info("created autoreceive-block", "identifier", transaction.Block.Header())
 

--- a/pillar/worker_updater.go
+++ b/pillar/worker_updater.go
@@ -28,8 +28,8 @@ func (w *worker) updateContracts(momentumStore store.Momentum) error {
 				Data:      definition.ABICommon.PackMethodPanic(definition.UpdateMethodName),
 			}, w.coinbase.Signer); err != nil {
 				return err
-			} else {
-				w.broadcaster.CreateAccountBlock(block)
+			} else if err := w.broadcaster.CreateAccountBlock(block); err != nil {
+				return err
 			}
 		} else if err == constants.ErrUpdateTooRecent || err == constants.ErrContractMethodNotFound {
 		} else {

--- a/pillar/worker_updater.go
+++ b/pillar/worker_updater.go
@@ -29,7 +29,7 @@ func (w *worker) updateContracts(momentumStore store.Momentum) error {
 			}, w.coinbase.Signer); err != nil {
 				return err
 			} else if err := w.broadcaster.CreateAccountBlock(block); err != nil {
-				return err
+				w.log.Error("unable to insert update block for embedded-contract", "contract-address", address, "reason", err)
 			}
 		} else if err == constants.ErrUpdateTooRecent || err == constants.ErrContractMethodNotFound {
 		} else {

--- a/protocol/broadcaster.go
+++ b/protocol/broadcaster.go
@@ -71,15 +71,17 @@ func (b *broadcaster) CreateMomentum(momentumTransaction *nom.MomentumTransactio
 }
 
 // CreateAccountBlock is called when our node created an account block.
-// The account-block will be inserted in the chain and broadcasted.
-func (b *broadcaster) CreateAccountBlock(accountBlockTransaction *nom.AccountBlockTransaction) {
+// The account-block will be inserted in the chain and broadcasted. The
+// insert error is returned to the caller.
+func (b *broadcaster) CreateAccountBlock(accountBlockTransaction *nom.AccountBlockTransaction) error {
 	insert := b.chain.AcquireInsert(fmt.Sprintf("zenon - create account-block %v", accountBlockTransaction.Block.Header()))
 	err := b.chain.AddAccountBlockTransaction(insert, accountBlockTransaction)
 	insert.Unlock()
 	if err != nil {
 		b.log.Error("failed to insert own account-block", "reason", err)
-		return
+		return err
 	}
 
 	b.protocol.BroadcastAccountBlock(accountBlockTransaction.Block)
+	return nil
 }

--- a/protocol/interfaces.go
+++ b/protocol/interfaces.go
@@ -53,5 +53,5 @@ type ChainBridge interface {
 type Broadcaster interface {
 	SyncInfo() *SyncInfo
 	CreateMomentum(*nom.MomentumTransaction, *nom.DetailedMomentum)
-	CreateAccountBlock(*nom.AccountBlockTransaction)
+	CreateAccountBlock(*nom.AccountBlockTransaction) error
 }

--- a/rpc/api/ledger.go
+++ b/rpc/api/ledger.go
@@ -69,10 +69,6 @@ func (l *LedgerApi) PublishRawTransaction(block *AccountBlock) error {
 		return err
 	}
 
-	if err = l.chain.CheckUncommittedBlocksCount(block.Address); err != nil {
-		return err
-	}
-
 	l.z.Broadcaster().CreateAccountBlock(transaction)
 	return nil
 }

--- a/rpc/api/ledger.go
+++ b/rpc/api/ledger.go
@@ -69,8 +69,7 @@ func (l *LedgerApi) PublishRawTransaction(block *AccountBlock) error {
 		return err
 	}
 
-	l.z.Broadcaster().CreateAccountBlock(transaction)
-	return nil
+	return l.z.Broadcaster().CreateAccountBlock(transaction)
 }
 
 // Unconfirmed AccountBlocks

--- a/verifier/momentum.go
+++ b/verifier/momentum.go
@@ -209,7 +209,7 @@ func (rmv *rawMomentumVerifier) content(isDynamicPlasmaActive bool) error {
 		if err != nil {
 			return err
 		}
-		maxContent := config.MaxBasePlasmaInMomentum/constants.AccountBlockBasePlasma + config.MaxBasePlasmaInMomentum/constants.EmbeddedSimplePlasma
+		maxContent := config.MaxBasePlasmaInMomentum/constants.AccountBlockBasePlasma + dp.MaxContractBlocks(config)
 		if uint64(len(rmv.momentum.Content)) > maxContent {
 			return ErrMContentTooBig
 		}

--- a/verifier/momentum.go
+++ b/verifier/momentum.go
@@ -15,6 +15,8 @@ import (
 	"github.com/zenon-network/go-zenon/common/types"
 	"github.com/zenon-network/go-zenon/consensus"
 	"github.com/zenon-network/go-zenon/dp"
+	"github.com/zenon-network/go-zenon/vm/constants"
+	"github.com/zenon-network/go-zenon/vm/embedded/definition"
 	"github.com/zenon-network/go-zenon/wallet"
 )
 
@@ -195,6 +197,26 @@ func (rmv *rawMomentumVerifier) nextWorkPrice() error {
 	return nil
 }
 func (rmv *rawMomentumVerifier) content(isDynamicPlasmaActive bool) error {
+	// Cheap upper bound on content size before any allocation sized from
+	// attacker-supplied content. On the legacy path this is a fixed
+	// constant; on the dynamic-plasma path it's derived from the
+	// per-momentum plasma cap plus the contract-block count cap, since
+	// there's no fixed block count there.
+	var config *definition.PlasmaVariables
+	if isDynamicPlasmaActive {
+		var err error
+		config, err = rmv.momentumStore.GetPlasmaVariables()
+		if err != nil {
+			return err
+		}
+		maxContent := config.MaxBasePlasmaInMomentum/constants.AccountBlockBasePlasma + config.MaxBasePlasmaInMomentum/constants.EmbeddedSimplePlasma
+		if uint64(len(rmv.momentum.Content)) > maxContent {
+			return ErrMContentTooBig
+		}
+	} else if len(rmv.momentum.Content) > chain.MaxAccountBlocksInMomentum {
+		return ErrMContentTooBig
+	}
+
 	blocksLookup := make(map[types.HashHeight]*nom.AccountBlock, len(rmv.accountBlocks))
 
 	// insert all account-blocks in lookup map, rejecting duplicates so a repeated block can't be
@@ -237,11 +259,6 @@ func (rmv *rawMomentumVerifier) content(isDynamicPlasmaActive bool) error {
 			return err
 		}
 
-		config, err := rmv.momentumStore.GetPlasmaVariables()
-		if err != nil {
-			return err
-		}
-
 		plasma := dp.NewDynamicPlasma(previousMomentum, config)
 		contractBlockCount := uint64(0)
 		basePlasma := types.BasePlasma{Fusion: 0, Pow: 0}
@@ -256,11 +273,18 @@ func (rmv *rawMomentumVerifier) content(isDynamicPlasmaActive bool) error {
 				if err != nil {
 					return err
 				}
-				block.BasePlasma = canonical
-				if !plasma.ValidPrice(block) {
+				// Verify using a local copy priced at the canonical
+				// BasePlasma rather than mutating the caller's block: the
+				// caller owns detailed.AccountBlocks, and nothing here
+				// needs the field to persist past this check (the VM
+				// already set it to this same canonical value earlier,
+				// when the block was applied).
+				priced := *block
+				priced.BasePlasma = canonical
+				if !plasma.ValidPrice(&priced) {
 					return errors.Errorf("block price is too small")
 				}
-				basePlasma.Add(plasma.ComputeBasePlasma(block))
+				basePlasma.Add(plasma.ComputeBasePlasma(&priced))
 				if basePlasma.Total() > config.MaxBasePlasmaInMomentum {
 					return ErrMContentTooBig
 				}
@@ -275,10 +299,6 @@ func (rmv *rawMomentumVerifier) content(isDynamicPlasmaActive bool) error {
 		nextWorkPrice := plasma.NextWorkPrice(basePlasma.Pow)
 		if nextWorkPrice != rmv.momentum.NextWorkPrice {
 			return errors.Errorf("mismatch in momentum work price: have %d, want %d", nextWorkPrice, rmv.momentum.NextWorkPrice)
-		}
-	} else {
-		if len(rmv.momentum.Content) > chain.MaxAccountBlocksInMomentum {
-			return ErrMContentTooBig
 		}
 	}
 

--- a/verifier/momentum_test.go
+++ b/verifier/momentum_test.go
@@ -35,6 +35,16 @@ func (*stubMomentumStore) GetPlasmaVariables() (*definition.PlasmaVariables, err
 	}, nil
 }
 
+// tinyBudgetMomentumStore caps MaxBasePlasmaInMomentum at exactly one
+// user block's worth of plasma, so the derived content-size bound is 1.
+type tinyBudgetMomentumStore struct {
+	stubMomentumStore
+}
+
+func (*tinyBudgetMomentumStore) GetPlasmaVariables() (*definition.PlasmaVariables, error) {
+	return &definition.PlasmaVariables{MaxBasePlasmaInMomentum: 21000}, nil
+}
+
 // A momentum content header with no matching entry in the prefetched
 // account-blocks must be rejected with an error, not dereference a nil block.
 func TestRawMomentumVerifier_Content_MissingAccountBlock_ReturnsError(t *testing.T) {
@@ -252,6 +262,114 @@ func TestRawMomentumVerifier_Content_ForgedBasePlasma_ReturnsError(t *testing.T)
 	err := rmv.content(true)
 	if err == nil {
 		t.Fatal("expected an error for a momentum whose prices were derived from a forged wire base plasma, got nil")
+	}
+}
+
+// content() must not mutate the caller's account-block: it recomputes
+// canonical base plasma into a local copy for its own price checks, but
+// the BasePlasma field on the block the caller passed in (part of
+// detailed.AccountBlocks) must be left exactly as received.
+func TestRawMomentumVerifier_Content_DoesNotMutateInputBlock(t *testing.T) {
+	const (
+		wireBasePlasma = uint64(999999) // deliberately different from canonical
+		canonical      = uint64(21000)  // matches stubMomentumStore's FusedPlasmaTarget/PowPlasmaTarget
+	)
+
+	address := types.ParseAddressPanic("z1qph8dkja68pg3g6j4spwk9re0kjdkul0amwqnt")
+	blockHash := types.NewHash([]byte("block"))
+
+	block := &nom.AccountBlock{
+		Address:     address,
+		Hash:        blockHash,
+		Height:      1,
+		Difficulty:  0,
+		BasePlasma:  wireBasePlasma,
+		FusedPlasma: canonical,
+	}
+
+	momentum := &nom.Momentum{
+		Version: 2,
+		Content: nom.MomentumContent{
+			{
+				Address: address,
+				HashHeight: types.HashHeight{
+					Hash:   blockHash,
+					Height: 1,
+				},
+			},
+		},
+	}
+
+	config := &definition.PlasmaVariables{
+		MaxBasePlasmaInMomentum: 1_000_000_000,
+		FusedPlasmaTarget:       canonical,
+		PowPlasmaTarget:         canonical,
+		MaxPriceChangePercent:   10,
+		PriceChangeDenominator:  20,
+	}
+
+	// What content() itself computes internally once fixed to use the
+	// canonical value rather than the wire one.
+	honestBlock := &nom.AccountBlock{
+		Address:     address,
+		Hash:        blockHash,
+		Height:      1,
+		Difficulty:  0,
+		BasePlasma:  canonical,
+		FusedPlasma: canonical,
+	}
+	honestPlasma := dp.NewDynamicPlasma(&nom.Momentum{Version: 1}, config)
+	honestBasePlasma := types.BasePlasma{Fusion: 0, Pow: 0}
+	honestBasePlasma.Add(honestPlasma.ComputeBasePlasma(honestBlock))
+	momentum.NextFusionPrice = honestPlasma.NextFusionPrice(honestBasePlasma.Fusion)
+	momentum.NextWorkPrice = honestPlasma.NextWorkPrice(honestBasePlasma.Pow)
+
+	accountBlocks := []*nom.AccountBlock{block}
+
+	rmv := &rawMomentumVerifier{
+		momentum:      momentum,
+		accountBlocks: accountBlocks,
+		momentumStore: &stubMomentumStore{},
+		chain:         nil,
+		canonicalBasePlasma: func(chain.Chain, *nom.AccountBlock) (uint64, error) {
+			return canonical, nil
+		},
+	}
+
+	if err := rmv.content(true); err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if block.BasePlasma != wireBasePlasma {
+		t.Fatalf("content() mutated the caller's block: BasePlasma = %d, want unchanged %d", block.BasePlasma, wireBasePlasma)
+	}
+}
+
+// content()'s dynamic-plasma path must reject an oversized content list
+// with ErrMContentTooBig before doing any block-matching work, using a
+// cheap bound derived from the plasma config (there's no fixed
+// block-count constant once dynamic plasma is active, unlike the legacy
+// path). accountBlocks is deliberately left empty: the size-mismatch
+// check further down would also produce *an* error for this input, but
+// a different one - asserting the specific sentinel pins down that
+// rejection happens at the new early bound check, not incidentally
+// later.
+func TestRawMomentumVerifier_Content_DynamicPlasma_OversizedContentRejected(t *testing.T) {
+	momentum := &nom.Momentum{
+		Version: 2,
+		Content: nom.MomentumContent{
+			{Address: types.ZeroAddress, HashHeight: types.HashHeight{Hash: types.NewHash([]byte("a")), Height: 1}},
+			{Address: types.ZeroAddress, HashHeight: types.HashHeight{Hash: types.NewHash([]byte("b")), Height: 1}},
+		},
+	}
+
+	rmv := &rawMomentumVerifier{
+		momentum:      momentum,
+		accountBlocks: nil,
+		momentumStore: &tinyBudgetMomentumStore{},
+	}
+
+	if err := rmv.content(true); err != ErrMContentTooBig {
+		t.Fatalf("expected ErrMContentTooBig for oversized dynamic-plasma content, got %v", err)
 	}
 }
 

--- a/vm/embedded/embedded.go
+++ b/vm/embedded/embedded.go
@@ -205,11 +205,16 @@ func getOrigin() map[types.Address]*embeddedImplementation {
 }
 
 const (
-	acceleratorSporkBit         = 1 << 0
-	bridgeAndLiquiditySporkBit  = 1 << 1
-	htlcSporkBit                = 1 << 2
-	dynamicPlasmaSporkBit       = 1 << 3
-	embeddedVariantCombinations = 16 // one map per combination of the 4 spork bits above
+	// One bit per spork GetEmbeddedMethod consults, followed by
+	// embeddedVariantCombinations, which iota makes 1 << (number of bits
+	// above) — the size of the precomputed variant table. Add a new spork
+	// bit anywhere above that last line and the table grows with it.
+	acceleratorSporkBit = 1 << iota
+	bridgeAndLiquiditySporkBit
+	htlcSporkBit
+	dynamicPlasmaSporkBit
+
+	embeddedVariantCombinations
 )
 
 var (

--- a/vm/embedded/embedded.go
+++ b/vm/embedded/embedded.go
@@ -1,6 +1,8 @@
 package embedded
 
 import (
+	"sync"
+
 	"github.com/zenon-network/go-zenon/chain/nom"
 	"github.com/zenon-network/go-zenon/common/types"
 	"github.com/zenon-network/go-zenon/vm/abi"
@@ -202,15 +204,41 @@ func getOrigin() map[types.Address]*embeddedImplementation {
 	}
 }
 
-// getAllEmbedded returns the fully merged contract map with all spork diffs applied.
-// Used by tests to introspect the complete set of contract methods.
-func getAllEmbedded() map[types.Address]*embeddedImplementation {
-	contractsMap := getOrigin()
-	applyAcceleratorDiffs(contractsMap)
-	applyBridgeAndLiquidityDiffs(contractsMap)
-	applyHtlcDiffs(contractsMap)
-	applyDynamicPlasmaDiffs(contractsMap)
-	return contractsMap
+const (
+	acceleratorSporkBit         = 1 << 0
+	bridgeAndLiquiditySporkBit  = 1 << 1
+	htlcSporkBit                = 1 << 2
+	dynamicPlasmaSporkBit       = 1 << 3
+	embeddedVariantCombinations = 16 // one map per combination of the 4 spork bits above
+)
+
+var (
+	embeddedVariantsOnce sync.Once
+	embeddedVariants     [embeddedVariantCombinations]map[types.Address]*embeddedImplementation
+)
+
+// buildEmbeddedVariants precomputes the merged contract map for every
+// combination of the 4 sporks GetEmbeddedMethod consults, so a call
+// only ever does an array lookup rather than rebuilding the map (10
+// contracts, ~60 method structs) from scratch every time. Runs once,
+// lazily, guarded by embeddedVariantsOnce.
+func buildEmbeddedVariants() {
+	for key := 0; key < embeddedVariantCombinations; key++ {
+		contractsMap := getOrigin()
+		if key&acceleratorSporkBit != 0 {
+			applyAcceleratorDiffs(contractsMap)
+		}
+		if key&bridgeAndLiquiditySporkBit != 0 {
+			applyBridgeAndLiquidityDiffs(contractsMap)
+		}
+		if key&htlcSporkBit != 0 {
+			applyHtlcDiffs(contractsMap)
+		}
+		if key&dynamicPlasmaSporkBit != 0 {
+			applyDynamicPlasmaDiffs(contractsMap)
+		}
+		embeddedVariants[key] = contractsMap
+	}
 }
 
 // GetEmbeddedMethod finds method instance of embedded contract by address and abiSelector
@@ -222,28 +250,23 @@ func GetEmbeddedMethod(context vm_context.AccountVmContext, address types.Addres
 		return nil, constants.ErrNotContractAddress
 	}
 
-	// changing from fast assignment to doing merges
-	// how often is this called? better to only do once/as needed?
+	embeddedVariantsOnce.Do(buildEmbeddedVariants)
 
-	// the code before assumed a linear activation of sporks
-	// accelerator, bridge-liq, then htlc
-	// this will allow us to activate them independently on hyperqubes
-	// although other implicit dependencies may exist
-
-	contractsMap := getOrigin()
+	key := 0
 	if context.IsAcceleratorSporkEnforced() {
-		applyAcceleratorDiffs(contractsMap)
+		key |= acceleratorSporkBit
 	}
 	if context.IsBridgeAndLiquiditySporkEnforced() {
-		applyBridgeAndLiquidityDiffs(contractsMap)
+		key |= bridgeAndLiquiditySporkBit
 	}
 	if context.IsHtlcSporkEnforced() {
-		applyHtlcDiffs(contractsMap)
+		key |= htlcSporkBit
 	}
 	if context.IsDynamicPlasmaSporkEnforced() {
-		applyDynamicPlasmaDiffs(contractsMap)
+		key |= dynamicPlasmaSporkBit
 	}
 	// No change for NoPillarRegSpork
+	contractsMap := embeddedVariants[key]
 
 	// contract address must exist in map
 	if p, found := contractsMap[address]; found {

--- a/vm/embedded/embedded_test.go
+++ b/vm/embedded/embedded_test.go
@@ -7,7 +7,20 @@ import (
 	"testing"
 
 	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/common/types"
 )
+
+// getAllEmbedded returns the fully merged contract map with all spork
+// diffs applied, for tests that introspect the complete set of contract
+// methods.
+func getAllEmbedded() map[types.Address]*embeddedImplementation {
+	contractsMap := getOrigin()
+	applyAcceleratorDiffs(contractsMap)
+	applyBridgeAndLiquidityDiffs(contractsMap)
+	applyHtlcDiffs(contractsMap)
+	applyDynamicPlasmaDiffs(contractsMap)
+	return contractsMap
+}
 
 func TestDumpContractsABIMethods(t *testing.T) {
 	dumps := make([]string, 0)

--- a/vm/embedded/tests/dp_test.go
+++ b/vm/embedded/tests/dp_test.go
@@ -22,7 +22,7 @@ func activateDynamicPlasma(t *testing.T, z mock.MockZenon) {
 		Address:   g.Spork.Address,
 		ToAddress: types.SporkContract,
 		Data: definition.ABISpork.PackMethodPanic(definition.SporkCreateMethodName,
-			"dynamic-plasma",              // name
+			"dynamic-plasma",           // name
 			"Activates Dynamic Plasma", // description
 		),
 	}, nil, mock.SkipVmChanges)

--- a/vm/embedded/tests/rpc_ledger_test.go
+++ b/vm/embedded/tests/rpc_ledger_test.go
@@ -2,10 +2,12 @@ package tests
 
 import (
 	"encoding/json"
+	"errors"
 	"math/big"
 	"testing"
 	"time"
 
+	"github.com/zenon-network/go-zenon/chain"
 	g "github.com/zenon-network/go-zenon/chain/genesis/mock"
 	"github.com/zenon-network/go-zenon/chain/nom"
 	"github.com/zenon-network/go-zenon/common"
@@ -229,6 +231,46 @@ func TestRPCLedger_PublishRawTransaction(t *testing.T) {
   "signature": "130sas2Jlmu5AC5SsvJ3I0m31WtvzTKmB3DfoAROQ7kuvx/Hd/g+eZn5rSW5+o5jxV5BJtq1vITs/3lCieGaAw=="
 }`), a))
 	common.FailIfErr(t, ledgerApi.PublishRawTransaction(a))
+}
+
+// A block the pool rejects is reported to the RPC caller as an error.
+func TestRPCLedger_PublishRawTransactionReportsPoolRejection(t *testing.T) {
+	saveChainGlobals(t)
+	chain.MaxUncommittedBlocksPerAccount = 0
+
+	z := mock.NewMockZenon(t)
+	ledgerApi := api.NewLedgerApi(z)
+	defer z.StopPanic()
+
+	a := &api.AccountBlock{}
+	common.FailIfErr(t, json.Unmarshal([]byte(`
+{
+  "version": 1,
+  "chainIdentifier": 100,
+  "blockType": 2,
+  "hash": "6e9bf5f7512931a4b74d3d1dd20b0f8105a006b1ae059e1535f935e283f2a66c",
+  "previousHash": "598fa623dd308bec7163bb375aa7546ec4aced3b71a1c9278709903e69280dbd",
+  "height": 2,
+  "momentumAcknowledged": {
+    "hash": "0385d849ee33b94c8783288c148e3ae741c2ecec98b08b3f59d6bcc219168fe5",
+    "height": 1
+  },
+  "address": "z1qzal6c5s9rjnnxd2z7dvdhjxpmmj4fmw56a0mz",
+  "toAddress": "z1qr4pexnnfaexqqz8nscjjcsajy5hdqfkgadvwx",
+  "amount": "10000000000",
+  "tokenStandard": "zts1znnxxxxxxxxxxxxx9z4ulx",
+  "fromBlockHash": "0000000000000000000000000000000000000000000000000000000000000000",
+  "data": "",
+  "fusedPlasma": 21000,
+  "difficulty": 0,
+  "nonce": "0000000000000000",
+  "publicKey": "GYyn77OXTL31zPbDBCe/eKir+VCF3hv+LxiOUF3XcJY=",
+  "signature": "130sas2Jlmu5AC5SsvJ3I0m31WtvzTKmB3DfoAROQ7kuvx/Hd/g+eZn5rSW5+o5jxV5BJtq1vITs/3lCieGaAw=="
+}`), a))
+
+	err := ledgerApi.PublishRawTransaction(a)
+	common.ExpectTrue(t, err != nil)
+	common.ExpectTrue(t, errors.Is(err, chain.ErrFailedToAddAccountBlockTransaction))
 }
 
 func ExpectGetFrontierAccountBlock(t *testing.T, z mock.MockZenon) {

--- a/vm/embedded/tests/simple_test.go
+++ b/vm/embedded/tests/simple_test.go
@@ -512,7 +512,7 @@ t=2001-09-09T01:46:40+0000 lvl=eror msg="failed to insert own account-block." mo
 
 	// MaxUncommittedBlocksPerAccount pending blocks are allowed; the one that
 	// would push the count past it is rejected.
-	for i := 0; i < int(chain.MaxUncommittedBlocksPerAccount)+1; i += 1 {
+	for i := 0; i < int(chain.MaxUncommittedBlocksPerAccount); i += 1 {
 		z.InsertSendBlock(&nom.AccountBlock{
 			Address:       g.User1.Address,
 			ToAddress:     g.User2.Address,
@@ -520,6 +520,12 @@ t=2001-09-09T01:46:40+0000 lvl=eror msg="failed to insert own account-block." mo
 			Amount:        big.NewInt(1500 * g.Zexp),
 		}, nil, mock.SkipVmChanges)
 	}
+	z.InsertSendBlockRejected(&nom.AccountBlock{
+		Address:       g.User1.Address,
+		ToAddress:     g.User2.Address,
+		TokenStandard: types.ZnnTokenStandard,
+		Amount:        big.NewInt(1500 * g.Zexp),
+	}, chain.ErrFailedToAddAccountBlockTransaction)
 
 	frontierAccBlock, err := ledgerApi.GetFrontierAccountBlock(g.User1.Address)
 	common.FailIfErr(t, err)

--- a/vm/embedded/tests/z_bridge_test.go
+++ b/vm/embedded/tests/z_bridge_test.go
@@ -2028,7 +2028,7 @@ func TestBridge_GetAllUnwrapTokenRequests_SortStability(t *testing.T) {
 	const tieCount = 12
 	tieHashes := make([]types.Hash, tieCount)
 	for i := 0; i < tieCount; i++ {
-		hex := fmt.Sprintf("%02x" + "01010101010101010101010101010101010101010101010101010101010101", i)
+		hex := fmt.Sprintf("%02x"+"01010101010101010101010101010101010101010101010101010101010101", i)
 		tieHashes[i] = types.HexToHashPanic(hex)
 		signature := getUnwrapTokenSignature(t, networkClass, chainId, tieHashes[i], 200, tokenAddress, amount, networkClass)
 		defer z.CallContract(unwrapToken(networkClass, chainId, tieHashes[i], 200, tokenAddress, amount, signature)).

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -64,7 +64,9 @@ func enoughPlasma(context vm_context.AccountVmContext, block *nom.AccountBlock) 
 		} else {
 			available, err = AvailablePlasma(context.CacheStore(), context)
 		}
-		common.DealWithErr(err)
+		if err != nil {
+			return err
+		}
 		if available < block.FusedPlasma {
 			return constants.ErrNotEnoughPlasma
 		}

--- a/zenon/mock/interfaces.go
+++ b/zenon/mock/interfaces.go
@@ -16,6 +16,7 @@ type MockZenon interface {
 
 	CallContract(template *nom.AccountBlock) *common.Expecter
 	InsertSendBlock(template *nom.AccountBlock, expectedError error, expectedVmChanges string) *nom.AccountBlock
+	InsertSendBlockRejected(template *nom.AccountBlock, expectedError error)
 	InsertReceiveBlock(fromHeader types.AccountHeader, template *nom.AccountBlock, expectedError error, expectedVmChanges string) *nom.AccountBlock
 
 	SaveLogs(logger common.Logger) *common.Expecter

--- a/zenon/mock/zenon.go
+++ b/zenon/mock/zenon.go
@@ -130,6 +130,15 @@ type mockZenon struct {
 	loggers              []log15.Logger
 	handlers             []log15.Handler
 	initialEpochDuration time.Duration
+
+	// failInsertFor, when non-nil, makes CreateAccountBlock reject every
+	// block for that account address with an injected error instead of
+	// inserting it. Test-only fault injection for the pillar worker's
+	// insert-failure handling. Set it before the momentum round that
+	// should observe the failure: InsertNewMomentum runs the worker on
+	// its own goroutine and waits for it, so a write from the test
+	// goroutine before that call is ordered ahead of every read.
+	failInsertFor *types.Address
 }
 
 func (zenon *mockZenon) SyncInfo() *protocol.SyncInfo {
@@ -158,6 +167,9 @@ func (zenon *mockZenon) CreateMomentum(momentumTransaction *nom.MomentumTransact
 	}
 }
 func (zenon *mockZenon) CreateAccountBlock(accountBlockTransaction *nom.AccountBlockTransaction) error {
+	if zenon.failInsertFor != nil && accountBlockTransaction.Block.Address == *zenon.failInsertFor {
+		return fmt.Errorf("injected insert failure for %v", *zenon.failInsertFor)
+	}
 	insert := zenon.chain.AcquireInsert("mock-zenon create-account-block")
 	defer insert.Unlock()
 	err := zenon.chain.AddAccountBlockTransaction(insert, accountBlockTransaction)

--- a/zenon/mock/zenon.go
+++ b/zenon/mock/zenon.go
@@ -239,10 +239,24 @@ func (zenon *mockZenon) InsertSendBlock(template *nom.AccountBlock, expectedErro
 		if expectedVmChanges != SkipVmChanges {
 			common.ExpectString(zenon.t, db.DebugPatch(transaction.Changes), expectedVmChanges)
 		}
-		zenon.CreateAccountBlock(transaction)
+		common.FailIfErr(zenon.t, zenon.CreateAccountBlock(transaction))
 		return transaction.Block
 	}
 	return nil
+}
+
+// InsertSendBlockRejected generates a send block from template and
+// requires the account pool to reject it with expectedError. Its
+// counterpart InsertSendBlock requires the insert to succeed.
+func (zenon *mockZenon) InsertSendBlockRejected(template *nom.AccountBlock, expectedError error) {
+	template.BlockType = nom.BlockTypeUserSend
+	transaction, err := zenon.supervisor.GenerateFromTemplate(template, getSignFunc(template.Address))
+	common.FailIfErr(zenon.t, err)
+	// errors.Is, not common.ExpectError: the pool returns some rejections
+	// as-is and others wrapped with %w around a sentinel.
+	if err := zenon.CreateAccountBlock(transaction); !errors.Is(err, expectedError) {
+		zenon.t.Fatalf("expected block %v to be rejected with '%v' but got '%v'", transaction.Block.Header(), expectedError, err)
+	}
 }
 func (zenon *mockZenon) InsertReceiveBlock(fromHeader types.AccountHeader, template *nom.AccountBlock, expectedError error, expectedVmChanges string) *nom.AccountBlock {
 	store := zenon.chain.GetFrontierAccountStore(fromHeader.Address)
@@ -276,7 +290,7 @@ func (zenon *mockZenon) InsertReceiveBlock(fromHeader types.AccountHeader, templ
 		if expectedVmChanges != SkipVmChanges {
 			common.ExpectString(zenon.t, db.DebugPatch(transaction.Changes), expectedVmChanges)
 		}
-		zenon.CreateAccountBlock(transaction)
+		common.FailIfErr(zenon.t, zenon.CreateAccountBlock(transaction))
 		return transaction.Block
 	}
 	return nil

--- a/zenon/mock/zenon.go
+++ b/zenon/mock/zenon.go
@@ -157,7 +157,7 @@ func (zenon *mockZenon) CreateMomentum(momentumTransaction *nom.MomentumTransact
 		zenon.log.Info("added block to momentum", "momentum-height", momentumTransaction.Momentum.Height, "identifier", block)
 	}
 }
-func (zenon *mockZenon) CreateAccountBlock(accountBlockTransaction *nom.AccountBlockTransaction) {
+func (zenon *mockZenon) CreateAccountBlock(accountBlockTransaction *nom.AccountBlockTransaction) error {
 	insert := zenon.chain.AcquireInsert("mock-zenon create-account-block")
 	defer insert.Unlock()
 	err := zenon.chain.AddAccountBlockTransaction(insert, accountBlockTransaction)
@@ -169,6 +169,7 @@ func (zenon *mockZenon) CreateAccountBlock(accountBlockTransaction *nom.AccountB
 	if err != nil {
 		zenon.log.Error("failed to insert own account-block.", "reason", err)
 	}
+	return err
 }
 
 func (zenon *mockZenon) InsertNewMomentum() {

--- a/zenon/mock/zenon_test.go
+++ b/zenon/mock/zenon_test.go
@@ -100,3 +100,35 @@ t=2001-09-09T01:48:10+0000 lvl=eror msg="failed to update contracts" module=pill
 
 	z.InsertMomentumsTo(10)
 }
+
+func TestProducerContinuesAfterFailedContractInsert(t *testing.T) {
+	time.Local = time.UTC
+	z := NewMockZenon(t)
+	defer z.StopPanic()
+	constants.UpdateMinNumMomentums = 5
+	z.InsertMomentumsTo(5) // warm-up: reaches the round that autoreceives
+
+	addr := types.PillarContract
+	z.(*mockZenon).failInsertFor = &addr
+
+	defer z.SaveLogs(common.PillarLogger).HideHashes().Equals(t, `
+t=2001-09-09T01:47:20+0000 lvl=info msg="producing momentum" module=pillar submodule=worker event="{StartTime:2001-09-09 01:47:30 +0000 UTC EndTime:2001-09-09 01:47:40 +0000 UTC Producer:z1qqq43dyrswfehx9w9td43exflqzcxrt7g6alah Name:}"
+t=2001-09-09T01:47:20+0000 lvl=info msg="broadcasting own momentum" module=pillar submodule=worker identifier="{Hash:XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX Height:6}"
+t=2001-09-09T01:47:30+0000 lvl=info msg="start creating autoreceive blocks" module=pillar submodule=worker
+t=2001-09-09T01:47:30+0000 lvl=info msg="generated embedded-block" module=pillar submodule=worker send-block-header="{Address:z1qz8v73ea2vy2rrlq7skssngu8cm8mknjjkr2ju HashHeight:{Hash:XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX Height:2}}" identifier="{Address:z1qxemdeddedxpyllarxxxxxxxxxxxxxxxsy3fmg HashHeight:{Hash:XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX Height:2}}" send-block-hash=XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX returned-error=nil
+t=2001-09-09T01:47:30+0000 lvl=eror msg="unable to insert autoreceive block for contract" module=pillar submodule=worker contract-address=z1qxemdeddedxpyllarxxxxxxxxxxxxxxxsy3fmg reason="injected insert failure for z1qxemdeddedxpyllarxxxxxxxxxxxxxxxsy3fmg"
+t=2001-09-09T01:47:30+0000 lvl=info msg="generated embedded-block" module=pillar submodule=worker send-block-header="{Address:z1qz8v73ea2vy2rrlq7skssngu8cm8mknjjkr2ju HashHeight:{Hash:XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX Height:4}}" identifier="{Address:z1qxemdeddedxsentynelxxxxxxxxxxxxxwy0r2r HashHeight:{Hash:XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX Height:1}}" send-block-hash=XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX returned-error=nil
+t=2001-09-09T01:47:30+0000 lvl=info msg="created autoreceive-block" module=pillar submodule=worker identifier="{Address:z1qxemdeddedxsentynelxxxxxxxxxxxxxwy0r2r HashHeight:{Hash:XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX Height:1}}"
+t=2001-09-09T01:47:30+0000 lvl=info msg="generated embedded-block" module=pillar submodule=worker send-block-header="{Address:z1qz8v73ea2vy2rrlq7skssngu8cm8mknjjkr2ju HashHeight:{Hash:XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX Height:3}}" identifier="{Address:z1qxemdeddedxstakexxxxxxxxxxxxxxxxjv8v62 HashHeight:{Hash:XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX Height:1}}" send-block-hash=XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX returned-error=nil
+t=2001-09-09T01:47:30+0000 lvl=info msg="created autoreceive-block" module=pillar submodule=worker identifier="{Address:z1qxemdeddedxstakexxxxxxxxxxxxxxxxjv8v62 HashHeight:{Hash:XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX Height:1}}"
+t=2001-09-09T01:47:30+0000 lvl=info msg="generated embedded-block" module=pillar submodule=worker send-block-header="{Address:z1qz8v73ea2vy2rrlq7skssngu8cm8mknjjkr2ju HashHeight:{Hash:XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX Height:5}}" identifier="{Address:z1qxemdeddedxlyquydytyxxxxxxxxxxxxflaaae HashHeight:{Hash:XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX Height:1}}" send-block-hash=XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX returned-error=nil
+t=2001-09-09T01:47:30+0000 lvl=info msg="created autoreceive-block" module=pillar submodule=worker identifier="{Address:z1qxemdeddedxlyquydytyxxxxxxxxxxxxflaaae HashHeight:{Hash:XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX Height:1}}"
+t=2001-09-09T01:47:30+0000 lvl=info msg="generated embedded-block" module=pillar submodule=worker send-block-header="{Address:z1qz8v73ea2vy2rrlq7skssngu8cm8mknjjkr2ju HashHeight:{Hash:XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX Height:2}}" identifier="{Address:z1qxemdeddedxpyllarxxxxxxxxxxxxxxxsy3fmg HashHeight:{Hash:XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX Height:2}}" send-block-hash=XXXHASHXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX returned-error=nil
+t=2001-09-09T01:47:30+0000 lvl=eror msg="unable to insert autoreceive block for contract" module=pillar submodule=worker contract-address=z1qxemdeddedxpyllarxxxxxxxxxxxxxxxsy3fmg reason="injected insert failure for z1qxemdeddedxpyllarxxxxxxxxxxxxxxxsy3fmg"
+t=2001-09-09T01:47:30+0000 lvl=info msg="checking if can update contracts" module=pillar submodule=worker
+t=2001-09-09T01:47:30+0000 lvl=info msg="producing block to update embedded-contract" module=pillar submodule=worker contract-address=z1qxemdeddedxpyllarxxxxxxxxxxxxxxxsy3fmg
+t=2001-09-09T01:47:30+0000 lvl=info msg="producing block to update embedded-contract" module=pillar submodule=worker contract-address=z1qxemdeddedxaccelerat0rxxxxxxxxxxp4tk22
+t=2001-09-09T01:47:30+0000 lvl=eror msg="failed to update contracts" module=pillar submodule=worker reason="method not found in the abi"
+`)
+	z.InsertNewMomentum()
+}


### PR DESCRIPTION
This PR addresses the comments along with some additional findings from https://github.com/zenon-network/go-zenon/pull/73

## @0x3639's comments

### MaxPeers / MaxPendingPeers enforced only after the Zenon handshake

Confirmed. `p2p/libp2p/server.go` built the libp2p host with no `ConnectionManager`, so `MaxPeers`/`MaxPendingPeers` only ever looked at `peerMap`, which is populated *after* the `/znn/eth/1` handshake completes — raw connections that never spoke Zenon were invisible to both limits. Worse, `MaxPendingPeers` turned out to be a single global counter held per *stream* for the full 30s handshake read timeout, so one peer opening a handful of stalled streams could exhaust the global pending budget and deny every other inbound handshake on the node.

Fixed:
- Capped concurrent pending handshakes at one per remote `peer.ID` (`handleStream` in `server.go`), so a single connection can no longer hold more than one pending slot no matter how many streams it opens.
- Cut the handshake read deadline from the steady-state 30s down to 5s (new `handshakeTimeout` constant; `stream_rw.go` gained `ReadMsgLimitedTimeout` to support it).
- `ClosePeer` on handshake failure, so a retry needs a fresh TCP connection rather than reusing the same one indefinitely.
- Added a libp2p `ConnectionManager` sized from `MaxPeers`/`MaxPendingPeers`, and `Protect()`/`Unprotect()` adopted Zenon peers on adoption/disconnect, so libp2p's own trimmer can no longer evict a real peer to make room for an unauthenticated connection sitting inside the default grace period.
- Regression test: `TestPendingHandshakeCapPerPeer` (`p2p/libp2p/server_test.go`) — a raw libp2p host opens 5 stalled streams on one connection; a legitimate peer must still be able to complete its handshake concurrently. Verified it fails on the old code and passes on the fix.

### Uncommitted-block cap rejects valid replacements

Confirmed. `chain/account_pool.go`'s `checkUncommittedBlocksCount` ran unconditionally before branching into fast-forward / duplicate / rollback, so at the 500-block cap it rejected both a higher-priced replacement (which *shortens* the pending chain via rollback) and an idempotent resubmission of an already-inserted block.

Fixed:
- Moved the check inside the fast-forward branch only (`addAccountBlockTransaction` in `account_pool.go`) — replacements and duplicates are no longer gated by it at all, since neither grows the uncommitted chain.
- Dropped the equivalent pre-check in `rpc/api/ledger.go`'s `PublishRawTransaction`: it ran *before* the account-pool insert and would have kept blocking valid replacements/duplicates at the RPC layer even after the pool-level fix, since it couldn't tell fast-forward from replacement either. The pool's own check is synchronous and authoritative for every call path, so this was purely redundant.
- Removed the now-unused `CheckUncommittedBlocksCount` method from the `Chain` interface and its implementation.
- Regression test: `TestAccountPool_ReplacementAndDuplicateAcceptedAtCap` (`chain/account_pool_test.go`) — fills an account to the cap, then verifies both a duplicate resubmission and a same-height higher-priced replacement are accepted. Verified it fails on the old ordering and passes on the fix.

## Additional issues found while reviewing

- **Pool replacement ranking mismatch** (`chain/account_pool.go`) — `higherPriority` still used the legacy `TotalPlasma`/`BasePlasma` ratio for replacement decisions even after dynamic plasma activates, disagreeing with the `dp.HigherPrice`-based rule that actually decides momentum inclusion. Made it spork-aware: once `DynamicPlasmaSpork` is active it defers to `dp.HigherPrice` (via a widened `Stable` interface exposing `GetFrontierMomentumStore`), falling back to the legacy ratio pre-activation or when the store can't answer (e.g. genesis construction).

- **`GetEmbeddedMethod` rebuilt the whole contract map on every call** (`vm/embedded/embedded.go`) — this sits on the per-block plasma path (including the new `CanonicalBasePlasma` check, which calls it once per block during momentum verification), and was reallocating ~10 contracts / ~60 method structs every time. Memoized all 16 spork-combination variants behind a `sync.Once`, so a call is now an array lookup.

- **Content-selector comparator wasn't a strict weak ordering** (`pillar/content_selector.go`) — `higherPriority` mixed a same-address height rule with a cross-address price rule, which admits 3-cycles (a cheap low-height block and an expensive high-height block from the same address can each rank differently against a third address' block priced between them). `sort.SliceStable` over that comparator could separate a block from its own ancestor, leaving a gap the producer's own chain-order check would then reject the whole momentum for. Rewrote `sortBlocksByPriority` to group blocks by address first (each group ordered by height), then order the *groups* by their lowest-height block's price — this makes the comparator total. Added `TestContent_sortBlocksByPriority_NoGapAcrossThirdAddress`, verified it fails on the old comparator and passes on the fix.

- **Plasma-availability error converted into a panic** (`vm/vm.go`) — `enoughPlasma` switched a `return err` into `common.DealWithErr(err)`, turning a clean block rejection (including the data-dependent "got negative available plasma" case) into a hard panic on a path that processes every remote account block. Restored `return err`.

- **`ValidPrice` uint64 overflow** (`dp/dp.go`) — `AccountBlockBasePlasma * fusionPrice` was computed in raw uint64, which overflows and silently wraps the minimum-price floor down to a small value at extreme (governance-settable) prices — exactly defeating the check when it matters most. Now computed in `big.Int` and saturated at `MaxUint64` on overflow (fail closed instead of fail open). Added `TestValidPrice` and `TestValidPrice_OverflowSaturatesInsteadOfWrappingToZero`.

- **Verifier mutating its input, and a dropped size pre-check** (`verifier/momentum.go`) — `content()` wrote the recomputed canonical `BasePlasma` directly into the caller's block (harmless today since nothing downstream reads it afterward, but a landmine for any future caller that shares block pointers). It now uses a local shallow copy for its own price checks instead. Also restored a cheap content-length bound on the dynamic-plasma path *before* building the lookup maps/slices — previously only the legacy path had an upfront size check, so the dynamic-plasma path allocated at attacker-supplied content size before any bound applied. Added `TestRawMomentumVerifier_Content_DoesNotMutateInputBlock` and `TestRawMomentumVerifier_Content_DynamicPlasma_OversizedContentRejected`, both verified against the pre-fix code.

- **Peer database unbounded growth, pure-recency seed selection** (`p2p/libp2p/peerdb.go`) — every handshaked peer was recorded with no cap on total records, and `seeds()` ranked candidates purely by `lastSeen`, letting a source that cycles many identities through the handshake dominate a restarting node's warm-bootstrap dial list. Capped the database at 2000 records (oldest evicted during the existing hourly `expire()` pass), and reworked `seeds()` to group candidates by /24 (IPv4) or /48 (IPv6) subnet and select round-robin across subnets rather than taking a pure recency-ranked prefix. Added `TestPeerDBExpireCapsRecordCount` and `TestPeerDBSeedsDiversifyAcrossSubnets`.

- **Formatting / naming cleanup** — `gofmt -w` on the files this PR touched that weren't clean (`common/types/spork.go`, `p2p/legacy/nat/nat.go`, `p2p/legacy/peer.go`, `p2p/legacy/server.go`, `vm/embedded/tests/dp_test.go`, `vm/embedded/tests/z_bridge_test.go`); renamed the bug-numbered switcher tests (`TestStopPreActivation_Bug1` → `TestStopDoesNotDeadlockBeforeActivation`, etc.) to describe behaviour instead of a past review round; moved `getAllEmbedded()` out of production code into `embedded_test.go`, since it exists solely for test introspection.

## Verification

Every fix was checked with `go build`/`go vet` plus the relevant package's existing test suite, and I added regression tests for the ones above where it was practical to write one — for the higher-severity fixes (P2P handshake cap, account-pool cap ordering, content-selector cycle, `ValidPrice` overflow, verifier mutation, peer-DB cap/diversity) I also confirmed each new test actually discriminates: it fails against the pre-fix code and passes against the fix, not just "returns no error" either way. Full repo test suite is clean (excluding the pre-existing, unrelated `p2p/legacy/nat` UPnP test hang on macOS that's already flagged in this thread).

One more item from the review I'm handling directly rather than through this PR: `GovernanceAddress`. I'll follow up separately once I've settled on the right address for testnet.
