### PR TITLE
chain,protocol: keep the canonical branch when a side-chain replacement fails

### DIFF
--- a/chain/interface.go
+++ b/chain/interface.go
@@ -37,6 +37,10 @@ type MomentumEventManager interface {
 }
 
 type MomentumPool interface {
+	// CaptureBranchAbove returns every momentum above identifier, lowest first,
+	// together with its stored state patch, so the branch can be re-inserted
+	// after a rollback. It fails, without side effects, if any patch is missing.
+	CaptureBranchAbove(insertLocker sync.Locker, identifier types.HashHeight) ([]*RemovedMomentum, error)
 	AddMomentumTransaction(insertLocker sync.Locker, transaction *nom.MomentumTransaction) error
 	RollbackTo(insertLocker sync.Locker, identifier types.HashHeight) error
 

--- a/chain/interface.go
+++ b/chain/interface.go
@@ -41,6 +41,9 @@ type MomentumPool interface {
 	// together with its stored state patch, so the branch can be re-inserted
 	// after a rollback. It fails, without side effects, if any patch is missing.
 	CaptureBranchAbove(insertLocker sync.Locker, identifier types.HashHeight) ([]*RemovedMomentum, error)
+	// GetMomentumPatch returns the state patch stored for the momentum with
+	// this identifier, as the manager holds it, or nil if there is none.
+	GetMomentumPatch(identifier types.HashHeight) db.Patch
 	AddMomentumTransaction(insertLocker sync.Locker, transaction *nom.MomentumTransaction) error
 	RollbackTo(insertLocker sync.Locker, identifier types.HashHeight) error
 

--- a/chain/momentum_pool.go
+++ b/chain/momentum_pool.go
@@ -166,6 +166,12 @@ func (c *momentumPool) CaptureBranchAbove(insertLocker sync.Locker, identifier t
 	return removed, nil
 }
 
+func (c *momentumPool) GetMomentumPatch(identifier types.HashHeight) db.Patch {
+	c.changes.Lock()
+	defer c.changes.Unlock()
+	return c.chainManager.GetPatch(identifier)
+}
+
 func (c *momentumPool) RollbackTo(insertLocker sync.Locker, identifier types.HashHeight) error {
 	c.log.Info("rollbacking momentums", "to-identifier", identifier)
 	if insertLocker == nil {

--- a/chain/momentum_pool.go
+++ b/chain/momentum_pool.go
@@ -108,6 +108,64 @@ func (c *momentumPool) AddMomentumTransaction(insertLocker sync.Locker, transact
 
 	return nil
 }
+
+// RemovedMomentum is one momentum taken off the canonical chain by a rollback,
+// with the state patch that re-inserts it.
+type RemovedMomentum struct {
+	Detailed *nom.DetailedMomentum
+	Changes  db.Patch
+}
+
+func (c *momentumPool) CaptureBranchAbove(insertLocker sync.Locker, identifier types.HashHeight) ([]*RemovedMomentum, error) {
+	if insertLocker == nil {
+		return nil, errors.Errorf("insertLocker can't be nil")
+	}
+	c.changes.Lock()
+	defer c.changes.Unlock()
+
+	store := c.getFrontierStore()
+	target, err := store.GetMomentumByHeight(identifier.Height)
+	if err != nil {
+		return nil, err
+	}
+	if target == nil || target.Hash != identifier.Hash {
+		return nil, errors.Errorf("can't capture branch above %v. Not on the canonical chain", identifier)
+	}
+	frontier, err := store.GetFrontierMomentum()
+	if err != nil {
+		return nil, err
+	}
+
+	removed := make([]*RemovedMomentum, 0, frontier.Height-identifier.Height)
+	for height := identifier.Height + 1; height <= frontier.Height; height++ {
+		momentum, err := store.GetMomentumByHeight(height)
+		if err != nil {
+			return nil, err
+		}
+		if momentum == nil {
+			return nil, errors.Errorf("can't capture branch above %v. Missing momentum at height %v", identifier, height)
+		}
+		detailed, err := store.PrefetchMomentum(momentum)
+		if err != nil {
+			return nil, err
+		}
+		stored := c.chainManager.GetPatch(momentum.Identifier())
+		if stored == nil {
+			return nil, errors.Errorf("can't capture branch above %v. Missing patch for momentum %v", identifier, momentum.Identifier())
+		}
+		// The stored patch already carries the frontier writes Manager.Add
+		// appended when the momentum was first inserted. Strip them so that
+		// re-adding the momentum appends them exactly once and the stored
+		// patch stays byte-identical across a restore.
+		changes, err := db.RemoveKeys(stored, db.FrontierWriteKeys(momentum.Identifier()))
+		if err != nil {
+			return nil, err
+		}
+		removed = append(removed, &RemovedMomentum{Detailed: detailed, Changes: changes})
+	}
+	return removed, nil
+}
+
 func (c *momentumPool) RollbackTo(insertLocker sync.Locker, identifier types.HashHeight) error {
 	c.log.Info("rollbacking momentums", "to-identifier", identifier)
 	if insertLocker == nil {

--- a/common/db/patch.go
+++ b/common/db/patch.go
@@ -134,6 +134,35 @@ func (pa *patchApplierWO) Delete(key []byte) {
 	}
 }
 
+// keyFilter replays a patch into another one, dropping the listed keys.
+type keyFilter struct {
+	out  Patch
+	skip map[string]struct{}
+}
+
+func (kf *keyFilter) Put(key []byte, value []byte) {
+	if _, drop := kf.skip[string(key)]; !drop {
+		kf.out.Put(key, value)
+	}
+}
+func (kf *keyFilter) Delete(key []byte) {
+	if _, drop := kf.skip[string(key)]; !drop {
+		kf.out.Delete(key)
+	}
+}
+
+// RemoveKeys returns a copy of patch without any operation on the given keys.
+func RemoveKeys(patch Patch, keys [][]byte) (Patch, error) {
+	filter := &keyFilter{out: NewPatch(), skip: make(map[string]struct{}, len(keys))}
+	for _, key := range keys {
+		filter.skip[string(key)] = struct{}{}
+	}
+	if err := patch.Replay(filter); err != nil {
+		return nil, err
+	}
+	return filter.out, nil
+}
+
 func DebugPatch(patch Patch) string {
 	pp := new(patchPrinter)
 	err := patch.Replay(pp)

--- a/common/db/store.go
+++ b/common/db/store.go
@@ -17,6 +17,17 @@ func getEntryByHeightKey(height uint64) []byte {
 	return common.JoinBytes(entryByHeightPrefix, common.Uint64ToBytes(height))
 }
 
+// FrontierWriteKeys lists the keys SetFrontier writes for a version. A patch
+// read back from a versioned manager already contains these writes, appended
+// by Manager.Add; strip them before handing such a patch to Add again.
+func FrontierWriteKeys(version types.HashHeight) [][]byte {
+	return [][]byte{
+		getFrontierIdentifierKey(),
+		getHeightByHashKey(version.Hash),
+		getEntryByHeightKey(version.Height),
+	}
+}
+
 func SetFrontier(db DB, version types.HashHeight, data []byte) error {
 	if err := db.Put(getFrontierIdentifierKey(), version.Serialize()); err != nil {
 		return err

--- a/protocol/chain_bridge.go
+++ b/protocol/chain_bridge.go
@@ -14,6 +14,7 @@ import (
 	"github.com/zenon-network/go-zenon/consensus"
 	"github.com/zenon-network/go-zenon/verifier"
 	"github.com/zenon-network/go-zenon/vm"
+	"github.com/zenon-network/go-zenon/wallet"
 )
 
 type chainBridge struct {
@@ -198,6 +199,29 @@ func (c chainBridge) InsertChain(momentums []*nom.DetailedMomentum) (int, error)
 			return 0, errors.Errorf("won't insert side-chain which is not longer")
 		}
 
+		// Everything that can be checked without chain state is checked
+		// before any canonical momentum is removed, so a candidate that is
+		// not even internally consistent never triggers a rollback.
+		for index, detailed := range momentums {
+			if err := verifyMomentumStatically(detailed.Momentum); err != nil {
+				log.Info("side-chain momentum failed static verification", "reason", err, "momentum-identifier", detailed.Momentum.Identifier())
+				return index + start, err
+			}
+		}
+		if c.verifier != nil {
+			if err := c.verifier.Momentum(momentums[0]); err != nil {
+				log.Info("side-chain head failed verification", "reason", err, "momentum-identifier", head.Identifier())
+				return start, err
+			}
+		}
+
+		// The state-dependent checks can only run after the rollback, so keep
+		// the branch being removed and put it back if the replacement fails.
+		removed, err := c.chain.CaptureBranchAbove(insert, target.Identifier())
+		if err != nil {
+			return 0, errors.Errorf("unable to capture branch above %v for rollback. Reason:%v", target.Identifier(), err)
+		}
+
 		if err := c.rollbackSideChain(insert, target.Identifier()); err != nil {
 			var uncertain *chain.ErrCanonicalStateUncertain
 			if errors.As(err, &uncertain) {
@@ -206,9 +230,71 @@ func (c chainBridge) InsertChain(momentums []*nom.DetailedMomentum) (int, error)
 			}
 			return 0, errors.Errorf("unable to rollback to %v. Reason:%v", target.Identifier(), err)
 		}
+
+		index, err := c.insertMomentums(insert, momentums)
+		if err != nil {
+			log.Info("side-chain replacement failed, restoring original branch", "reason", err, "target", target.Identifier(), "num-momentums", len(removed))
+			if restoreErr := c.restoreBranch(insert, target.Identifier(), removed); restoreErr != nil {
+				log.Crit("chain state uncertain after failed side-chain restore, can't continue", "reason", restoreErr, "cause", err, "target", target.Identifier())
+				os.Exit(2)
+			}
+			return index + start, err
+		}
+		return 0, nil
 	}
 
-	// Insert momentum now
+	index, err := c.insertMomentums(insert, momentums)
+	if err != nil {
+		return index + start, err
+	}
+	return 0, nil
+}
+
+// verifyMomentumStatically runs the checks that need no chain state: the
+// advertised hash matches the content, and the signature is valid for the
+// public key carried by the momentum. Whether that key is the elected
+// producer is a state-dependent check that runs later.
+func verifyMomentumStatically(momentum *nom.Momentum) error {
+	if momentum == nil {
+		return errors.Errorf("missing momentum")
+	}
+	if momentum.ComputeHash() != momentum.Hash {
+		return verifier.ErrMHashInvalid
+	}
+	if len(momentum.Signature) == 0 {
+		return verifier.ErrMSignatureMissing
+	}
+	if len(momentum.PublicKey) == 0 {
+		return verifier.ErrMPublicKeyMissing
+	}
+	isVerified, err := wallet.VerifySignature(momentum.PublicKey, momentum.Hash.Bytes(), momentum.Signature)
+	if err != nil || !isVerified {
+		return verifier.ErrMSignatureInvalid
+	}
+	return nil
+}
+
+// restoreBranch drops whatever replaced the branch above target and puts the
+// captured momentums back, in order, with their cache state.
+func (c chainBridge) restoreBranch(insert sync.Locker, target types.HashHeight, removed []*chain.RemovedMomentum) error {
+	if err := c.rollbackSideChain(insert, target); err != nil {
+		return err
+	}
+	for _, momentum := range removed {
+		if err := c.chain.UpdateCache(insert, momentum.Detailed, momentum.Changes); err != nil {
+			return errors.Errorf("unable to restore cache for %v. Reason:%v", momentum.Detailed.Momentum.Identifier(), err)
+		}
+		transaction := &nom.MomentumTransaction{Momentum: momentum.Detailed.Momentum, Changes: momentum.Changes}
+		if err := c.chain.AddMomentumTransaction(insert, transaction); err != nil {
+			return errors.Errorf("unable to restore momentum %v. Reason:%v", momentum.Detailed.Momentum.Identifier(), err)
+		}
+	}
+	return nil
+}
+
+// insertMomentums applies and commits the momentums one by one. The returned
+// index identifies the momentum that failed.
+func (c chainBridge) insertMomentums(insert sync.Locker, momentums []*nom.DetailedMomentum) (int, error) {
 	for index, detailed := range momentums {
 		for _, block := range detailed.AccountBlocks {
 			if block.BlockType == nom.BlockTypeContractSend {
@@ -221,21 +307,21 @@ func (c chainBridge) InsertChain(momentums []*nom.DetailedMomentum) (int, error)
 			transaction, err := c.supervisor.ApplyBlock(block)
 			if err != nil {
 				log.Error("error while applying account-block", "reason", err, "account-block-header", block.Header())
-				return index + start, err
+				return index, err
 			}
 			if err := c.chain.ForceAddAccountBlockTransaction(insert, transaction); err != nil {
 				log.Error("error while inserting account-block in pool", "reason", err, "account-block-header", block.Header())
-				return index + start, err
+				return index, err
 			}
 		}
 
 		transaction, err := c.supervisor.ApplyMomentum(detailed)
 		if err != nil {
-			return index + start, err
+			return index, err
 		}
 		if err := c.chain.UpdateCache(insert, detailed, transaction.Changes); err != nil {
 			log.Error("error while inserting cache", "reason", err, "momentum-identifier", detailed.Momentum.Identifier())
-			return index + start, err
+			return index, err
 		}
 		if err := c.chain.AddMomentumTransaction(insert, transaction); err != nil {
 			log.Error("error while inserting momentum", "reason", err, "momentum-identifier", detailed.Momentum.Identifier())
@@ -248,7 +334,7 @@ func (c chainBridge) InsertChain(momentums []*nom.DetailedMomentum) (int, error)
 				log.Crit("cache rollback failed after failed momentum insertion, can't continue", "reason", rollbackErr, "cause", err, "momentum-identifier", detailed.Momentum.Identifier())
 				os.Exit(2)
 			}
-			return index + start, err
+			return index, err
 		}
 	}
 

--- a/protocol/chain_bridge.go
+++ b/protocol/chain_bridge.go
@@ -233,6 +233,17 @@ func (c chainBridge) InsertChain(momentums []*nom.DetailedMomentum) (int, error)
 
 		index, err := c.insertMomentums(insert, momentums)
 		if err != nil {
+			// index is also how many candidates were committed. Once that
+			// prefix is longer than the branch it replaced, the node sits on a
+			// valid chain longer than the one it had, so the prefix stays.
+			// A restore only happens while the prefix is at most as long as
+			// the removed branch, which the depth check above bounds to 30;
+			// rolling that far back always fits in the cache's rollback
+			// window, whereas the committed prefix has no such bound.
+			if index > len(removed) {
+				log.Info("side-chain replacement failed after exceeding the removed branch, keeping the applied prefix", "reason", err, "target", target.Identifier(), "num-applied", index, "num-removed", len(removed))
+				return index + start, err
+			}
 			log.Info("side-chain replacement failed, restoring original branch", "reason", err, "target", target.Identifier(), "num-momentums", len(removed))
 			if restoreErr := c.restoreBranch(insert, target.Identifier(), removed); restoreErr != nil {
 				log.Crit("chain state uncertain after failed side-chain restore, can't continue", "reason", restoreErr, "cause", err, "target", target.Identifier())
@@ -276,6 +287,13 @@ func verifyMomentumStatically(momentum *nom.Momentum) error {
 
 // restoreBranch drops whatever replaced the branch above target and puts the
 // captured momentums back, in order, with their cache state.
+//
+// What it restores is the canonical chain and the cache. It does not undo the
+// delete events listeners already saw (they see insert events for the same
+// momentums instead), and the account pool stays as the rollback left it. The
+// captured branch lives only in memory: if the process dies part-way through,
+// the node comes back at the fork point plus whatever was committed, which is
+// a valid prefix it resynchronises from, not the restored branch.
 func (c chainBridge) restoreBranch(insert sync.Locker, target types.HashHeight, removed []*chain.RemovedMomentum) error {
 	if err := c.rollbackSideChain(insert, target); err != nil {
 		return err

--- a/protocol/chain_bridge_sidechain_test.go
+++ b/protocol/chain_bridge_sidechain_test.go
@@ -1,0 +1,355 @@
+package protocol_test
+
+import (
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/zenon-network/go-zenon/chain"
+	g "github.com/zenon-network/go-zenon/chain/genesis/mock"
+	"github.com/zenon-network/go-zenon/chain/nom"
+	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/common/types"
+	"github.com/zenon-network/go-zenon/protocol"
+	"github.com/zenon-network/go-zenon/vm"
+	"github.com/zenon-network/go-zenon/zenon/mock"
+)
+
+// rollbackCountingChain records how often the bridge rolls the canonical
+// chain back.
+type rollbackCountingChain struct {
+	chain.Chain
+	rollbacks int
+}
+
+func (c *rollbackCountingChain) RollbackTo(insertLocker sync.Locker, identifier types.HashHeight) error {
+	c.rollbacks++
+	return c.Chain.RollbackTo(insertLocker, identifier)
+}
+
+// chainSnapshot is everything a failed side-chain insert must leave alone.
+type chainSnapshot struct {
+	frontier      types.HashHeight
+	cacheFrontier types.HashHeight
+	hashes        map[uint64]types.Hash
+	balances      map[types.Address]string
+}
+
+func snapshotChain(t *testing.T, c chain.Chain) chainSnapshot {
+	t.Helper()
+	store := c.GetFrontierMomentumStore()
+	frontier, err := store.GetFrontierMomentum()
+	common.FailIfErr(t, err)
+	snapshot := chainSnapshot{
+		frontier:      frontier.Identifier(),
+		cacheFrontier: c.GetFrontierCacheStore().Identifier(),
+		hashes:        make(map[uint64]types.Hash, frontier.Height),
+	}
+	for height := uint64(1); height <= frontier.Height; height++ {
+		momentum, err := store.GetMomentumByHeight(height)
+		common.FailIfErr(t, err)
+		snapshot.hashes[height] = momentum.Hash
+	}
+	common.Expect(t, snapshot.cacheFrontier, snapshot.frontier)
+	snapshot.balances = make(map[types.Address]string)
+	for _, address := range []types.Address{g.User1.Address, g.User2.Address, g.Pillar1.Address, types.PillarContract} {
+		balance, err := store.GetAccountStore(address).GetBalance(types.ZnnTokenStandard)
+		common.FailIfErr(t, err)
+		snapshot.balances[address] = balance.String()
+	}
+	return snapshot
+}
+
+func expectChainEquals(t *testing.T, c chain.Chain, expected chainSnapshot) {
+	t.Helper()
+	actual := snapshotChain(t, c)
+	common.Expect(t, actual.frontier, expected.frontier)
+	common.Expect(t, actual.cacheFrontier, expected.cacheFrontier)
+	common.Expect(t, len(actual.hashes), len(expected.hashes))
+	for height, hash := range expected.hashes {
+		common.Expect(t, actual.hashes[height], hash)
+	}
+	for address, balance := range expected.balances {
+		common.Expect(t, actual.balances[address], balance)
+	}
+}
+
+// attackerMomentum builds a momentum on top of previous that is internally
+// consistent (hash recomputed, signed by a key that is not an elected
+// producer) but carries a changes-hash the node cannot reproduce. It passes
+// every check that needs no chain state and fails the first one that does.
+func attackerMomentum(previous *nom.Momentum, height uint64) *nom.Momentum {
+	timestamp := time.Unix(int64(previous.TimestampUnix+10), 0)
+	momentum := &nom.Momentum{
+		Version:         previous.Version,
+		ChainIdentifier: previous.ChainIdentifier,
+		PreviousHash:    previous.Hash,
+		Height:          height,
+		TimestampUnix:   previous.TimestampUnix + 10,
+		Timestamp:       &timestamp,
+		Content:         nom.NewMomentumContent(nil),
+		ChangesHash:     types.NewHash([]byte("not the state this momentum produces")),
+	}
+	momentum.Hash = momentum.ComputeHash()
+	momentum.PublicKey = g.User1.Public
+	momentum.Signature = g.User1.Sign(momentum.Hash.Bytes())
+	return momentum
+}
+
+func detailedOf(momentums ...*nom.Momentum) []*nom.DetailedMomentum {
+	detailed := make([]*nom.DetailedMomentum, len(momentums))
+	for i, momentum := range momentums {
+		detailed[i] = &nom.DetailedMomentum{Momentum: momentum, AccountBlocks: []*nom.AccountBlock{}}
+	}
+	return detailed
+}
+
+func momentumAt(t *testing.T, c chain.Chain, height uint64) *nom.Momentum {
+	t.Helper()
+	momentum, err := c.GetFrontierMomentumStore().GetMomentumByHeight(height)
+	common.FailIfErr(t, err)
+	if momentum == nil {
+		t.Fatalf("no momentum at height %d", height)
+	}
+	return momentum
+}
+
+func rollbackChainAndCache(t *testing.T, c chain.Chain, identifier types.HashHeight) {
+	t.Helper()
+	insert := c.AcquireInsert("test rollback")
+	defer insert.Unlock()
+	common.FailIfErr(t, c.RollbackTo(insert, identifier))
+	common.FailIfErr(t, c.RollbackCacheTo(insert, identifier))
+}
+
+// expectRolledBack asserts the canonical chain was rolled back at least once;
+// a restore rolls the failed candidates back again, so the count is not one.
+func expectRolledBack(t *testing.T, c *rollbackCountingChain) {
+	t.Helper()
+	if c.rollbacks == 0 {
+		t.Fatal("expected the side chain to have triggered a rollback")
+	}
+}
+
+func newSideChainBridge(z mock.MockZenon) (*rollbackCountingChain, protocol.ChainBridge) {
+	counting := &rollbackCountingChain{Chain: z.Chain()}
+	supervisor := vm.NewSupervisor(z.Chain(), z.Consensus())
+	return counting, protocol.NewChainBridge(counting, z.Consensus(), z.Verifier(), supervisor)
+}
+
+func TestInsertChain_SideChainRestoredWhenCandidateFailsAfterRollback(t *testing.T) {
+	z := mock.NewMockZenon(t)
+	defer z.StopPanic()
+	z.InsertMomentumsTo(6)
+	counting, bridge := newSideChainBridge(z)
+	before := snapshotChain(t, z.Chain())
+
+	// Side chain forking one below the frontier, longer than ours.
+	target := momentumAt(t, z.Chain(), 5)
+	head := attackerMomentum(target, 6)
+	tail := attackerMomentum(head, 7)
+
+	_, err := bridge.InsertChain(detailedOf(head, tail))
+	if err == nil {
+		t.Fatal("expected the side chain to be rejected")
+	}
+	// The candidate passes every stateless check, so the rollback happens;
+	// the failure comes from the state-dependent checks after it.
+	expectRolledBack(t, counting)
+	expectChainEquals(t, z.Chain(), before)
+}
+
+func TestInsertChain_SideChainWithInvalidSignatureIsRejectedBeforeRollback(t *testing.T) {
+	z := mock.NewMockZenon(t)
+	defer z.StopPanic()
+	z.InsertMomentumsTo(6)
+	counting, bridge := newSideChainBridge(z)
+	before := snapshotChain(t, z.Chain())
+
+	target := momentumAt(t, z.Chain(), 5)
+	head := attackerMomentum(target, 6)
+	head.Signature[0] ^= 0xff
+	tail := attackerMomentum(head, 7)
+
+	_, err := bridge.InsertChain(detailedOf(head, tail))
+	if err == nil {
+		t.Fatal("expected the side chain to be rejected")
+	}
+	common.Expect(t, counting.rollbacks, 0)
+	expectChainEquals(t, z.Chain(), before)
+}
+
+func TestInsertChain_SideChainWithTamperedHashIsRejectedBeforeRollback(t *testing.T) {
+	z := mock.NewMockZenon(t)
+	defer z.StopPanic()
+	z.InsertMomentumsTo(6)
+	counting, bridge := newSideChainBridge(z)
+	before := snapshotChain(t, z.Chain())
+
+	target := momentumAt(t, z.Chain(), 5)
+	head := attackerMomentum(target, 6)
+	head.Hash = types.NewHash([]byte("advertised hash that does not match the content"))
+	tail := attackerMomentum(head, 7)
+
+	_, err := bridge.InsertChain(detailedOf(head, tail))
+	if err == nil {
+		t.Fatal("expected the side chain to be rejected")
+	}
+	common.Expect(t, counting.rollbacks, 0)
+	expectChainEquals(t, z.Chain(), before)
+}
+
+// forkFixture holds a node at an original branch plus a genuine, valid
+// alternative branch forking one below its frontier.
+type forkFixture struct {
+	z        mock.MockZenon
+	original chainSnapshot
+	fork     []*nom.DetailedMomentum
+}
+
+func newForkFixture(t *testing.T) *forkFixture {
+	z := mock.NewMockZenon(t)
+	z.InsertMomentumsTo(6)
+	store := z.Chain().GetFrontierMomentumStore()
+	originalSix, err := store.PrefetchMomentum(momentumAt(t, z.Chain(), 6))
+	common.FailIfErr(t, err)
+	base := momentumAt(t, z.Chain(), 5).Identifier()
+
+	// Produce a different branch from height 5: add a transaction so the
+	// content differs, then let the pillars build two momentums.
+	rollbackChainAndCache(t, z.Chain(), base)
+	z.InsertSendBlock(&nom.AccountBlock{
+		Address:       g.User1.Address,
+		ToAddress:     g.User2.Address,
+		TokenStandard: types.ZnnTokenStandard,
+		Amount:        big.NewInt(1),
+	}, nil, mock.SkipVmChanges)
+	z.InsertMomentumsTo(7)
+	fork := make([]*nom.DetailedMomentum, 0, 2)
+	for height := uint64(6); height <= 7; height++ {
+		detailed, err := z.Chain().GetFrontierMomentumStore().PrefetchMomentum(momentumAt(t, z.Chain(), height))
+		common.FailIfErr(t, err)
+		fork = append(fork, detailed)
+	}
+	if fork[0].Momentum.Hash == originalSix.Momentum.Hash {
+		t.Fatal("fork did not diverge from the original branch")
+	}
+
+	// Back to the original branch.
+	rollbackChainAndCache(t, z.Chain(), base)
+	_, bridge := newSideChainBridge(z)
+	_, err = bridge.InsertChain([]*nom.DetailedMomentum{originalSix})
+	common.FailIfErr(t, err)
+
+	return &forkFixture{z: z, original: snapshotChain(t, z.Chain()), fork: fork}
+}
+
+func TestInsertChain_ValidLongerSideChainReplacesBranch(t *testing.T) {
+	f := newForkFixture(t)
+	defer f.z.StopPanic()
+	counting, bridge := newSideChainBridge(f.z)
+
+	_, err := bridge.InsertChain(f.fork)
+	common.FailIfErr(t, err)
+	common.Expect(t, counting.rollbacks, 1)
+	common.Expect(t, f.z.Chain().GetFrontierMomentumStore().Identifier(), f.fork[1].Momentum.Identifier())
+	common.Expect(t, f.z.Chain().GetFrontierCacheStore().Identifier(), f.fork[1].Momentum.Identifier())
+}
+
+func TestInsertChain_SideChainRestoredWhenLaterCandidateFails(t *testing.T) {
+	f := newForkFixture(t)
+	defer f.z.StopPanic()
+	counting, bridge := newSideChainBridge(f.z)
+
+	// A genuine first candidate that replaces our branch, followed by one
+	// that fails only after it has been applied.
+	bad := attackerMomentum(f.fork[0].Momentum, 7)
+	_, err := bridge.InsertChain([]*nom.DetailedMomentum{f.fork[0], detailedOf(bad)[0]})
+	if err == nil {
+		t.Fatal("expected the side chain to be rejected")
+	}
+	expectRolledBack(t, counting)
+	expectChainEquals(t, f.z.Chain(), f.original)
+
+	// The restored state is real state: the genuine fork still replaces the
+	// branch afterwards, which requires its changes-hash to be reproducible
+	// from what was put back.
+	_, err = bridge.InsertChain(f.fork)
+	common.FailIfErr(t, err)
+	common.Expect(t, f.z.Chain().GetFrontierMomentumStore().Identifier(), f.fork[1].Momentum.Identifier())
+}
+
+func TestInsertChain_SideChainDepthBoundary(t *testing.T) {
+	z := mock.NewMockZenon(t)
+	defer z.StopPanic()
+	z.InsertMomentumsTo(40)
+	counting, bridge := newSideChainBridge(z)
+	before := snapshotChain(t, z.Chain())
+
+	// Depth 31: rejected before anything is touched.
+	tooDeep := momentumAt(t, z.Chain(), 9)
+	head := attackerMomentum(tooDeep, 10)
+	tail := attackerMomentum(head, 41)
+	_, err := bridge.InsertChain(detailedOf(head, tail))
+	if err == nil {
+		t.Fatal("expected a 31-deep side chain to be rejected")
+	}
+	common.Expect(t, counting.rollbacks, 0)
+	expectChainEquals(t, z.Chain(), before)
+
+	// Depth 30: allowed, rolls back, fails after, and every removed momentum
+	// comes back.
+	deepest := momentumAt(t, z.Chain(), 10)
+	head = attackerMomentum(deepest, 11)
+	tail = attackerMomentum(head, 41)
+	_, err = bridge.InsertChain(detailedOf(head, tail))
+	if err == nil {
+		t.Fatal("expected the side chain to be rejected")
+	}
+	expectRolledBack(t, counting)
+	expectChainEquals(t, z.Chain(), before)
+}
+
+// storedPatchDumps returns the serialized state patch of every momentum above
+// identifier, as the momentum store holds them right now.
+func storedPatchDumps(t *testing.T, c chain.Chain, identifier types.HashHeight) [][]byte {
+	t.Helper()
+	insert := c.AcquireInsert("test capture")
+	defer insert.Unlock()
+	removed, err := c.CaptureBranchAbove(insert, identifier)
+	common.FailIfErr(t, err)
+	dumps := make([][]byte, len(removed))
+	for i, momentum := range removed {
+		dumps[i] = momentum.Changes.Dump()
+	}
+	return dumps
+}
+
+func TestInsertChain_RepeatedRestoresKeepStoredPatchesIdentical(t *testing.T) {
+	z := mock.NewMockZenon(t)
+	defer z.StopPanic()
+	z.InsertMomentumsTo(6)
+	_, bridge := newSideChainBridge(z)
+	before := snapshotChain(t, z.Chain())
+	target := momentumAt(t, z.Chain(), 4).Identifier()
+	patchesBefore := storedPatchDumps(t, z.Chain(), target)
+
+	for attempt := 0; attempt < 3; attempt++ {
+		head := attackerMomentum(momentumAt(t, z.Chain(), 4), 5)
+		tail := attackerMomentum(head, 7)
+		_, err := bridge.InsertChain(detailedOf(head, tail))
+		if err == nil {
+			t.Fatalf("attempt %d: expected the side chain to be rejected", attempt)
+		}
+		expectChainEquals(t, z.Chain(), before)
+
+		patchesAfter := storedPatchDumps(t, z.Chain(), target)
+		common.Expect(t, len(patchesAfter), len(patchesBefore))
+		for i := range patchesBefore {
+			if string(patchesAfter[i]) != string(patchesBefore[i]) {
+				t.Fatalf("attempt %d: stored patch for height %d changed: %d bytes before, %d bytes after", attempt, target.Height+uint64(i)+1, len(patchesBefore[i]), len(patchesAfter[i]))
+			}
+		}
+	}
+}

--- a/protocol/chain_bridge_sidechain_test.go
+++ b/protocol/chain_bridge_sidechain_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/zenon-network/go-zenon/chain"
+	"github.com/zenon-network/go-zenon/chain/cache/storage"
 	g "github.com/zenon-network/go-zenon/chain/genesis/mock"
 	"github.com/zenon-network/go-zenon/chain/nom"
 	"github.com/zenon-network/go-zenon/common"
@@ -105,6 +106,18 @@ func detailedOf(momentums ...*nom.Momentum) []*nom.DetailedMomentum {
 	return detailed
 }
 
+// invalidTail chains attacker momentums on top of previous up to and
+// including height top. Each passes the stateless checks and fails the first
+// state-dependent one.
+func invalidTail(previous *nom.Momentum, top uint64) []*nom.DetailedMomentum {
+	tail := make([]*nom.Momentum, 0, top-previous.Height)
+	for height := previous.Height + 1; height <= top; height++ {
+		previous = attackerMomentum(previous, height)
+		tail = append(tail, previous)
+	}
+	return detailedOf(tail...)
+}
+
 func momentumAt(t *testing.T, c chain.Chain, height uint64) *nom.Momentum {
 	t.Helper()
 	momentum, err := c.GetFrontierMomentumStore().GetMomentumByHeight(height)
@@ -113,14 +126,6 @@ func momentumAt(t *testing.T, c chain.Chain, height uint64) *nom.Momentum {
 		t.Fatalf("no momentum at height %d", height)
 	}
 	return momentum
-}
-
-func rollbackChainAndCache(t *testing.T, c chain.Chain, identifier types.HashHeight) {
-	t.Helper()
-	insert := c.AcquireInsert("test rollback")
-	defer insert.Unlock()
-	common.FailIfErr(t, c.RollbackTo(insert, identifier))
-	common.FailIfErr(t, c.RollbackCacheTo(insert, identifier))
 }
 
 // expectRolledBack asserts the canonical chain was rolled back at least once;
@@ -201,52 +206,68 @@ func TestInsertChain_SideChainWithTamperedHashIsRejectedBeforeRollback(t *testin
 }
 
 // forkFixture holds a node at an original branch plus a genuine, valid
-// alternative branch forking one below its frontier.
+// alternative branch forking one below the original branch's lowest momentum.
 type forkFixture struct {
 	z        mock.MockZenon
 	original chainSnapshot
-	fork     []*nom.DetailedMomentum
+	// removed is how many momentums the original branch has above the fork
+	// point.
+	removed int
+	fork    []*nom.DetailedMomentum
 }
 
-func newForkFixture(t *testing.T) *forkFixture {
+// newForkFixture builds the original branch on one node and the fork on a
+// second node so that neither branch has to be rolled back to reach the fork
+// point; the cache only keeps 100 rollback steps, which a long fork exceeds.
+// Both nodes share genesis and a deterministic clock, so the momentums below
+// the fork point are byte-identical on both. The original branch spans heights
+// forkBase+1..originalTop, the fork spans forkBase+1..forkTop.
+func newForkFixture(t *testing.T, originalTop, forkTop uint64) *forkFixture {
+	const forkBase = uint64(5)
 	z := mock.NewMockZenon(t)
-	z.InsertMomentumsTo(6)
-	store := z.Chain().GetFrontierMomentumStore()
-	originalSix, err := store.PrefetchMomentum(momentumAt(t, z.Chain(), 6))
-	common.FailIfErr(t, err)
-	base := momentumAt(t, z.Chain(), 5).Identifier()
+	z.InsertMomentumsTo(originalTop)
 
-	// Produce a different branch from height 5: add a transaction so the
-	// content differs, then let the pillars build two momentums.
-	rollbackChainAndCache(t, z.Chain(), base)
-	z.InsertSendBlock(&nom.AccountBlock{
+	other := mock.NewMockZenon(t)
+	defer other.StopPanic()
+	other.InsertMomentumsTo(forkBase)
+	common.Expect(t, momentumAt(t, other.Chain(), forkBase).Hash, momentumAt(t, z.Chain(), forkBase).Hash)
+	// Produce a different branch from the fork point: add a transaction so
+	// the content differs, then let the pillars build the rest.
+	other.InsertSendBlock(&nom.AccountBlock{
 		Address:       g.User1.Address,
 		ToAddress:     g.User2.Address,
 		TokenStandard: types.ZnnTokenStandard,
 		Amount:        big.NewInt(1),
 	}, nil, mock.SkipVmChanges)
-	z.InsertMomentumsTo(7)
-	fork := make([]*nom.DetailedMomentum, 0, 2)
-	for height := uint64(6); height <= 7; height++ {
-		detailed, err := z.Chain().GetFrontierMomentumStore().PrefetchMomentum(momentumAt(t, z.Chain(), height))
+	other.InsertMomentumsTo(forkTop)
+	fork := make([]*nom.DetailedMomentum, 0, forkTop-forkBase)
+	for height := forkBase + 1; height <= forkTop; height++ {
+		detailed, err := other.Chain().GetFrontierMomentumStore().PrefetchMomentum(momentumAt(t, other.Chain(), height))
 		common.FailIfErr(t, err)
 		fork = append(fork, detailed)
 	}
-	if fork[0].Momentum.Hash == originalSix.Momentum.Hash {
+	if fork[0].Momentum.Hash == momentumAt(t, z.Chain(), forkBase+1).Hash {
 		t.Fatal("fork did not diverge from the original branch")
 	}
 
-	// Back to the original branch.
-	rollbackChainAndCache(t, z.Chain(), base)
-	_, bridge := newSideChainBridge(z)
-	_, err = bridge.InsertChain([]*nom.DetailedMomentum{originalSix})
-	common.FailIfErr(t, err)
+	return &forkFixture{
+		z:        z,
+		original: snapshotChain(t, z.Chain()),
+		removed:  int(originalTop - forkBase),
+		fork:     fork,
+	}
+}
 
-	return &forkFixture{z: z, original: snapshotChain(t, z.Chain()), fork: fork}
+// expectFrontierAt asserts both the canonical and the cache frontier sit at
+// the given momentum.
+func expectFrontierAt(t *testing.T, c chain.Chain, momentum *nom.Momentum) {
+	t.Helper()
+	common.Expect(t, c.GetFrontierMomentumStore().Identifier(), momentum.Identifier())
+	common.Expect(t, c.GetFrontierCacheStore().Identifier(), momentum.Identifier())
 }
 
 func TestInsertChain_ValidLongerSideChainReplacesBranch(t *testing.T) {
-	f := newForkFixture(t)
+	f := newForkFixture(t, 6, 7)
 	defer f.z.StopPanic()
 	counting, bridge := newSideChainBridge(f.z)
 
@@ -258,7 +279,7 @@ func TestInsertChain_ValidLongerSideChainReplacesBranch(t *testing.T) {
 }
 
 func TestInsertChain_SideChainRestoredWhenLaterCandidateFails(t *testing.T) {
-	f := newForkFixture(t)
+	f := newForkFixture(t, 6, 7)
 	defer f.z.StopPanic()
 	counting, bridge := newSideChainBridge(f.z)
 
@@ -278,6 +299,85 @@ func TestInsertChain_SideChainRestoredWhenLaterCandidateFails(t *testing.T) {
 	_, err = bridge.InsertChain(f.fork)
 	common.FailIfErr(t, err)
 	common.Expect(t, f.z.Chain().GetFrontierMomentumStore().Identifier(), f.fork[1].Momentum.Identifier())
+}
+
+// TestInsertChain_RestoreBoundaryAtRemovedBranchLength pins the rule that
+// decides between restoring the original branch and keeping the committed
+// replacement prefix: the original comes back only while the prefix is no
+// longer than it. A longer prefix is a valid chain longer than the one the
+// node had, so it stays, exactly as it would have before restores existed.
+func TestInsertChain_RestoreBoundaryAtRemovedBranchLength(t *testing.T) {
+	cases := []struct {
+		name      string
+		committed int
+		restored  bool
+	}{
+		{"prefix shorter than removed branch is restored", 1, true},
+		{"prefix as long as removed branch is restored", 2, true},
+		{"prefix longer than removed branch is kept", 3, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newForkFixture(t, 7, 9)
+			defer f.z.StopPanic()
+			common.Expect(t, f.removed, 2)
+			counting, bridge := newSideChainBridge(f.z)
+
+			// The genuine prefix, then invalid candidates up to a height that
+			// keeps the side chain taller than our frontier.
+			candidates := append([]*nom.DetailedMomentum{}, f.fork[:tc.committed]...)
+			candidates = append(candidates, invalidTail(f.fork[tc.committed-1].Momentum, 10)...)
+
+			index, err := bridge.InsertChain(candidates)
+			if err == nil {
+				t.Fatal("expected the side chain to be rejected")
+			}
+			common.Expect(t, index, tc.committed)
+			if tc.restored {
+				common.Expect(t, counting.rollbacks, 2)
+				expectChainEquals(t, f.z.Chain(), f.original)
+			} else {
+				common.Expect(t, counting.rollbacks, 1)
+				expectFrontierAt(t, f.z.Chain(), f.fork[tc.committed-1].Momentum)
+			}
+
+			// Whatever was kept is real state: the rest of the genuine fork
+			// still inserts on top of it.
+			_, err = bridge.InsertChain(f.fork)
+			common.FailIfErr(t, err)
+			expectFrontierAt(t, f.z.Chain(), f.fork[len(f.fork)-1].Momentum)
+		})
+	}
+}
+
+// TestInsertChain_ReplacementPrefixBeyondCacheWindowIsKept commits more
+// replacement momentums than the cache keeps rollback steps for, then fails
+// the next candidate. A restore would have to roll the cache back further
+// than it can go, after the canonical chain has already been rolled back,
+// and the node would exit with a cache it cannot reconcile on restart. The
+// committed prefix is longer than the removed branch, so it stays instead.
+func TestInsertChain_ReplacementPrefixBeyondCacheWindowIsKept(t *testing.T) {
+	committed := storage.GetRollbackCacheSize() + 1
+	f := newForkFixture(t, 6, uint64(5+committed+1))
+	defer f.z.StopPanic()
+	counting, bridge := newSideChainBridge(f.z)
+
+	candidates := append([]*nom.DetailedMomentum{}, f.fork[:committed]...)
+	last := f.fork[committed-1].Momentum
+	candidates = append(candidates, invalidTail(last, last.Height+1)...)
+
+	index, err := bridge.InsertChain(candidates)
+	if err == nil {
+		t.Fatal("expected the side chain to be rejected")
+	}
+	common.Expect(t, index, committed)
+	common.Expect(t, counting.rollbacks, 1)
+	expectFrontierAt(t, f.z.Chain(), last)
+
+	// The node carries on from the kept prefix.
+	_, err = bridge.InsertChain(f.fork[committed:])
+	common.FailIfErr(t, err)
+	expectFrontierAt(t, f.z.Chain(), f.fork[len(f.fork)-1].Momentum)
 }
 
 func TestInsertChain_SideChainDepthBoundary(t *testing.T) {
@@ -312,16 +412,19 @@ func TestInsertChain_SideChainDepthBoundary(t *testing.T) {
 }
 
 // storedPatchDumps returns the serialized state patch of every momentum above
-// identifier, as the momentum store holds them right now.
+// identifier exactly as the momentum store holds it, frontier writes included.
+// It deliberately does not go through CaptureBranchAbove, which strips those
+// writes and would hide the very growth this is used to detect.
 func storedPatchDumps(t *testing.T, c chain.Chain, identifier types.HashHeight) [][]byte {
 	t.Helper()
-	insert := c.AcquireInsert("test capture")
-	defer insert.Unlock()
-	removed, err := c.CaptureBranchAbove(insert, identifier)
-	common.FailIfErr(t, err)
-	dumps := make([][]byte, len(removed))
-	for i, momentum := range removed {
-		dumps[i] = momentum.Changes.Dump()
+	frontier := c.GetFrontierMomentumStore().Identifier()
+	dumps := make([][]byte, 0, frontier.Height-identifier.Height)
+	for height := identifier.Height + 1; height <= frontier.Height; height++ {
+		patch := c.GetMomentumPatch(momentumAt(t, c, height).Identifier())
+		if patch == nil {
+			t.Fatalf("no stored patch for height %d", height)
+		}
+		dumps = append(dumps, patch.Dump())
 	}
 	return dumps
 }


### PR DESCRIPTION
## Summary

`InsertChain` accepted a side chain on structural grounds alone: the head links to a canonical momentum at most 30 back, and the tail is higher than our frontier. It then rolled the canonical chain and cache back to the fork point before applying the first replacement momentum, and only afterwards ran the checks that need chain state (changes-hash, producer, VM application). A candidate that failed any of those left the node with its canonical branch removed and nothing in its place, until it resynchronised from another peer. Any connected peer selected for a download could trigger this with a momentum that is internally consistent but signed by a key that is not the elected producer, or that carries a changes-hash the node cannot reproduce.

## Changes

Side-chain replacement now leaves the chain in one of three states: fully replaced, on a committed replacement prefix that is longer than the branch it removed, or exactly as it was.

- **Static checks before any rollback.** Every candidate's advertised hash must match its content and its signature must verify under the carried public key. The head is additionally run through the raw momentum verifier against the store at the fork point. A candidate that fails these never causes a rollback. The state-dependent checks still run afterwards, as before.
- **Undo log before the rollback.** `momentumPool.CaptureBranchAbove` records each momentum above the fork point with its prefetched account blocks and the state patch the momentum store holds for it. The ldb-backed manager deletes a patch when its momentum is popped, so the capture happens first; if any patch is missing the insert is refused without touching the chain. The stored patch already carries the three frontier writes `Manager.Add` appends on every insert, so the capture strips them (`db.FrontierWriteKeys`, `db.RemoveKeys`); otherwise each restore would persistently grow the forward and rollback records of up to 30 momentums.
- **Restore on a later failure, while the prefix is short.** If applying the replacement fails at some candidate and the committed prefix is no longer than the removed branch, the bridge rolls the applied candidates back to the fork point and re-adds the captured momentums in order, updating the cache from the stored patch and committing through `AddMomentumTransaction`, so listeners see the same insert events a normal insert produces. A restore failure is handled like the existing uncertain-state cases: logged at Crit, process exits.
- **Keep the prefix once it is longer than what was removed.** The removed branch is bounded to 30 momentums by the depth check, but the committed replacement prefix is bounded only by the downloader batch (up to 256). The cache keeps 100 rollback steps, so a restore after more than 100 committed candidates would roll the canonical chain back and then fail on the cache, exiting with a state `Init` cannot reconcile on restart. Once the prefix is longer than the removed branch, the node is already on a valid chain longer than the one it had, so the prefix stays, which is what the code did before this change. This bounds every restore to at most 30 steps.

What the restore does not cover, deliberately: the rollback still clears the account pool as any rollback does (valid blocks force-inserted from the rejected candidates remain, as if a peer had relayed them); event listeners see delete notifications followed by insert notifications for restored momentums; and the captured branch is held in memory only, so a crash mid-restore leaves the node at the fork point plus whatever was committed, a valid prefix it resynchronises from, not the restored branch. None of this is crash-atomic and it is not meant to be.

## Tests

All in `protocol/chain_bridge_sidechain_test.go`, through the real `InsertChain` on the mock node. Genuine forks are produced on a second mock node sharing genesis and clock, so a fork longer than the cache window can be built without rolling anything back.

- `SideChainRestoredWhenCandidateFailsAfterRollback`: head passes every stateless check, fails after the rollback; frontier, every momentum hash, cache frontier and account balances unchanged.
- `SideChainWithInvalidSignatureIsRejectedBeforeRollback`, `SideChainWithTamperedHashIsRejectedBeforeRollback`: rejected with no rollback at all.
- `ValidLongerSideChainReplacesBranch`: a genuine fork produced by the mock pillars still replaces the branch.
- `SideChainRestoredWhenLaterCandidateFails`: the fork's first momentum is applied, the second candidate fails, the original branch is restored, and the genuine fork then inserts on top of the restored state.
- `RestoreBoundaryAtRemovedBranchLength`: with a two-momentum original branch, a committed prefix of one or two is restored and a prefix of three is kept; in every case the rest of the genuine fork then inserts on top of whatever the node was left with.
- `ReplacementPrefixBeyondCacheWindowIsKept`: 101 replacement momentums commit, the 102nd fails; the prefix is kept with chain and cache frontiers agreeing, and the remaining fork inserts on top. Without the guard this test exits the process with the cache rollback error.
- `SideChainDepthBoundary`: depth 31 rejected untouched; depth 30 rolls back, fails, and all 30 momentums come back.
- `RepeatedRestoresKeepStoredPatchesIdentical`: three consecutive failed attempts leave every stored patch above the fork point byte-identical. The comparison reads the raw stored patches through the new `GetMomentumPatch` accessor, frontier writes included, rather than through `CaptureBranchAbove`, which strips them and would hide the growth.

Verification: `GOWORK=off go build ./...`, `go test -race ./chain ./common/db ./protocol`, `go test ./...`, `golangci-lint run` clean on the touched files.

Ref: internal security review finding on unverified side-chain rollback (affects every tagged release through v0.1.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAfAxvtiPqYU6873a9K4uH
