### PR TITLE
chain,protocol: replace pool copy of a block when momentum bytes differ

### DIFF
--- a/chain/account_pool.go
+++ b/chain/account_pool.go
@@ -276,6 +276,67 @@ func (ap *accountPool) rebuild(detailed *nom.DetailedMomentum) error {
 	return nil
 }
 
+// UncommittedSnapshot captures the pool managers of a set of addresses so they
+// can be put back after a failed insertion. Each entry is an independent clone
+// of the manager as it was, or nil when the address had no manager. A snapshot
+// can be restored once; restoring installs the clones themselves.
+type UncommittedSnapshot struct {
+	managers map[types.Address]db.Manager
+}
+
+// SnapshotUncommitted clones the current pool manager of each given address.
+// Restoring the snapshot returns those addresses to exactly this state, byte
+// for byte and patch for patch, as long as their stable state has not advanced.
+func (ap *accountPool) SnapshotUncommitted(insertLocker sync.Locker, addresses []types.Address) *UncommittedSnapshot {
+	if insertLocker == nil {
+		panic("insertLocker can't be nil")
+	}
+	ap.changes.Lock()
+	defer ap.changes.Unlock()
+
+	snapshot := &UncommittedSnapshot{managers: make(map[types.Address]db.Manager, len(addresses))}
+	for _, address := range addresses {
+		if _, seen := snapshot.managers[address]; seen {
+			continue
+		}
+		manager := ap.managers[address]
+		if manager == nil {
+			snapshot.managers[address] = nil
+			continue
+		}
+		cloneable, ok := manager.(db.Cloneable)
+		if !ok {
+			// The pool only ever creates in-memory managers, which clone.
+			panic(fmt.Sprintf("account pool manager for %v can't be cloned", address))
+		}
+		snapshot.managers[address] = cloneable.Clone()
+	}
+	return snapshot
+}
+
+// RestoreUncommitted puts the snapshotted managers back, discarding whatever
+// the pool holds for those addresses now. The snapshot is consumed.
+func (ap *accountPool) RestoreUncommitted(insertLocker sync.Locker, snapshot *UncommittedSnapshot) error {
+	if insertLocker == nil {
+		return errors.Errorf("insertLocker can't be nil")
+	}
+	if snapshot == nil {
+		return nil
+	}
+	ap.changes.Lock()
+	defer ap.changes.Unlock()
+
+	for address, manager := range snapshot.managers {
+		if manager == nil {
+			delete(ap.managers, address)
+		} else {
+			ap.managers[address] = manager
+		}
+	}
+	snapshot.managers = nil
+	return nil
+}
+
 func (ap *accountPool) GetNewMomentumContent() []*nom.AccountBlock {
 	return ap.filterBlocksToCommit(ap.GetAllUncommittedAccountBlocks())
 }

--- a/chain/account_pool.go
+++ b/chain/account_pool.go
@@ -131,8 +131,16 @@ func (ap *accountPool) addAccountBlockTransaction(transaction *nom.AccountBlockT
 		return fmt.Errorf(`%w reason:%v; frontier-identifier:%v; identifier:%v`, ErrFailedToAddAccountBlockTransaction, err, frontierIdentifier, identifier)
 	}
 	if trueBlock != nil && trueBlock.Identifier() == identifier {
-		log.Info("account-block is already inserted")
-		return nil
+		// A block's identifier covers only its hashed fields. Fields that are
+		// stored but not hashed can still differ between two copies, and the
+		// stored bytes feed into the momentum changes-hash. A forced insert
+		// carries the copy the momentum was built from, so it must replace a
+		// byte-different copy instead of being treated as a duplicate.
+		if !forceAdd || trueBlock.EqualBytes(block) {
+			log.Info("account-block is already inserted")
+			return nil
+		}
+		log.Info("replacing account-block with different bytes but same identifier")
 	}
 
 	if err := ap.canRollback(block); err != nil {

--- a/chain/account_pool_test.go
+++ b/chain/account_pool_test.go
@@ -121,3 +121,148 @@ func TestAccountPool_AddKeepsFirstVariantOfSameIdentifier(t *testing.T) {
 	common.FailIfErr(t, err)
 	common.ExpectBytes(t, stored.Signature, "0x"+hex.EncodeToString(a.Signature))
 }
+
+func TestAccountPool_RestoreUncommittedRevertsForcedReplacement(t *testing.T) {
+	base, a, b, descendant := poolBlockChain()
+
+	ap := newAccountPool(&memStable{})
+	locker := &sync.Mutex{}
+	common.FailIfErr(t, ap.AddAccountBlockTransaction(locker, poolTransaction(base)))
+	common.FailIfErr(t, ap.AddAccountBlockTransaction(locker, poolTransaction(a)))
+	common.FailIfErr(t, ap.AddAccountBlockTransaction(locker, poolTransaction(descendant)))
+
+	patchesBefore := poolPatchDumps(ap, a.Address, base, a, descendant)
+
+	snapshot := ap.SnapshotUncommitted(locker, []types.Address{a.Address})
+	common.FailIfErr(t, ap.ForceAddAccountBlockTransaction(locker, poolTransaction(b)))
+	common.Expect(t, ap.GetFrontierAccountStore(a.Address).Identifier(), b.Identifier())
+
+	common.FailIfErr(t, ap.RestoreUncommitted(locker, snapshot))
+
+	frontier := ap.GetFrontierAccountStore(a.Address)
+	common.Expect(t, frontier.Identifier(), descendant.Identifier())
+	stored, err := frontier.ByHeight(2)
+	common.FailIfErr(t, err)
+	common.ExpectBytes(t, stored.Signature, "0x"+hex.EncodeToString(a.Signature))
+	common.Expect(t, len(ap.GetUncommittedAccountBlocksByAddress(a.Address)), 3)
+	expectPatchDumps(t, patchesBefore, poolPatchDumps(ap, a.Address, base, a, descendant))
+}
+
+// poolPatchDumps returns the serialized patch of each block as the pool holds it.
+func poolPatchDumps(ap *accountPool, address types.Address, blocks ...*nom.AccountBlock) [][]byte {
+	dumps := make([][]byte, 0, len(blocks))
+	for _, block := range blocks {
+		patch := ap.GetPatch(address, block.Identifier())
+		if patch == nil {
+			dumps = append(dumps, nil)
+			continue
+		}
+		dumps = append(dumps, patch.Dump())
+	}
+	return dumps
+}
+
+func expectPatchDumps(t *testing.T, before, after [][]byte) {
+	t.Helper()
+	common.Expect(t, len(after), len(before))
+	for i := range before {
+		if !bytes.Equal(before[i], after[i]) {
+			t.Fatalf("patch %d changed after restore: %d bytes before, %d bytes after", i, len(before[i]), len(after[i]))
+		}
+	}
+}
+
+// embeddedReceiveChain builds a contract receive at height 2 that carries two
+// descendant contract sends, on top of a height-1 base block.
+func embeddedReceiveChain() (base, receive *nom.AccountBlock) {
+	address := types.PillarContract
+	base = &nom.AccountBlock{
+		Version:         1,
+		ChainIdentifier: 1,
+		BlockType:       nom.BlockTypeContractReceive,
+		Address:         address,
+		Height:          1,
+		Amount:          big.NewInt(0),
+	}
+	base.Hash = base.ComputeHash()
+	previous := base.Hash
+	descendants := make([]*nom.AccountBlock, 0, 2)
+	for height := uint64(2); height <= 3; height++ {
+		d := &nom.AccountBlock{
+			Version:         1,
+			ChainIdentifier: 1,
+			BlockType:       nom.BlockTypeContractSend,
+			Address:         address,
+			Height:          height,
+			PreviousHash:    previous,
+			Amount:          big.NewInt(0),
+		}
+		d.Hash = d.ComputeHash()
+		previous = d.Hash
+		descendants = append(descendants, d)
+	}
+	receive = &nom.AccountBlock{
+		Version:          1,
+		ChainIdentifier:  1,
+		BlockType:        nom.BlockTypeContractReceive,
+		Address:          address,
+		Height:           4,
+		PreviousHash:     previous,
+		Amount:           big.NewInt(0),
+		DescendantBlocks: descendants,
+	}
+	receive.Hash = receive.ComputeHash()
+	return base, receive
+}
+
+func TestAccountPool_RestoreUncommittedKeepsBatchedEmbeddedTransaction(t *testing.T) {
+	base, receive := embeddedReceiveChain()
+
+	ap := newAccountPool(&memStable{})
+	locker := &sync.Mutex{}
+	common.FailIfErr(t, ap.AddAccountBlockTransaction(locker, poolTransaction(base)))
+	common.FailIfErr(t, ap.AddAccountBlockTransaction(locker, poolTransaction(receive)))
+	all := append([]*nom.AccountBlock{base}, receive.DescendantBlocks...)
+	all = append(all, receive)
+	common.Expect(t, ap.GetFrontierAccountStore(receive.Address).Identifier(), receive.Identifier())
+	patchesBefore := poolPatchDumps(ap, receive.Address, all...)
+
+	snapshot := ap.SnapshotUncommitted(locker, []types.Address{receive.Address})
+	// Roll the account back to the base block, as a forced insert of a
+	// competing block would.
+	replacement := base.Copy()
+	replacement.Height = 2
+	replacement.PreviousHash = base.Hash
+	replacement.Hash = replacement.ComputeHash()
+	common.FailIfErr(t, ap.ForceAddAccountBlockTransaction(locker, poolTransaction(replacement)))
+	common.Expect(t, ap.GetFrontierAccountStore(receive.Address).Identifier(), replacement.Identifier())
+
+	common.FailIfErr(t, ap.RestoreUncommitted(locker, snapshot))
+
+	frontier := ap.GetFrontierAccountStore(receive.Address)
+	common.Expect(t, frontier.Identifier(), receive.Identifier())
+	for _, block := range all {
+		stored, err := frontier.ByHeight(block.Height)
+		common.FailIfErr(t, err)
+		if stored == nil || !stored.EqualBytes(block) {
+			t.Fatalf("block at height %d not restored byte-identically", block.Height)
+		}
+	}
+	expectPatchDumps(t, patchesBefore, poolPatchDumps(ap, receive.Address, all...))
+}
+
+func TestAccountPool_RestoreUncommittedEmptySnapshotClearsAddress(t *testing.T) {
+	base, a, _, _ := poolBlockChain()
+
+	ap := newAccountPool(&memStable{})
+	locker := &sync.Mutex{}
+	snapshot := ap.SnapshotUncommitted(locker, []types.Address{a.Address, a.Address})
+	common.FailIfErr(t, ap.AddAccountBlockTransaction(locker, poolTransaction(base)))
+	common.FailIfErr(t, ap.AddAccountBlockTransaction(locker, poolTransaction(a)))
+
+	common.FailIfErr(t, ap.RestoreUncommitted(locker, snapshot))
+
+	common.Expect(t, ap.GetFrontierAccountStore(a.Address).Identifier(), types.ZeroHashHeight)
+	common.Expect(t, len(ap.GetAllUncommittedAccountBlocks()), 0)
+	common.FailIfErr(t, ap.RestoreUncommitted(locker, nil))
+}

--- a/chain/account_pool_test.go
+++ b/chain/account_pool_test.go
@@ -266,3 +266,12 @@ func TestAccountPool_RestoreUncommittedEmptySnapshotClearsAddress(t *testing.T) 
 	common.Expect(t, len(ap.GetAllUncommittedAccountBlocks()), 0)
 	common.FailIfErr(t, ap.RestoreUncommitted(locker, nil))
 }
+
+func TestAccountBlockCopyPreservesBytes(t *testing.T) {
+	base, receive := embeddedReceiveChain()
+	for _, block := range []*nom.AccountBlock{base, receive} {
+		if !block.Copy().EqualBytes(block) {
+			t.Fatalf("copy of block at height %d serializes differently", block.Height)
+		}
+	}
+}

--- a/chain/account_pool_test.go
+++ b/chain/account_pool_test.go
@@ -1,10 +1,16 @@
 package chain
 
 import (
+	"bytes"
+	"encoding/hex"
+	"math/big"
+	"sync"
 	"testing"
 
 	"github.com/zenon-network/go-zenon/chain/nom"
 	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/common/db"
+	"github.com/zenon-network/go-zenon/common/types"
 )
 
 func TestAccountPool_filterBlocksToCommit(t *testing.T) {
@@ -21,4 +27,97 @@ func TestAccountPool_filterBlocksToCommit(t *testing.T) {
 		{Height: 2, BlockType: nom.BlockTypeContractSend},
 		{Height: 3, BlockType: nom.BlockTypeUserReceive},
 	})), 0)
+}
+
+// memStable backs an account pool with one in-memory stable DB per address.
+type memStable struct {
+	dbs map[types.Address]db.DB
+}
+
+func (s *memStable) GetStableAccountDB(address types.Address) db.DB {
+	if s.dbs == nil {
+		s.dbs = map[types.Address]db.DB{}
+	}
+	if s.dbs[address] == nil {
+		s.dbs[address] = db.NewMemDB()
+	}
+	return s.dbs[address]
+}
+
+// poolBlockChain builds a height-1 base block, two copies of a height-2 block
+// that share an identifier but differ in a field that is stored without being
+// hashed, and a height-3 descendant on top of the first copy.
+func poolBlockChain() (base, a, b, descendant *nom.AccountBlock) {
+	address := types.ParseAddressPanic("z1qqjfammypam0sjhzst0jfjth60vy9g8w0g5lhg")
+	base = &nom.AccountBlock{
+		Version:         1,
+		ChainIdentifier: 1,
+		BlockType:       nom.BlockTypeUserReceive,
+		Address:         address,
+		Height:          1,
+		Amount:          big.NewInt(0),
+		Signature:       bytes.Repeat([]byte{0x11}, 64),
+	}
+	base.Hash = base.ComputeHash()
+	a = &nom.AccountBlock{
+		Version:         1,
+		ChainIdentifier: 1,
+		BlockType:       nom.BlockTypeUserReceive,
+		Address:         address,
+		Height:          2,
+		PreviousHash:    base.Hash,
+		Amount:          big.NewInt(0),
+		Signature:       bytes.Repeat([]byte{0xaa}, 64),
+	}
+	a.Hash = a.ComputeHash()
+	b = a.Copy()
+	b.Signature = bytes.Repeat([]byte{0xbb}, 64)
+	descendant = &nom.AccountBlock{
+		Version:         1,
+		ChainIdentifier: 1,
+		BlockType:       nom.BlockTypeUserSend,
+		Address:         address,
+		Height:          3,
+		PreviousHash:    a.Hash,
+		Amount:          big.NewInt(0),
+		Signature:       bytes.Repeat([]byte{0x33}, 64),
+	}
+	descendant.Hash = descendant.ComputeHash()
+	return base, a, b, descendant
+}
+
+func poolTransaction(block *nom.AccountBlock) *nom.AccountBlockTransaction {
+	return &nom.AccountBlockTransaction{Block: block, Changes: db.NewPatch()}
+}
+
+func TestAccountPool_ForceAddReplacesSameIdentifierWithDifferentBytes(t *testing.T) {
+	base, a, b, descendant := poolBlockChain()
+	common.Expect(t, a.Identifier(), b.Identifier())
+
+	ap := newAccountPool(&memStable{})
+	locker := &sync.Mutex{}
+	common.FailIfErr(t, ap.AddAccountBlockTransaction(locker, poolTransaction(base)))
+	common.FailIfErr(t, ap.AddAccountBlockTransaction(locker, poolTransaction(a)))
+	common.FailIfErr(t, ap.AddAccountBlockTransaction(locker, poolTransaction(descendant)))
+	common.FailIfErr(t, ap.ForceAddAccountBlockTransaction(locker, poolTransaction(b)))
+
+	frontier := ap.GetFrontierAccountStore(a.Address)
+	common.Expect(t, frontier.Identifier(), b.Identifier())
+	stored, err := frontier.ByHeight(2)
+	common.FailIfErr(t, err)
+	common.ExpectBytes(t, stored.Signature, "0x"+hex.EncodeToString(b.Signature))
+}
+
+func TestAccountPool_AddKeepsFirstVariantOfSameIdentifier(t *testing.T) {
+	base, a, b, _ := poolBlockChain()
+
+	ap := newAccountPool(&memStable{})
+	locker := &sync.Mutex{}
+	common.FailIfErr(t, ap.AddAccountBlockTransaction(locker, poolTransaction(base)))
+	common.FailIfErr(t, ap.AddAccountBlockTransaction(locker, poolTransaction(a)))
+	common.FailIfErr(t, ap.AddAccountBlockTransaction(locker, poolTransaction(b)))
+
+	stored, err := ap.GetFrontierAccountStore(a.Address).ByHeight(2)
+	common.FailIfErr(t, err)
+	common.ExpectBytes(t, stored.Signature, "0x"+hex.EncodeToString(a.Signature))
 }

--- a/chain/interface.go
+++ b/chain/interface.go
@@ -62,4 +62,9 @@ type AccountPool interface {
 	GetNewMomentumContent() []*nom.AccountBlock
 	GetAllUncommittedAccountBlocks() []*nom.AccountBlock
 	GetUncommittedAccountBlocksByAddress(address types.Address) []*nom.AccountBlock
+
+	// SnapshotUncommitted and RestoreUncommitted bracket a sequence of pool
+	// mutations so they can be undone if a later validation step fails.
+	SnapshotUncommitted(insertLocker sync.Locker, addresses []types.Address) *UncommittedSnapshot
+	RestoreUncommitted(insertLocker sync.Locker, snapshot *UncommittedSnapshot) error
 }

--- a/chain/nom/account_block.go
+++ b/chain/nom/account_block.go
@@ -1,6 +1,7 @@
 package nom
 
 import (
+	"bytes"
 	"crypto/ed25519"
 	"encoding/hex"
 	"encoding/json"
@@ -289,6 +290,25 @@ func DeProtoAccountBlock(pb *AccountBlockProto) *AccountBlock {
 	}
 	return ab
 }
+
+// EqualBytes reports whether both blocks serialize to identical bytes. This is
+// stricter than comparing identifiers, because some stored fields are not part
+// of the hash.
+func (ab *AccountBlock) EqualBytes(other *AccountBlock) bool {
+	if ab == nil || other == nil {
+		return ab == other
+	}
+	abBytes, err := ab.Serialize()
+	if err != nil {
+		return false
+	}
+	otherBytes, err := other.Serialize()
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(abBytes, otherBytes)
+}
+
 func (ab *AccountBlock) Serialize() ([]byte, error) {
 	return proto.Marshal(ab.Proto())
 }

--- a/common/db/versioned_db.go
+++ b/common/db/versioned_db.go
@@ -78,6 +78,40 @@ func NewMemDBManager(rawDB DB) Manager {
 	}
 }
 
+// Cloneable is implemented by managers whose uncommitted state can be captured
+// as an independent manager sharing the same stable base.
+type Cloneable interface {
+	Clone() Manager
+}
+
+// Clone returns a manager with the same stable base and the same uncommitted
+// versions and patches. Stored versions and patches are never modified after
+// insertion, and Pop only drops map entries, so the two managers can share
+// them and diverge independently from here on.
+func (m *memdbManager) Clone() Manager {
+	m.changes.Lock()
+	defer m.changes.Unlock()
+
+	clone := &memdbManager{
+		stableDB:           m.stableDB,
+		stableIdentifier:   m.stableIdentifier,
+		frontierIdentifier: m.frontierIdentifier,
+		previous:           make(map[types.HashHeight]types.HashHeight, len(m.previous)),
+		versions:           make(map[types.HashHeight]DB, len(m.versions)),
+		patches:            make(map[types.HashHeight]Patch, len(m.patches)),
+	}
+	for k, v := range m.previous {
+		clone.previous[k] = v
+	}
+	for k, v := range m.versions {
+		clone.versions[k] = v
+	}
+	for k, v := range m.patches {
+		clone.patches[k] = v
+	}
+	return clone
+}
+
 func (m *memdbManager) Frontier() DB {
 	m.changes.Lock()
 	frontierIdentifier := m.frontierIdentifier

--- a/common/db/versioned_db_clone_test.go
+++ b/common/db/versioned_db_clone_test.go
@@ -1,0 +1,50 @@
+package db
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/zenon-network/go-zenon/common"
+)
+
+func TestMemDBManagerCloneDivergesIndependently(t *testing.T) {
+	original := NewMemDBManager(NewMemDB())
+	t1 := newMockTransaction(1, original.Frontier())
+	common.FailIfErr(t, original.Add(t1))
+	t1Patch := original.GetPatch(t1.commit.Identifier()).Dump()
+
+	clone := original.(Cloneable).Clone()
+	common.Expect(t, GetFrontierIdentifier(clone.Frontier()), t1.commit.Identifier())
+	common.ExpectBytes(t, clone.GetPatch(t1.commit.Identifier()).Dump(), "0x"+hex.EncodeToString(t1Patch))
+
+	// Mutating the original after cloning must not show up in the clone.
+	t2 := newMockTransaction(2, original.Frontier())
+	common.FailIfErr(t, original.Add(t2))
+	common.Expect(t, GetFrontierIdentifier(original.Frontier()), t2.commit.Identifier())
+	common.Expect(t, GetFrontierIdentifier(clone.Frontier()), t1.commit.Identifier())
+	if clone.GetPatch(t2.commit.Identifier()) != nil {
+		t.Fatal("clone sees a transaction added to the original")
+	}
+	if clone.Get(t2.commit.Identifier()) != nil {
+		t.Fatal("clone sees a version added to the original")
+	}
+
+	// Popping the original back past the shared transaction must not remove
+	// it from the clone, and the clone's copy must be unchanged.
+	common.FailIfErr(t, original.Pop())
+	common.FailIfErr(t, original.Pop())
+	common.Expect(t, GetFrontierIdentifier(original.Frontier()), GetFrontierIdentifier(NewMemDB()))
+	common.Expect(t, GetFrontierIdentifier(clone.Frontier()), t1.commit.Identifier())
+	common.ExpectBytes(t, clone.GetPatch(t1.commit.Identifier()).Dump(), "0x"+hex.EncodeToString(t1Patch))
+
+	// Mutating the clone must not show up in the original.
+	t3 := newMockTransaction(3, clone.Frontier())
+	common.FailIfErr(t, clone.Add(t3))
+	common.Expect(t, GetFrontierIdentifier(clone.Frontier()), t3.commit.Identifier())
+	if original.GetPatch(t3.commit.Identifier()) != nil {
+		t.Fatal("original sees a transaction added to the clone")
+	}
+	if original.Get(t1.commit.Identifier()) != nil {
+		t.Fatal("original still holds a popped version")
+	}
+}

--- a/protocol/chain_bridge.go
+++ b/protocol/chain_bridge.go
@@ -53,6 +53,19 @@ func (c chainBridge) AddAccountBlocks(blocks []*nom.AccountBlock) error {
 	}
 	return nil
 }
+
+// poolHoldsSameBytes reports whether the account pool's frontier chain already
+// contains this exact block. A pool copy that matches by identifier but not by
+// bytes must not be reused, because the stored bytes feed into the momentum
+// changes-hash and the momentum was built from the copy passed in here.
+func (c chainBridge) poolHoldsSameBytes(block *nom.AccountBlock) bool {
+	stored, err := c.chain.GetFrontierAccountStore(block.Address).ByHeight(block.Height)
+	if err != nil || stored == nil {
+		return false
+	}
+	return stored.EqualBytes(block)
+}
+
 func (c chainBridge) GetTransactions() []*nom.AccountBlock {
 	blocks := c.chain.GetAllUncommittedAccountBlocks()
 	return blocks
@@ -184,7 +197,7 @@ func (c chainBridge) InsertChain(momentums []*nom.DetailedMomentum) (int, error)
 			if block.BlockType == nom.BlockTypeContractSend {
 				continue
 			}
-			if patch := c.chain.GetPatch(block.Address, block.Identifier()); patch != nil {
+			if c.poolHoldsSameBytes(block) {
 				// already applied
 				continue
 			}

--- a/protocol/chain_bridge.go
+++ b/protocol/chain_bridge.go
@@ -157,6 +157,25 @@ func (c chainBridge) InsertChain(momentums []*nom.DetailedMomentum) (int, error)
 	}
 	momentums = momentums[start:]
 
+	// Cheap structural check on peer-supplied data before anything is
+	// sized from it, before any rollback and before any pool state is
+	// touched. The verifier repeats the semantic checks later; this only
+	// bounds the input and puts the blocks into content order. The caller
+	// keeps using its own objects concurrently (the fetcher broadcasts the
+	// same DetailedMomentum while importing it), and the VM writes computed
+	// plasma fields onto whatever block it applies, so the loop below works
+	// on private copies of the blocks rather than on the caller's.
+	candidates := make([]*nom.DetailedMomentum, len(momentums))
+	for index, detailed := range momentums {
+		ordered, err := validatePrefetchedBlocks(detailed)
+		if err != nil {
+			log.Error("malformed prefetched account-blocks", "reason", err, "momentum-identifier", detailed.Momentum.Identifier())
+			return index + start, err
+		}
+		candidates[index] = &nom.DetailedMomentum{Momentum: detailed.Momentum, AccountBlocks: copyAccountBlocks(ordered)}
+	}
+	momentums = candidates
+
 	head := momentums[0].Momentum
 	tail := momentums[len(momentums)-1].Momentum
 	ourFrontier, err := store.GetFrontierMomentum()
@@ -213,6 +232,61 @@ func (c chainBridge) InsertChain(momentums []*nom.DetailedMomentum) (int, error)
 	}
 
 	return 0, nil
+}
+
+// validatePrefetchedBlocks rejects a detailed momentum whose block list is not
+// exactly the set of blocks named by the momentum's content: no nil entries,
+// no duplicates, no more entries than a momentum may hold, and one block per
+// content header. Peers are not required to send the blocks in content order,
+// so on success it returns the blocks in content order, which is also the
+// order they must be applied in. The supplied momentum is not modified.
+func validatePrefetchedBlocks(detailed *nom.DetailedMomentum) ([]*nom.AccountBlock, error) {
+	if detailed == nil || detailed.Momentum == nil {
+		return nil, errors.Errorf("missing momentum")
+	}
+	blocks := detailed.AccountBlocks
+	content := detailed.Momentum.Content
+	if len(blocks) > chain.MaxAccountBlocksInMomentum {
+		return nil, errors.Errorf("too many prefetched account-blocks: %v > %v", len(blocks), chain.MaxAccountBlocksInMomentum)
+	}
+	if len(blocks) != len(content) {
+		return nil, errors.Errorf("prefetched account-blocks (%v) do not match momentum content (%v)", len(blocks), len(content))
+	}
+
+	byIdentifier := make(map[types.HashHeight]*nom.AccountBlock, len(blocks))
+	for index, block := range blocks {
+		if block == nil {
+			return nil, errors.Errorf("prefetched account-block at index %v is nil", index)
+		}
+		identifier := block.Identifier()
+		if _, seen := byIdentifier[identifier]; seen {
+			return nil, errors.Errorf("duplicate prefetched account-block %v", identifier)
+		}
+		byIdentifier[identifier] = block
+	}
+
+	ordered := make([]*nom.AccountBlock, len(content))
+	for index, header := range content {
+		if header == nil {
+			return nil, errors.Errorf("momentum content header at index %v is nil", index)
+		}
+		block, ok := byIdentifier[header.Identifier()]
+		if !ok || block.Address != header.Address {
+			return nil, errors.Errorf("momentum content header %v has no matching prefetched account-block", header)
+		}
+		ordered[index] = block
+	}
+	return ordered, nil
+}
+
+// copyAccountBlocks returns deep copies of the blocks, descendants included,
+// so nothing downstream writes to objects the caller still shares.
+func copyAccountBlocks(blocks []*nom.AccountBlock) []*nom.AccountBlock {
+	copied := make([]*nom.AccountBlock, len(blocks))
+	for index, block := range blocks {
+		copied[index] = block.Copy()
+	}
+	return copied
 }
 
 // momentumAddresses lists each account whose pool state the momentum's blocks

--- a/protocol/chain_bridge.go
+++ b/protocol/chain_bridge.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"fmt"
+	"sync"
 
 	"github.com/pkg/errors"
 
@@ -193,34 +194,66 @@ func (c chainBridge) InsertChain(momentums []*nom.DetailedMomentum) (int, error)
 
 	// Insert momentum now
 	for index, detailed := range momentums {
-		for _, block := range detailed.AccountBlocks {
-			if block.BlockType == nom.BlockTypeContractSend {
-				continue
+		// Blocks are force-inserted into the pool before the momentum itself
+		// is validated, so keep a snapshot of every account the momentum
+		// touches and put it back if anything fails.
+		snapshot := c.chain.SnapshotUncommitted(insert, momentumAddresses(detailed))
+		frontierBefore := c.chain.GetFrontierMomentumStore().Identifier()
+		if err := c.insertMomentum(insert, detailed); err != nil {
+			if c.chain.GetFrontierMomentumStore().Identifier() != frontierBefore {
+				// The momentum was committed before the error surfaced. The
+				// snapshot predates that commit, so putting it back would
+				// resurrect pool state that no longer links to the chain.
+				log.Error("momentum committed despite insert error; not restoring account-pool", "reason", err, "momentum-identifier", detailed.Momentum.Identifier())
+			} else if restoreErr := c.chain.RestoreUncommitted(insert, snapshot); restoreErr != nil {
+				log.Error("error while restoring account-pool after failed momentum", "reason", restoreErr, "momentum-identifier", detailed.Momentum.Identifier())
 			}
-			if c.poolHoldsSameBytes(block) {
-				// already applied
-				continue
-			}
-			transaction, err := c.supervisor.ApplyBlock(block)
-			if err != nil {
-				log.Error("error while applying account-block", "reason", err, "account-block-header", block.Header())
-				return index + start, err
-			}
-			if err := c.chain.ForceAddAccountBlockTransaction(insert, transaction); err != nil {
-				log.Error("error while inserting account-block in pool", "reason", err, "account-block-header", block.Header())
-				return index + start, err
-			}
-		}
-
-		transaction, err := c.supervisor.ApplyMomentum(detailed)
-		if err != nil {
-			return index + start, err
-		}
-		if err := c.chain.AddMomentumTransaction(insert, transaction); err != nil {
-			log.Error("error while inserting momentum", "reason", err, "momentum-identifier", detailed.Momentum.Identifier())
 			return index + start, err
 		}
 	}
 
 	return 0, nil
+}
+
+// momentumAddresses lists each account whose pool state the momentum's blocks
+// can modify.
+func momentumAddresses(detailed *nom.DetailedMomentum) []types.Address {
+	addresses := make([]types.Address, 0, len(detailed.AccountBlocks))
+	for _, block := range detailed.AccountBlocks {
+		addresses = append(addresses, block.Address)
+	}
+	return addresses
+}
+
+// insertMomentum applies the momentum's blocks to the pool, then validates and
+// commits the momentum. Under the caller's insert lock.
+func (c chainBridge) insertMomentum(insert sync.Locker, detailed *nom.DetailedMomentum) error {
+	for _, block := range detailed.AccountBlocks {
+		if block.BlockType == nom.BlockTypeContractSend {
+			continue
+		}
+		if c.poolHoldsSameBytes(block) {
+			// already applied
+			continue
+		}
+		transaction, err := c.supervisor.ApplyBlock(block)
+		if err != nil {
+			log.Error("error while applying account-block", "reason", err, "account-block-header", block.Header())
+			return err
+		}
+		if err := c.chain.ForceAddAccountBlockTransaction(insert, transaction); err != nil {
+			log.Error("error while inserting account-block in pool", "reason", err, "account-block-header", block.Header())
+			return err
+		}
+	}
+
+	transaction, err := c.supervisor.ApplyMomentum(detailed)
+	if err != nil {
+		return err
+	}
+	if err := c.chain.AddMomentumTransaction(insert, transaction); err != nil {
+		log.Error("error while inserting momentum", "reason", err, "momentum-identifier", detailed.Momentum.Identifier())
+		return err
+	}
+	return nil
 }

--- a/protocol/chain_bridge.go
+++ b/protocol/chain_bridge.go
@@ -160,21 +160,14 @@ func (c chainBridge) InsertChain(momentums []*nom.DetailedMomentum) (int, error)
 	// Cheap structural check on peer-supplied data before anything is
 	// sized from it, before any rollback and before any pool state is
 	// touched. The verifier repeats the semantic checks later; this only
-	// bounds the input and puts the blocks into content order. The caller
-	// keeps using its own objects concurrently (the fetcher broadcasts the
-	// same DetailedMomentum while importing it), and the VM writes computed
-	// plasma fields onto whatever block it applies, so the loop below works
-	// on private copies of the blocks rather than on the caller's.
-	candidates := make([]*nom.DetailedMomentum, len(momentums))
+	// bounds the input and checks that the blocks are the momentum's
+	// content, in content order.
 	for index, detailed := range momentums {
-		ordered, err := validatePrefetchedBlocks(detailed)
-		if err != nil {
+		if err := validatePrefetchedBlocks(detailed); err != nil {
 			log.Error("malformed prefetched account-blocks", "reason", err, "momentum-identifier", detailed.Momentum.Identifier())
 			return index + start, err
 		}
-		candidates[index] = &nom.DetailedMomentum{Momentum: detailed.Momentum, AccountBlocks: copyAccountBlocks(ordered)}
 	}
-	momentums = candidates
 
 	head := momentums[0].Momentum
 	tail := momentums[len(momentums)-1].Momentum
@@ -212,7 +205,15 @@ func (c chainBridge) InsertChain(momentums []*nom.DetailedMomentum) (int, error)
 	}
 
 	// Insert momentum now
-	for index, detailed := range momentums {
+	for index, supplied := range momentums {
+		// The caller keeps using its own objects concurrently (the fetcher
+		// broadcasts the same DetailedMomentum while importing it), and the
+		// VM writes computed plasma fields onto whatever block it applies,
+		// so insert works on private copies of the blocks. Copies are made
+		// one momentum at a time so a batch that fails early does not pay
+		// for the momentums it never reaches.
+		detailed := &nom.DetailedMomentum{Momentum: supplied.Momentum, AccountBlocks: copyAccountBlocks(supplied.AccountBlocks)}
+
 		// Blocks are force-inserted into the pool before the momentum itself
 		// is validated, so keep a snapshot of every account the momentum
 		// touches and put it back if anything fails.
@@ -235,48 +236,47 @@ func (c chainBridge) InsertChain(momentums []*nom.DetailedMomentum) (int, error)
 }
 
 // validatePrefetchedBlocks rejects a detailed momentum whose block list is not
-// exactly the set of blocks named by the momentum's content: no nil entries,
-// no duplicates, no more entries than a momentum may hold, and one block per
-// content header. Peers are not required to send the blocks in content order,
-// so on success it returns the blocks in content order, which is also the
-// order they must be applied in. The supplied momentum is not modified.
-func validatePrefetchedBlocks(detailed *nom.DetailedMomentum) ([]*nom.AccountBlock, error) {
+// exactly the momentum's content, in content order: no nil entries, no more
+// entries than a momentum may hold, and the block at each index matching the
+// content header at the same index by address, hash and height. Every producer
+// of a DetailedMomentum emits the blocks in content order, which is also the
+// order they must be applied in, so a mismatch is malformed input rather than
+// a legitimate alternative layout. A content header listed twice is rejected
+// here as well, so that no duplicate reaches the pool before the verifier
+// sees it. The supplied momentum is not modified.
+func validatePrefetchedBlocks(detailed *nom.DetailedMomentum) error {
 	if detailed == nil || detailed.Momentum == nil {
-		return nil, errors.Errorf("missing momentum")
+		return errors.Errorf("missing momentum")
 	}
 	blocks := detailed.AccountBlocks
 	content := detailed.Momentum.Content
 	if len(blocks) > chain.MaxAccountBlocksInMomentum {
-		return nil, errors.Errorf("too many prefetched account-blocks: %v > %v", len(blocks), chain.MaxAccountBlocksInMomentum)
+		return errors.Errorf("too many prefetched account-blocks: %v > %v", len(blocks), chain.MaxAccountBlocksInMomentum)
 	}
 	if len(blocks) != len(content) {
-		return nil, errors.Errorf("prefetched account-blocks (%v) do not match momentum content (%v)", len(blocks), len(content))
+		return errors.Errorf("prefetched account-blocks (%v) do not match momentum content (%v)", len(blocks), len(content))
 	}
 
-	byIdentifier := make(map[types.HashHeight]*nom.AccountBlock, len(blocks))
-	for index, block := range blocks {
-		if block == nil {
-			return nil, errors.Errorf("prefetched account-block at index %v is nil", index)
-		}
-		identifier := block.Identifier()
-		if _, seen := byIdentifier[identifier]; seen {
-			return nil, errors.Errorf("duplicate prefetched account-block %v", identifier)
-		}
-		byIdentifier[identifier] = block
-	}
-
-	ordered := make([]*nom.AccountBlock, len(content))
 	for index, header := range content {
 		if header == nil {
-			return nil, errors.Errorf("momentum content header at index %v is nil", index)
+			return errors.Errorf("momentum content header at index %v is nil", index)
 		}
-		block, ok := byIdentifier[header.Identifier()]
-		if !ok || block.Address != header.Address {
-			return nil, errors.Errorf("momentum content header %v has no matching prefetched account-block", header)
+		block := blocks[index]
+		if block == nil {
+			return errors.Errorf("prefetched account-block at index %v is nil", index)
 		}
-		ordered[index] = block
+		if block.Address != header.Address || block.Identifier() != header.Identifier() {
+			return errors.Errorf("prefetched account-block at index %v (%v) does not match momentum content header %v", index, block.Header(), header)
+		}
+		// Content is bounded to MaxAccountBlocksInMomentum entries, so a
+		// pairwise scan stays cheap and needs no allocation.
+		for _, earlier := range content[:index] {
+			if earlier.Identifier() == header.Identifier() {
+				return errors.Errorf("duplicate momentum content header %v", header)
+			}
+		}
 	}
-	return ordered, nil
+	return nil
 }
 
 // copyAccountBlocks returns deep copies of the blocks, descendants included,

--- a/protocol/chain_bridge_restore_test.go
+++ b/protocol/chain_bridge_restore_test.go
@@ -1,0 +1,233 @@
+package protocol_test
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/zenon-network/go-zenon/chain"
+	g "github.com/zenon-network/go-zenon/chain/genesis/mock"
+	"github.com/zenon-network/go-zenon/chain/nom"
+	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/common/types"
+	"github.com/zenon-network/go-zenon/protocol"
+	"github.com/zenon-network/go-zenon/vm"
+	"github.com/zenon-network/go-zenon/zenon/mock"
+)
+
+// restoreFixture holds a mock node that has been rolled back to just before a
+// momentum containing one receive block, so that momentum can be replayed
+// against an arbitrary pool state.
+type restoreFixture struct {
+	z          mock.MockZenon
+	supervisor *vm.Supervisor
+	bridge     protocol.ChainBridge
+	sends      [2]*nom.AccountBlock
+	receive    *nom.AccountBlockTransaction
+	detailed   *nom.DetailedMomentum
+	previous   types.HashHeight
+}
+
+func newRestoreFixture(t *testing.T) *restoreFixture {
+	z := mock.NewMockZenon(t)
+	supervisor := vm.NewSupervisor(z.Chain(), z.Consensus())
+	f := &restoreFixture{
+		z:          z,
+		supervisor: supervisor,
+		bridge:     protocol.NewChainBridge(z.Chain(), z.Consensus(), z.Verifier(), supervisor),
+	}
+
+	// User1 sends two separate units to User2; both get committed together.
+	for i := range f.sends {
+		f.sends[i] = z.InsertSendBlock(&nom.AccountBlock{
+			Address:       g.User1.Address,
+			ToAddress:     g.User2.Address,
+			TokenStandard: types.ZnnTokenStandard,
+			Amount:        big.NewInt(1),
+		}, nil, mock.SkipVmChanges)
+	}
+	z.InsertNewMomentum()
+
+	// User2 receives the first send; that block goes into the next momentum.
+	f.receive = f.generateReceive(t, f.sends[0])
+	z.Broadcaster().CreateAccountBlock(f.receive)
+	z.InsertNewMomentum()
+
+	store := z.Chain().GetFrontierMomentumStore()
+	momentum, err := store.GetFrontierMomentum()
+	common.FailIfErr(t, err)
+	f.detailed, err = store.PrefetchMomentum(momentum)
+	common.FailIfErr(t, err)
+	common.Expect(t, len(f.detailed.AccountBlocks), 1)
+	f.previous = momentum.Previous()
+
+	insert := z.Chain().AcquireInsert("test rollback")
+	common.FailIfErr(t, z.Chain().RollbackTo(insert, f.previous))
+	insert.Unlock()
+	return f
+}
+
+// generateReceive builds and signs a receive for User2 on top of whatever the
+// pool currently holds for that account.
+func (f *restoreFixture) generateReceive(t *testing.T, send *nom.AccountBlock) *nom.AccountBlockTransaction {
+	transaction, err := f.supervisor.GenerateFromTemplate(&nom.AccountBlock{
+		BlockType:     nom.BlockTypeUserReceive,
+		Address:       g.User2.Address,
+		FromBlockHash: send.Hash,
+	}, g.User2.Signer)
+	common.FailIfErr(t, err)
+	return transaction
+}
+
+// addToPool inserts an already generated transaction into the pool and fails
+// the test on any error, unlike the mock broadcaster which only logs it.
+func (f *restoreFixture) addToPool(t *testing.T, transaction *nom.AccountBlockTransaction) {
+	t.Helper()
+	insert := f.z.Chain().AcquireInsert("test add to pool")
+	defer insert.Unlock()
+	common.FailIfErr(t, f.z.Chain().AddAccountBlockTransaction(insert, transaction))
+}
+
+// tamperedMomentum returns the fixture's momentum with its block's unhashed
+// ChangesHash field altered. The block still passes signature and hash checks.
+func (f *restoreFixture) tamperedMomentum() *nom.DetailedMomentum {
+	block := f.detailed.AccountBlocks[0].Copy()
+	block.ChangesHash = types.NewHash([]byte("not the real changes hash"))
+	return &nom.DetailedMomentum{Momentum: f.detailed.Momentum, AccountBlocks: []*nom.AccountBlock{block}}
+}
+
+func (f *restoreFixture) expectPoolChain(t *testing.T, blocks ...*nom.AccountBlock) {
+	t.Helper()
+	frontier := f.z.Chain().GetFrontierAccountStore(g.User2.Address)
+	common.Expect(t, frontier.Identifier(), blocks[len(blocks)-1].Identifier())
+	for _, expected := range blocks {
+		stored, err := frontier.ByHeight(expected.Height)
+		common.FailIfErr(t, err)
+		if stored == nil || !stored.EqualBytes(expected) {
+			t.Fatalf("pool block at height %v does not match the expected bytes", expected.Height)
+		}
+	}
+}
+
+func expectChangesHashError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil || !strings.Contains(err.Error(), "changes-hash") {
+		t.Fatalf("expected a changes-hash error, got %v", err)
+	}
+}
+
+func TestInsertChain_FailedMomentumKeepsPoolCopyAndDescendant(t *testing.T) {
+	f := newRestoreFixture(t)
+	defer f.z.StopPanic()
+
+	// Pool holds the canonical copy of the momentum's block plus a descendant.
+	common.FailIfErr(t, f.bridge.AddAccountBlocks([]*nom.AccountBlock{f.receive.Block}))
+	descendant := f.generateReceive(t, f.sends[1])
+	f.addToPool(t, descendant)
+	f.expectPoolChain(t, f.receive.Block, descendant.Block)
+
+	_, err := f.bridge.InsertChain([]*nom.DetailedMomentum{f.tamperedMomentum()})
+	expectChangesHashError(t, err)
+
+	common.Expect(t, f.z.Chain().GetFrontierMomentumStore().Identifier(), f.previous)
+	f.expectPoolChain(t, f.receive.Block, descendant.Block)
+
+	// The genuine momentum still goes through afterwards.
+	_, err = f.bridge.InsertChain([]*nom.DetailedMomentum{f.detailed})
+	common.FailIfErr(t, err)
+	common.Expect(t, f.z.Chain().GetFrontierMomentumStore().Identifier(), f.detailed.Momentum.Identifier())
+}
+
+func TestInsertChain_FailedMomentumKeepsCompetingPoolChain(t *testing.T) {
+	f := newRestoreFixture(t)
+	defer f.z.StopPanic()
+
+	// Pool holds a different, valid chain for the same account: the two
+	// receives in the opposite order, so the block at the momentum's height
+	// has a different hash from the momentum's block.
+	first := f.generateReceive(t, f.sends[1])
+	f.addToPool(t, first)
+	second := f.generateReceive(t, f.sends[0])
+	f.addToPool(t, second)
+	common.Expect(t, first.Block.Height, f.receive.Block.Height)
+	if first.Block.Hash == f.receive.Block.Hash {
+		t.Fatal("competing block unexpectedly has the same hash")
+	}
+	f.expectPoolChain(t, first.Block, second.Block)
+
+	_, err := f.bridge.InsertChain([]*nom.DetailedMomentum{f.tamperedMomentum()})
+	expectChangesHashError(t, err)
+
+	common.Expect(t, f.z.Chain().GetFrontierMomentumStore().Identifier(), f.previous)
+	f.expectPoolChain(t, first.Block, second.Block)
+}
+
+// committingButFailingChain lets the momentum commit and then reports an
+// error, reproducing a failure that happens after the store has advanced.
+type committingButFailingChain struct {
+	chain.Chain
+}
+
+var errAfterCommit = errors.New("failure after momentum commit")
+
+func (c committingButFailingChain) AddMomentumTransaction(insertLocker sync.Locker, transaction *nom.MomentumTransaction) error {
+	if err := c.Chain.AddMomentumTransaction(insertLocker, transaction); err != nil {
+		return err
+	}
+	return errAfterCommit
+}
+
+func TestInsertChain_FailureAfterCommitDoesNotRestoreStalePool(t *testing.T) {
+	f := newRestoreFixture(t)
+	defer f.z.StopPanic()
+	bridge := protocol.NewChainBridge(committingButFailingChain{f.z.Chain()}, f.z.Consensus(), f.z.Verifier(), f.supervisor)
+
+	// Pool holds a competing chain that the momentum's block replaces.
+	first := f.generateReceive(t, f.sends[1])
+	f.addToPool(t, first)
+	second := f.generateReceive(t, f.sends[0])
+	f.addToPool(t, second)
+
+	_, err := bridge.InsertChain([]*nom.DetailedMomentum{f.detailed})
+	if !errors.Is(err, errAfterCommit) {
+		t.Fatalf("expected the post-commit error, got %v", err)
+	}
+
+	// The momentum is committed, so a snapshot taken against the old stable
+	// state must not be put back: the competing chain it holds no longer
+	// links to the committed block. The pool keeps the momentum's copy.
+	common.Expect(t, f.z.Chain().GetFrontierMomentumStore().Identifier(), f.detailed.Momentum.Identifier())
+	stored, err := f.z.Chain().GetFrontierAccountStore(g.User2.Address).ByHeight(f.receive.Block.Height)
+	common.FailIfErr(t, err)
+	if stored == nil || !stored.EqualBytes(f.receive.Block) {
+		t.Fatal("pool does not hold the committed block's bytes")
+	}
+}
+
+func TestInsertChain_SecondBlockFailureRestoresFirstBlockReplacement(t *testing.T) {
+	f := newRestoreFixture(t)
+	defer f.z.StopPanic()
+
+	// Pool holds a competing chain; the momentum carries the canonical block
+	// followed by a block that cannot be applied.
+	first := f.generateReceive(t, f.sends[1])
+	f.addToPool(t, first)
+	second := f.generateReceive(t, f.sends[0])
+	f.addToPool(t, second)
+
+	broken := second.Block.Copy()
+	broken.Signature[0] ^= 0xff
+	detailed := &nom.DetailedMomentum{
+		Momentum:      f.detailed.Momentum,
+		AccountBlocks: []*nom.AccountBlock{f.detailed.AccountBlocks[0], broken},
+	}
+	_, err := f.bridge.InsertChain([]*nom.DetailedMomentum{detailed})
+	if err == nil {
+		t.Fatal("expected the second block to fail")
+	}
+
+	common.Expect(t, f.z.Chain().GetFrontierMomentumStore().Identifier(), f.previous)
+	f.expectPoolChain(t, first.Block, second.Block)
+}

--- a/protocol/chain_bridge_restore_test.go
+++ b/protocol/chain_bridge_restore_test.go
@@ -31,6 +31,12 @@ type restoreFixture struct {
 }
 
 func newRestoreFixture(t *testing.T) *restoreFixture {
+	return newRestoreFixtureWith(t, false)
+}
+
+// newRestoreFixtureWith optionally puts a second, independent account's block
+// (a User1 send) into the same momentum as the User2 receive.
+func newRestoreFixtureWith(t *testing.T, twoBlocks bool) *restoreFixture {
 	z := mock.NewMockZenon(t)
 	supervisor := vm.NewSupervisor(z.Chain(), z.Consensus())
 	f := &restoreFixture{
@@ -53,6 +59,16 @@ func newRestoreFixture(t *testing.T) *restoreFixture {
 	// User2 receives the first send; that block goes into the next momentum.
 	f.receive = f.generateReceive(t, f.sends[0])
 	z.Broadcaster().CreateAccountBlock(f.receive)
+	expectedBlocks := 1
+	if twoBlocks {
+		z.InsertSendBlock(&nom.AccountBlock{
+			Address:       g.User1.Address,
+			ToAddress:     g.User2.Address,
+			TokenStandard: types.ZnnTokenStandard,
+			Amount:        big.NewInt(1),
+		}, nil, mock.SkipVmChanges)
+		expectedBlocks = 2
+	}
 	z.InsertNewMomentum()
 
 	store := z.Chain().GetFrontierMomentumStore()
@@ -60,7 +76,7 @@ func newRestoreFixture(t *testing.T) *restoreFixture {
 	common.FailIfErr(t, err)
 	f.detailed, err = store.PrefetchMomentum(momentum)
 	common.FailIfErr(t, err)
-	common.Expect(t, len(f.detailed.AccountBlocks), 1)
+	common.Expect(t, len(f.detailed.AccountBlocks), expectedBlocks)
 	f.previous = momentum.Previous()
 
 	insert := z.Chain().AcquireInsert("test rollback")
@@ -230,4 +246,199 @@ func TestInsertChain_SecondBlockFailureRestoresFirstBlockReplacement(t *testing.
 
 	common.Expect(t, f.z.Chain().GetFrontierMomentumStore().Identifier(), f.previous)
 	f.expectPoolChain(t, first.Block, second.Block)
+}
+
+// snapshotCountingChain records how often the bridge snapshots the pool.
+type snapshotCountingChain struct {
+	chain.Chain
+	snapshots int
+}
+
+func (c *snapshotCountingChain) SnapshotUncommitted(insertLocker sync.Locker, addresses []types.Address) *chain.UncommittedSnapshot {
+	c.snapshots++
+	return c.Chain.SnapshotUncommitted(insertLocker, addresses)
+}
+
+func TestInsertChain_RejectsMalformedPrefetchedBlocksBeforeTouchingPool(t *testing.T) {
+	f := newRestoreFixture(t)
+	defer f.z.StopPanic()
+	counting := &snapshotCountingChain{Chain: f.z.Chain()}
+	bridge := protocol.NewChainBridge(counting, f.z.Consensus(), f.z.Verifier(), f.supervisor)
+
+	// Pool holds a competing chain so any force-add would be visible.
+	first := f.generateReceive(t, f.sends[1])
+	f.addToPool(t, first)
+	second := f.generateReceive(t, f.sends[0])
+	f.addToPool(t, second)
+
+	genuine := f.detailed.AccountBlocks[0]
+	oversized := make([]*nom.AccountBlock, chain.MaxAccountBlocksInMomentum+1)
+	for i := range oversized {
+		oversized[i] = genuine
+	}
+	cases := map[string][]*nom.AccountBlock{
+		"oversized list":      oversized,
+		"length mismatch":     {genuine, second.Block},
+		"nil entry":           {nil},
+		"identifier mismatch": {second.Block},
+		"empty list":          {},
+	}
+	for name, blocks := range cases {
+		detailed := &nom.DetailedMomentum{Momentum: f.detailed.Momentum, AccountBlocks: blocks}
+		_, err := bridge.InsertChain([]*nom.DetailedMomentum{detailed})
+		if err == nil {
+			t.Fatalf("%s: expected an error", name)
+		}
+		common.Expect(t, counting.snapshots, 0)
+		common.Expect(t, f.z.Chain().GetFrontierMomentumStore().Identifier(), f.previous)
+		f.expectPoolChain(t, first.Block, second.Block)
+	}
+
+	// The well-formed momentum still inserts through the same bridge.
+	_, err := bridge.InsertChain([]*nom.DetailedMomentum{f.detailed})
+	common.FailIfErr(t, err)
+	common.Expect(t, counting.snapshots, 1)
+}
+
+func TestInsertChain_AcceptsPrefetchedBlocksInAnyOrder(t *testing.T) {
+	f := newRestoreFixtureWith(t, true)
+	defer f.z.StopPanic()
+
+	blocks := f.detailed.AccountBlocks
+	if blocks[0].Address == blocks[1].Address {
+		t.Fatal("fixture should hold blocks from two different accounts")
+	}
+	swapped := &nom.DetailedMomentum{
+		Momentum:      f.detailed.Momentum,
+		AccountBlocks: []*nom.AccountBlock{blocks[1], blocks[0]},
+	}
+	_, err := f.bridge.InsertChain([]*nom.DetailedMomentum{swapped})
+	common.FailIfErr(t, err)
+	common.Expect(t, f.z.Chain().GetFrontierMomentumStore().Identifier(), f.detailed.Momentum.Identifier())
+}
+
+func TestInsertChain_RejectsDuplicatePrefetchedBlocks(t *testing.T) {
+	f := newRestoreFixtureWith(t, true)
+	defer f.z.StopPanic()
+	counting := &snapshotCountingChain{Chain: f.z.Chain()}
+	bridge := protocol.NewChainBridge(counting, f.z.Consensus(), f.z.Verifier(), f.supervisor)
+
+	blocks := f.detailed.AccountBlocks
+	duplicated := &nom.DetailedMomentum{
+		Momentum:      f.detailed.Momentum,
+		AccountBlocks: []*nom.AccountBlock{blocks[0], blocks[0]},
+	}
+	_, err := bridge.InsertChain([]*nom.DetailedMomentum{duplicated})
+	if err == nil {
+		t.Fatal("expected duplicate prefetched blocks to be rejected")
+	}
+	common.Expect(t, counting.snapshots, 0)
+	common.Expect(t, f.z.Chain().GetFrontierMomentumStore().Identifier(), f.previous)
+}
+
+func TestInsertChain_MalformedSideChainDoesNotRollBack(t *testing.T) {
+	f := newRestoreFixture(t)
+	defer f.z.StopPanic()
+
+	// Advance one momentum so the node has a frontier the side chain competes with.
+	_, err := f.bridge.InsertChain([]*nom.DetailedMomentum{f.detailed})
+	common.FailIfErr(t, err)
+	frontier := f.z.Chain().GetFrontierMomentumStore().Identifier()
+	common.Expect(t, frontier, f.detailed.Momentum.Identifier())
+
+	// A longer side chain forking below the frontier, whose first momentum
+	// carries an oversized block list. Only the linkage and length are
+	// inspected before the rollback decision, so the momentums need no
+	// valid hashes or signatures.
+	oversized := make([]*nom.AccountBlock, chain.MaxAccountBlocksInMomentum+1)
+	for i := range oversized {
+		oversized[i] = f.detailed.AccountBlocks[0]
+	}
+	head := &nom.Momentum{Version: 1, ChainIdentifier: 1, Height: frontier.Height, PreviousHash: f.previous.Hash}
+	head.Hash = types.NewHash([]byte("side-chain head"))
+	tail := &nom.Momentum{Version: 1, ChainIdentifier: 1, Height: frontier.Height + 1, PreviousHash: head.Hash}
+	tail.Hash = types.NewHash([]byte("side-chain tail"))
+	side := []*nom.DetailedMomentum{
+		{Momentum: head, AccountBlocks: oversized},
+		{Momentum: tail, AccountBlocks: nil},
+	}
+	_, err = f.bridge.InsertChain(side)
+	if err == nil {
+		t.Fatal("expected the malformed side chain to be rejected")
+	}
+	common.Expect(t, f.z.Chain().GetFrontierMomentumStore().Identifier(), frontier)
+}
+
+func TestInsertChain_DoesNotMutateCallerDetailedMomentum(t *testing.T) {
+	f := newRestoreFixtureWith(t, true)
+	defer f.z.StopPanic()
+
+	blocks := f.detailed.AccountBlocks
+	supplied := &nom.DetailedMomentum{
+		Momentum:      f.detailed.Momentum,
+		AccountBlocks: []*nom.AccountBlock{blocks[1], blocks[0]},
+	}
+	before := append([]*nom.AccountBlock(nil), supplied.AccountBlocks...)
+
+	// The fetcher hands the same object to a broadcast goroutine before it
+	// calls InsertChain, so a concurrent reader must be safe.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 10000; i++ {
+			for _, block := range supplied.AccountBlocks {
+				_ = block.Height
+			}
+		}
+	}()
+	_, err := f.bridge.InsertChain([]*nom.DetailedMomentum{supplied})
+	<-done
+	common.FailIfErr(t, err)
+
+	common.Expect(t, len(supplied.AccountBlocks), len(before))
+	for i := range before {
+		if supplied.AccountBlocks[i] != before[i] {
+			t.Fatalf("caller's block list was reordered at index %d", i)
+		}
+	}
+}
+
+func TestInsertChain_DoesNotWriteToCallerAccountBlocks(t *testing.T) {
+	f := newRestoreFixture(t)
+	defer f.z.StopPanic()
+
+	// Pool holds a byte-different copy, so the momentum's block takes the
+	// replacement path through the VM, which sets plasma fields on the block
+	// it is given.
+	poolCopy := f.receive.Block.Copy()
+	poolCopy.Signature = alternateSign(g.User2, poolCopy.Hash.Bytes())
+	common.FailIfErr(t, f.bridge.AddAccountBlocks([]*nom.AccountBlock{poolCopy}))
+
+	supplied := f.detailed.AccountBlocks[0].Copy()
+	const sentinel = uint64(12345)
+	supplied.BasePlasma = sentinel
+	supplied.TotalPlasma = sentinel
+	detailed := &nom.DetailedMomentum{Momentum: f.detailed.Momentum, AccountBlocks: []*nom.AccountBlock{supplied}}
+
+	// Models the fetcher's concurrent broadcast reading the same block.
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 10000; i++ {
+			_ = supplied.BasePlasma + supplied.TotalPlasma
+		}
+	}()
+	_, err := f.bridge.InsertChain([]*nom.DetailedMomentum{detailed})
+	<-done
+	common.FailIfErr(t, err)
+
+	common.Expect(t, supplied.BasePlasma, sentinel)
+	common.Expect(t, supplied.TotalPlasma, sentinel)
+
+	// What reached the chain is the canonical bytes, not the sentinel.
+	committed, err := f.z.Chain().GetFrontierMomentumStore().GetAccountBlock(f.receive.Block.Header())
+	common.FailIfErr(t, err)
+	if committed == nil || !committed.EqualBytes(f.receive.Block) {
+		t.Fatal("committed block does not match the canonical bytes")
+	}
 }

--- a/protocol/chain_bridge_restore_test.go
+++ b/protocol/chain_bridge_restore_test.go
@@ -300,19 +300,31 @@ func TestInsertChain_RejectsMalformedPrefetchedBlocksBeforeTouchingPool(t *testi
 	common.Expect(t, counting.snapshots, 1)
 }
 
-func TestInsertChain_AcceptsPrefetchedBlocksInAnyOrder(t *testing.T) {
+func TestInsertChain_RejectsPrefetchedBlocksOutOfContentOrder(t *testing.T) {
 	f := newRestoreFixtureWith(t, true)
 	defer f.z.StopPanic()
+	counting := &snapshotCountingChain{Chain: f.z.Chain()}
+	bridge := protocol.NewChainBridge(counting, f.z.Consensus(), f.z.Verifier(), f.supervisor)
 
 	blocks := f.detailed.AccountBlocks
 	if blocks[0].Address == blocks[1].Address {
 		t.Fatal("fixture should hold blocks from two different accounts")
 	}
+	// The list is still exactly the momentum's content, only not in content
+	// order. Every producer emits content order, so this is malformed input.
 	swapped := &nom.DetailedMomentum{
 		Momentum:      f.detailed.Momentum,
 		AccountBlocks: []*nom.AccountBlock{blocks[1], blocks[0]},
 	}
-	_, err := f.bridge.InsertChain([]*nom.DetailedMomentum{swapped})
+	_, err := bridge.InsertChain([]*nom.DetailedMomentum{swapped})
+	if err == nil {
+		t.Fatal("expected out-of-order prefetched blocks to be rejected")
+	}
+	common.Expect(t, counting.snapshots, 0)
+	common.Expect(t, f.z.Chain().GetFrontierMomentumStore().Identifier(), f.previous)
+
+	// Content order still inserts through the same bridge.
+	_, err = bridge.InsertChain([]*nom.DetailedMomentum{f.detailed})
 	common.FailIfErr(t, err)
 	common.Expect(t, f.z.Chain().GetFrontierMomentumStore().Identifier(), f.detailed.Momentum.Identifier())
 }
@@ -331,6 +343,22 @@ func TestInsertChain_RejectsDuplicatePrefetchedBlocks(t *testing.T) {
 	_, err := bridge.InsertChain([]*nom.DetailedMomentum{duplicated})
 	if err == nil {
 		t.Fatal("expected duplicate prefetched blocks to be rejected")
+	}
+	common.Expect(t, counting.snapshots, 0)
+	common.Expect(t, f.z.Chain().GetFrontierMomentumStore().Identifier(), f.previous)
+
+	// A momentum whose content lists the same header twice, with a matching
+	// block list, is rejected before the pool is touched rather than left
+	// for the verifier.
+	momentum := *f.detailed.Momentum
+	momentum.Content = nom.MomentumContent{momentum.Content[0], momentum.Content[0]}
+	duplicatedContent := &nom.DetailedMomentum{
+		Momentum:      &momentum,
+		AccountBlocks: []*nom.AccountBlock{blocks[0], blocks[0]},
+	}
+	_, err = bridge.InsertChain([]*nom.DetailedMomentum{duplicatedContent})
+	if err == nil {
+		t.Fatal("expected duplicated content headers to be rejected")
 	}
 	common.Expect(t, counting.snapshots, 0)
 	common.Expect(t, f.z.Chain().GetFrontierMomentumStore().Identifier(), f.previous)
@@ -373,10 +401,9 @@ func TestInsertChain_DoesNotMutateCallerDetailedMomentum(t *testing.T) {
 	f := newRestoreFixtureWith(t, true)
 	defer f.z.StopPanic()
 
-	blocks := f.detailed.AccountBlocks
 	supplied := &nom.DetailedMomentum{
 		Momentum:      f.detailed.Momentum,
-		AccountBlocks: []*nom.AccountBlock{blocks[1], blocks[0]},
+		AccountBlocks: append([]*nom.AccountBlock(nil), f.detailed.AccountBlocks...),
 	}
 	before := append([]*nom.AccountBlock(nil), supplied.AccountBlocks...)
 
@@ -395,10 +422,12 @@ func TestInsertChain_DoesNotMutateCallerDetailedMomentum(t *testing.T) {
 	<-done
 	common.FailIfErr(t, err)
 
+	// The caller's list still holds its own objects, not the private copies
+	// insert worked on.
 	common.Expect(t, len(supplied.AccountBlocks), len(before))
 	for i := range before {
 		if supplied.AccountBlocks[i] != before[i] {
-			t.Fatalf("caller's block list was reordered at index %d", i)
+			t.Fatalf("caller's block list was modified at index %d", i)
 		}
 	}
 }
@@ -410,8 +439,7 @@ func TestInsertChain_DoesNotWriteToCallerAccountBlocks(t *testing.T) {
 	// Pool holds a byte-different copy, so the momentum's block takes the
 	// replacement path through the VM, which sets plasma fields on the block
 	// it is given.
-	poolCopy := f.receive.Block.Copy()
-	poolCopy.Signature = alternateSign(g.User2, poolCopy.Hash.Bytes())
+	poolCopy := byteDifferentCopy(t, f.receive.Block)
 	common.FailIfErr(t, f.bridge.AddAccountBlocks([]*nom.AccountBlock{poolCopy}))
 
 	supplied := f.detailed.AccountBlocks[0].Copy()

--- a/protocol/chain_bridge_test.go
+++ b/protocol/chain_bridge_test.go
@@ -1,0 +1,202 @@
+package protocol_test
+
+import (
+	"crypto/ed25519"
+	"crypto/sha512"
+	"encoding/hex"
+	"math/big"
+	"testing"
+
+	g "github.com/zenon-network/go-zenon/chain/genesis/mock"
+	"github.com/zenon-network/go-zenon/chain/nom"
+	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/common/types"
+	"github.com/zenon-network/go-zenon/protocol"
+	"github.com/zenon-network/go-zenon/vm"
+	"github.com/zenon-network/go-zenon/wallet"
+	"github.com/zenon-network/go-zenon/zenon/mock"
+)
+
+// Minimal Ed25519 group arithmetic over math/big, following the RFC 8032
+// reference construction. It exists only so this test can mint a second valid
+// signature for one message without adding a dependency; the result is
+// checked with crypto/ed25519.Verify before it is used.
+var (
+	ed25519P = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 255), big.NewInt(19))
+	ed25519L = func() *big.Int {
+		l, _ := new(big.Int).SetString("7237005577332262213973186563042994240857116359379907606001950938285454250989", 10)
+		return l
+	}()
+	ed25519D = func() *big.Int {
+		inv := new(big.Int).ModInverse(big.NewInt(121666), ed25519P)
+		d := new(big.Int).Mul(big.NewInt(-121665), inv)
+		return d.Mod(d, ed25519P)
+	}()
+	ed25519B = func() *edPoint {
+		y := new(big.Int).Mul(big.NewInt(4), new(big.Int).ModInverse(big.NewInt(5), ed25519P))
+		y.Mod(y, ed25519P)
+		return &edPoint{x: edRecoverX(y, 0), y: y}
+	}()
+)
+
+type edPoint struct{ x, y *big.Int }
+
+func edMod(v *big.Int) *big.Int { return new(big.Int).Mod(v, ed25519P) }
+
+// edRecoverX returns the x coordinate with the given parity for a y coordinate
+// on the curve, using the exponentiation from RFC 8032 section 5.1.3.
+func edRecoverX(y *big.Int, sign uint) *big.Int {
+	yy := edMod(new(big.Int).Mul(y, y))
+	u := edMod(new(big.Int).Sub(yy, big.NewInt(1)))
+	v := edMod(new(big.Int).Add(new(big.Int).Mul(ed25519D, yy), big.NewInt(1)))
+	xx := edMod(new(big.Int).Mul(u, new(big.Int).ModInverse(v, ed25519P)))
+	exp := new(big.Int).Rsh(new(big.Int).Add(ed25519P, big.NewInt(3)), 3)
+	x := new(big.Int).Exp(xx, exp, ed25519P)
+	if edMod(new(big.Int).Mul(x, x)).Cmp(xx) != 0 {
+		sqrtM1 := new(big.Int).Exp(big.NewInt(2), new(big.Int).Rsh(new(big.Int).Sub(ed25519P, big.NewInt(1)), 2), ed25519P)
+		x = edMod(new(big.Int).Mul(x, sqrtM1))
+	}
+	if x.Bit(0) != sign {
+		x = edMod(new(big.Int).Neg(x))
+	}
+	return x
+}
+
+func edAdd(p, q *edPoint) *edPoint {
+	x1x2 := new(big.Int).Mul(p.x, q.x)
+	y1y2 := new(big.Int).Mul(p.y, q.y)
+	x1y2 := new(big.Int).Mul(p.x, q.y)
+	x2y1 := new(big.Int).Mul(q.x, p.y)
+	dxxyy := edMod(new(big.Int).Mul(ed25519D, new(big.Int).Mul(x1x2, y1y2)))
+	x := new(big.Int).Mul(new(big.Int).Add(x1y2, x2y1), new(big.Int).ModInverse(edMod(new(big.Int).Add(big.NewInt(1), dxxyy)), ed25519P))
+	y := new(big.Int).Mul(new(big.Int).Add(y1y2, x1x2), new(big.Int).ModInverse(edMod(new(big.Int).Sub(big.NewInt(1), dxxyy)), ed25519P))
+	return &edPoint{x: edMod(x), y: edMod(y)}
+}
+
+func edScalarMult(scalar *big.Int, p *edPoint) *edPoint {
+	result := &edPoint{x: big.NewInt(0), y: big.NewInt(1)}
+	for i := scalar.BitLen() - 1; i >= 0; i-- {
+		result = edAdd(result, result)
+		if scalar.Bit(i) == 1 {
+			result = edAdd(result, p)
+		}
+	}
+	return result
+}
+
+func edEncode(p *edPoint) []byte {
+	out := make([]byte, 32)
+	p.y.FillBytes(out)
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	out[31] |= byte(p.x.Bit(0)) << 7
+	return out
+}
+
+func edLittleEndian(b []byte) *big.Int {
+	reversed := make([]byte, len(b))
+	for i := range b {
+		reversed[len(b)-1-i] = b[i]
+	}
+	return new(big.Int).SetBytes(reversed)
+}
+
+func edEncodeScalar(v *big.Int) []byte {
+	out := make([]byte, 32)
+	new(big.Int).Mod(v, ed25519L).FillBytes(out)
+	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
+		out[i], out[j] = out[j], out[i]
+	}
+	return out
+}
+
+// alternateSign produces a valid Ed25519 signature for message that differs from
+// the deterministic RFC 8032 signature, by deriving the nonce from an extra
+// domain string. Both signatures verify under the same public key.
+func alternateSign(keyPair *wallet.KeyPair, message []byte) []byte {
+	digest := sha512.Sum512(keyPair.Private.Seed())
+	clamped := make([]byte, 32)
+	copy(clamped, digest[:32])
+	clamped[0] &= 248
+	clamped[31] &= 127
+	clamped[31] |= 64
+	secret := edLittleEndian(clamped)
+	prefix := digest[32:]
+
+	nonceHash := sha512.New()
+	nonceHash.Write([]byte("alternate-nonce"))
+	nonceHash.Write(prefix)
+	nonceHash.Write(message)
+	nonce := new(big.Int).Mod(edLittleEndian(nonceHash.Sum(nil)), ed25519L)
+	commitment := edEncode(edScalarMult(nonce, ed25519B))
+
+	challengeHash := sha512.New()
+	challengeHash.Write(commitment)
+	challengeHash.Write(keyPair.Public)
+	challengeHash.Write(message)
+	challenge := new(big.Int).Mod(edLittleEndian(challengeHash.Sum(nil)), ed25519L)
+
+	response := new(big.Int).Add(nonce, new(big.Int).Mul(challenge, secret))
+	return append(commitment, edEncodeScalar(response)...)
+}
+
+func TestInsertChain_MomentumBytesReplacePoolCopyOfSameBlock(t *testing.T) {
+	z := mock.NewMockZenon(t)
+	defer z.StopPanic()
+	supervisor := vm.NewSupervisor(z.Chain(), z.Consensus())
+	bridge := protocol.NewChainBridge(z.Chain(), z.Consensus(), z.Verifier(), supervisor)
+
+	// User1 sends one raw ZNN unit to User2 and the send gets committed.
+	send := z.InsertSendBlock(&nom.AccountBlock{
+		Address:       g.User1.Address,
+		ToAddress:     g.User2.Address,
+		TokenStandard: types.ZnnTokenStandard,
+		Amount:        big.NewInt(1),
+	}, nil, mock.SkipVmChanges)
+	z.InsertNewMomentum()
+
+	// User2 receives it. This copy, with the deterministic signature, is the one
+	// the momentum is built from.
+	momentumCopy, err := supervisor.GenerateFromTemplate(&nom.AccountBlock{
+		BlockType:     nom.BlockTypeUserReceive,
+		Address:       g.User2.Address,
+		FromBlockHash: send.Hash,
+	}, g.User2.Signer)
+	common.FailIfErr(t, err)
+	z.Broadcaster().CreateAccountBlock(momentumCopy)
+	z.InsertNewMomentum()
+
+	store := z.Chain().GetFrontierMomentumStore()
+	momentum, err := store.GetFrontierMomentum()
+	common.FailIfErr(t, err)
+	detailed, err := store.PrefetchMomentum(momentum)
+	common.FailIfErr(t, err)
+	common.Expect(t, len(detailed.AccountBlocks), 1)
+	common.Expect(t, detailed.AccountBlocks[0].Identifier(), momentumCopy.Block.Identifier())
+
+	// Roll back so the momentum can be replayed against a pool that holds a
+	// byte-different copy of the same block.
+	insert := z.Chain().AcquireInsert("test rollback")
+	common.FailIfErr(t, z.Chain().RollbackTo(insert, momentum.Previous()))
+	insert.Unlock()
+
+	poolCopy := momentumCopy.Block.Copy()
+	poolCopy.Signature = alternateSign(g.User2, poolCopy.Hash.Bytes())
+	if !ed25519.Verify(g.User2.Public, poolCopy.Hash.Bytes(), poolCopy.Signature) {
+		t.Fatal("alternate signature does not verify")
+	}
+	if string(poolCopy.Signature) == string(momentumCopy.Block.Signature) {
+		t.Fatal("alternate signature is identical to the deterministic one")
+	}
+	common.FailIfErr(t, bridge.AddAccountBlocks([]*nom.AccountBlock{poolCopy}))
+
+	_, err = bridge.InsertChain([]*nom.DetailedMomentum{detailed})
+	common.FailIfErr(t, err)
+
+	frontier := z.Chain().GetFrontierMomentumStore()
+	common.Expect(t, frontier.Identifier(), momentum.Identifier())
+	committed, err := frontier.GetAccountBlock(momentumCopy.Block.Header())
+	common.FailIfErr(t, err)
+	common.ExpectBytes(t, committed.Signature, "0x"+hex.EncodeToString(momentumCopy.Block.Signature))
+}

--- a/protocol/chain_bridge_test.go
+++ b/protocol/chain_bridge_test.go
@@ -1,9 +1,6 @@
 package protocol_test
 
 import (
-	"crypto/ed25519"
-	"crypto/sha512"
-	"encoding/hex"
 	"math/big"
 	"testing"
 
@@ -13,132 +10,26 @@ import (
 	"github.com/zenon-network/go-zenon/common/types"
 	"github.com/zenon-network/go-zenon/protocol"
 	"github.com/zenon-network/go-zenon/vm"
-	"github.com/zenon-network/go-zenon/wallet"
 	"github.com/zenon-network/go-zenon/zenon/mock"
 )
 
-// Minimal Ed25519 group arithmetic over math/big, following the RFC 8032
-// reference construction. It exists only so this test can mint a second valid
-// signature for one message without adding a dependency; the result is
-// checked with crypto/ed25519.Verify before it is used.
-var (
-	ed25519P = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 255), big.NewInt(19))
-	ed25519L = func() *big.Int {
-		l, _ := new(big.Int).SetString("7237005577332262213973186563042994240857116359379907606001950938285454250989", 10)
-		return l
-	}()
-	ed25519D = func() *big.Int {
-		inv := new(big.Int).ModInverse(big.NewInt(121666), ed25519P)
-		d := new(big.Int).Mul(big.NewInt(-121665), inv)
-		return d.Mod(d, ed25519P)
-	}()
-	ed25519B = func() *edPoint {
-		y := new(big.Int).Mul(big.NewInt(4), new(big.Int).ModInverse(big.NewInt(5), ed25519P))
-		y.Mod(y, ed25519P)
-		return &edPoint{x: edRecoverX(y, 0), y: y}
-	}()
-)
-
-type edPoint struct{ x, y *big.Int }
-
-func edMod(v *big.Int) *big.Int { return new(big.Int).Mod(v, ed25519P) }
-
-// edRecoverX returns the x coordinate with the given parity for a y coordinate
-// on the curve, using the exponentiation from RFC 8032 section 5.1.3.
-func edRecoverX(y *big.Int, sign uint) *big.Int {
-	yy := edMod(new(big.Int).Mul(y, y))
-	u := edMod(new(big.Int).Sub(yy, big.NewInt(1)))
-	v := edMod(new(big.Int).Add(new(big.Int).Mul(ed25519D, yy), big.NewInt(1)))
-	xx := edMod(new(big.Int).Mul(u, new(big.Int).ModInverse(v, ed25519P)))
-	exp := new(big.Int).Rsh(new(big.Int).Add(ed25519P, big.NewInt(3)), 3)
-	x := new(big.Int).Exp(xx, exp, ed25519P)
-	if edMod(new(big.Int).Mul(x, x)).Cmp(xx) != 0 {
-		sqrtM1 := new(big.Int).Exp(big.NewInt(2), new(big.Int).Rsh(new(big.Int).Sub(ed25519P, big.NewInt(1)), 2), ed25519P)
-		x = edMod(new(big.Int).Mul(x, sqrtM1))
+// byteDifferentCopy returns a copy of block that keeps the same identifier and
+// signature but serializes to different bytes. ChangesHash is stored on user
+// blocks, excluded from the hash and never checked for them, so changing it is
+// the cheapest way to build such a copy. In the field the differing field was
+// the signature, which is also outside the hash; the code under test compares
+// whole serialized blocks, so it does not matter which field differs.
+func byteDifferentCopy(t *testing.T, block *nom.AccountBlock) *nom.AccountBlock {
+	t.Helper()
+	copied := block.Copy()
+	copied.ChangesHash = types.HexToHashPanic("1111111111111111111111111111111111111111111111111111111111111111")
+	if copied.ChangesHash == block.ChangesHash {
+		t.Fatal("changes-hash already had the substitute value")
 	}
-	if x.Bit(0) != sign {
-		x = edMod(new(big.Int).Neg(x))
+	if copied.Identifier() != block.Identifier() || copied.EqualBytes(block) {
+		t.Fatal("copy must keep the identifier and differ in bytes")
 	}
-	return x
-}
-
-func edAdd(p, q *edPoint) *edPoint {
-	x1x2 := new(big.Int).Mul(p.x, q.x)
-	y1y2 := new(big.Int).Mul(p.y, q.y)
-	x1y2 := new(big.Int).Mul(p.x, q.y)
-	x2y1 := new(big.Int).Mul(q.x, p.y)
-	dxxyy := edMod(new(big.Int).Mul(ed25519D, new(big.Int).Mul(x1x2, y1y2)))
-	x := new(big.Int).Mul(new(big.Int).Add(x1y2, x2y1), new(big.Int).ModInverse(edMod(new(big.Int).Add(big.NewInt(1), dxxyy)), ed25519P))
-	y := new(big.Int).Mul(new(big.Int).Add(y1y2, x1x2), new(big.Int).ModInverse(edMod(new(big.Int).Sub(big.NewInt(1), dxxyy)), ed25519P))
-	return &edPoint{x: edMod(x), y: edMod(y)}
-}
-
-func edScalarMult(scalar *big.Int, p *edPoint) *edPoint {
-	result := &edPoint{x: big.NewInt(0), y: big.NewInt(1)}
-	for i := scalar.BitLen() - 1; i >= 0; i-- {
-		result = edAdd(result, result)
-		if scalar.Bit(i) == 1 {
-			result = edAdd(result, p)
-		}
-	}
-	return result
-}
-
-func edEncode(p *edPoint) []byte {
-	out := make([]byte, 32)
-	p.y.FillBytes(out)
-	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
-		out[i], out[j] = out[j], out[i]
-	}
-	out[31] |= byte(p.x.Bit(0)) << 7
-	return out
-}
-
-func edLittleEndian(b []byte) *big.Int {
-	reversed := make([]byte, len(b))
-	for i := range b {
-		reversed[len(b)-1-i] = b[i]
-	}
-	return new(big.Int).SetBytes(reversed)
-}
-
-func edEncodeScalar(v *big.Int) []byte {
-	out := make([]byte, 32)
-	new(big.Int).Mod(v, ed25519L).FillBytes(out)
-	for i, j := 0, len(out)-1; i < j; i, j = i+1, j-1 {
-		out[i], out[j] = out[j], out[i]
-	}
-	return out
-}
-
-// alternateSign produces a valid Ed25519 signature for message that differs from
-// the deterministic RFC 8032 signature, by deriving the nonce from an extra
-// domain string. Both signatures verify under the same public key.
-func alternateSign(keyPair *wallet.KeyPair, message []byte) []byte {
-	digest := sha512.Sum512(keyPair.Private.Seed())
-	clamped := make([]byte, 32)
-	copy(clamped, digest[:32])
-	clamped[0] &= 248
-	clamped[31] &= 127
-	clamped[31] |= 64
-	secret := edLittleEndian(clamped)
-	prefix := digest[32:]
-
-	nonceHash := sha512.New()
-	nonceHash.Write([]byte("alternate-nonce"))
-	nonceHash.Write(prefix)
-	nonceHash.Write(message)
-	nonce := new(big.Int).Mod(edLittleEndian(nonceHash.Sum(nil)), ed25519L)
-	commitment := edEncode(edScalarMult(nonce, ed25519B))
-
-	challengeHash := sha512.New()
-	challengeHash.Write(commitment)
-	challengeHash.Write(keyPair.Public)
-	challengeHash.Write(message)
-	challenge := new(big.Int).Mod(edLittleEndian(challengeHash.Sum(nil)), ed25519L)
-
-	response := new(big.Int).Add(nonce, new(big.Int).Mul(challenge, secret))
-	return append(commitment, edEncodeScalar(response)...)
+	return copied
 }
 
 func TestInsertChain_MomentumBytesReplacePoolCopyOfSameBlock(t *testing.T) {
@@ -181,14 +72,7 @@ func TestInsertChain_MomentumBytesReplacePoolCopyOfSameBlock(t *testing.T) {
 	common.FailIfErr(t, z.Chain().RollbackTo(insert, momentum.Previous()))
 	insert.Unlock()
 
-	poolCopy := momentumCopy.Block.Copy()
-	poolCopy.Signature = alternateSign(g.User2, poolCopy.Hash.Bytes())
-	if !ed25519.Verify(g.User2.Public, poolCopy.Hash.Bytes(), poolCopy.Signature) {
-		t.Fatal("alternate signature does not verify")
-	}
-	if string(poolCopy.Signature) == string(momentumCopy.Block.Signature) {
-		t.Fatal("alternate signature is identical to the deterministic one")
-	}
+	poolCopy := byteDifferentCopy(t, momentumCopy.Block)
 	common.FailIfErr(t, bridge.AddAccountBlocks([]*nom.AccountBlock{poolCopy}))
 
 	_, err = bridge.InsertChain([]*nom.DetailedMomentum{detailed})
@@ -198,5 +82,7 @@ func TestInsertChain_MomentumBytesReplacePoolCopyOfSameBlock(t *testing.T) {
 	common.Expect(t, frontier.Identifier(), momentum.Identifier())
 	committed, err := frontier.GetAccountBlock(momentumCopy.Block.Header())
 	common.FailIfErr(t, err)
-	common.ExpectBytes(t, committed.Signature, "0x"+hex.EncodeToString(momentumCopy.Block.Signature))
+	if !committed.EqualBytes(momentumCopy.Block) {
+		t.Fatal("committed block does not match the momentum's copy")
+	}
 }


### PR DESCRIPTION
The Alphanet stall at momentum 14103620 was triggered by two differently signed copies of the same user transaction (account block). Both signatures were valid. The copies had the same hash and height because the signature is excluded from the block hash, but their stored bytes differed and those bytes contribute to the momentum's changes-hash. The momentum producer used one copy; nodes that received the other first kept it in their pools, computed a different changes-hash, and stopped syncing. This PR makes forced insertion use the momentum's copy and restores affected pool state if insertion fails before commit. Broadcast inserts still keep the first copy. Prefetched blocks are bounded, checked in content order, and copied before application; previously tolerated out-of-order lists are rejected.

The existing [regression test](https://github.com/0x3639/go-zenon/blob/2be586f0051f51bcd99e63461bf38e6b6809713e/protocol/chain_bridge_test.go#L35) reproduces the same byte mismatch by changing the pool copy's unhashed `ChangesHash` field. Verified with Go 1.25.4: it fails against the old insertion logic at `667a69d` with `momentum changes-hash is different than the one computed` and passes at PR head `2be586f`. Run on the PR branch:

```sh
GOWORK=off go test ./protocol -run '^TestInsertChain_MomentumBytesReplacePoolCopyOfSameBlock$' -count=1
```

<details>
<summary>Reproduce the failure before the fix</summary>

From a checkout containing the PR commit, run:

```sh
pr=2be586f0051f51bcd99e63461bf38e6b6809713e
before=$(mktemp -d)
git archive 667a69d9e9a418edf7580b08492ba5dcb9efd63a | tar -x -C "$before"
git show "$pr":protocol/chain_bridge_test.go > "$before/protocol/chain_bridge_test.go"
git show "$pr":chain/nom/account_block.go > "$before/chain/nom/account_block.go"
(cd "$before" && GOWORK=off go test ./protocol -run '^TestInsertChain_MomentumBytesReplacePoolCopyOfSameBlock$' -count=1)
```

The temporary copy includes the unchanged regression test and `AccountBlock.EqualBytes`, its serialization-comparison helper. That helper is the only production-file difference from the base; the account-pool and sync insertion logic remain unchanged. The run should fail with the changes-hash error above. Your checkout is untouched.

</details>

Review limitations remain: readers can observe provisional pool state during validation ([#100](https://github.com/zenon-network/go-zenon/issues/100)); maintainer acceptance is still pending. The existing post-commit test injects its error after broadcast and does not cover the [internal commit-to-broadcast failure window](https://github.com/zenon-network/go-zenon/pull/81#issuecomment-5575192433).
