### PR TITLE
rpc: bound subscriptions per connection and server-wide

### DIFF
--- a/rpc/api/subscribe/api.go
+++ b/rpc/api/subscribe/api.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"sync"
+	"sync/atomic"
+	"time"
 
 	"github.com/inconshreveable/log15"
 
@@ -18,11 +20,28 @@ import (
 // full; the caller should retry.
 var ErrSubscribeBacklogFull = errors.New("subscribe server backlog is full")
 
+// ErrSubscriptionLimitReached is returned when the server already serves
+// maxSubscriptions live subscriptions across all connections.
+var ErrSubscriptionLimitReached = errors.New("subscribe server subscription limit reached")
+
 const (
 	acChanSize  = 100
 	mChanSize   = 100
 	installSize = 100
+
+	// maxSubscriptions bounds the subscriptions kept installed across all
+	// connections. Every matching chain event is delivered to each of them
+	// from the single worker goroutine, so this also bounds the work one
+	// event can cost. Each connection is separately limited by the RPC
+	// server.
+	maxSubscriptions = 4096
 )
+
+// sweepInterval is how often the worker drops subscriptions whose client has
+// unsubscribed or disconnected. Broadcasts only visit subscriptions their
+// event matches, so without the sweep an address-filtered subscription
+// would stay installed until a block for that address arrives.
+var sweepInterval = 10 * time.Second
 
 var (
 	oneSingleton sync.Mutex
@@ -70,6 +89,13 @@ type Api struct {
 	isStopped bool
 	installCh chan *Subscription // add subscription
 	stopped   chan struct{}
+
+	// live counts subscriptions that hold a slot of maxSubscriptions: those
+	// waiting in installCh plus those installed by the worker. Only subscribe
+	// increments it, serialized by stopLock, and only the worker's uninstall
+	// decrements it, so the check-then-increment in subscribe cannot
+	// overshoot.
+	live atomic.Int64
 }
 type Server struct {
 	*Api
@@ -179,6 +205,8 @@ func (s *Server) work() {
 	defer common.RecoverStack()
 	log.Info("start event loop")
 	defer log.Info("stop event loop")
+	sweep := time.NewTicker(sweepInterval)
+	defer sweep.Stop()
 	for {
 		select {
 		case <-s.stopped:
@@ -187,6 +215,8 @@ func (s *Server) work() {
 			return
 		case sub := <-s.installCh:
 			s.install(sub)
+		case <-sweep.C:
+			s.sweep()
 		case momentums := <-s.mCh:
 			s.broadcastMomentums(momentums)
 		case blocks := <-s.acCh:
@@ -205,8 +235,32 @@ func (s *Server) install(subscription *Subscription) {
 	s.subscriptions[subscription.options.subscriptionType][subscription.rpc.ID] = subscription
 }
 func (s *Server) uninstall(subscription *Subscription) {
+	installed := s.subscriptions[subscription.options.subscriptionType]
+	if _, ok := installed[subscription.rpc.ID]; !ok {
+		return
+	}
 	s.log.Info("uninstall", "id", subscription.rpc.ID)
-	delete(s.subscriptions[subscription.options.subscriptionType], subscription.rpc.ID)
+	delete(installed, subscription.rpc.ID)
+	// Released exactly once, together with the map entry the slot was held for.
+	s.live.Add(-1)
+}
+
+// sweep uninstalls every subscription whose client has unsubscribed or
+// disconnected, regardless of whether an event for it has arrived.
+func (s *Server) sweep() {
+	startTime := common.Clock.Now()
+	stats := &BroadcastStats{}
+	for _, installed := range s.subscriptions {
+		for _, subscription := range installed {
+			if subscription.Closed() {
+				stats.NumUninstalls += 1
+				s.uninstall(subscription)
+			}
+		}
+	}
+	if stats.NumUninstalls > 0 {
+		s.log.Info("finish sweeping subscriptions", "elapsed", common.Clock.Now().Sub(startTime), "stats", stats)
+	}
 }
 func (s *Server) broadcast(subscription *Subscription, data interface{}, stats *BroadcastStats) {
 	if subscription.Closed() {
@@ -300,10 +354,17 @@ func (s *Api) subscribe(ctx context.Context, options *subscriptionOptions) (*rpc
 	// client never learns and cannot unsubscribe. stopLock serializes
 	// producers and the worker only drains, so once there is room the send
 	// below cannot block.
+	// The slot is claimed here, before the entry is handed to the worker, so
+	// the count covers queued and installed subscriptions alike; the worker
+	// returns it when it uninstalls the entry.
+	if s.live.Load() >= maxSubscriptions {
+		return nil, ErrSubscriptionLimitReached
+	}
 	if len(s.installCh) == cap(s.installCh) {
 		return nil, ErrSubscribeBacklogFull
 	}
 	subscription := NewSubscription(notifier, options)
+	s.live.Add(1)
 	s.installCh <- subscription
 	return subscription.rpc, nil
 }

--- a/rpc/api/subscribe/api.go
+++ b/rpc/api/subscribe/api.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/inconshreveable/log15"
 
@@ -36,12 +35,6 @@ const (
 	// server.
 	maxSubscriptions = 4096
 )
-
-// sweepInterval is how often the worker drops subscriptions whose client has
-// unsubscribed or disconnected. Broadcasts only visit subscriptions their
-// event matches, so without the sweep an address-filtered subscription
-// would stay installed until a block for that address arrives.
-var sweepInterval = 10 * time.Second
 
 var (
 	oneSingleton sync.Mutex
@@ -91,18 +84,24 @@ type Api struct {
 	stopped   chan struct{}
 
 	// live counts subscriptions that hold a slot of maxSubscriptions: those
-	// waiting in installCh plus those installed by the worker. Only subscribe
-	// increments it, serialized by stopLock, and only the worker's uninstall
-	// decrements it, so the check-then-increment in subscribe cannot
-	// overshoot.
+	// waiting in installCh plus those installed. Only subscribe increments
+	// it, serialized by stopLock, and only uninstall decrements it, under
+	// subsMu together with the map entry, so the check-then-increment in
+	// subscribe cannot overshoot and a slot is never released twice.
 	live atomic.Int64
 }
 type Server struct {
 	*Api
 
-	started       bool
-	acCh          chan []*AccountBlock
-	mCh           chan *Momentum
+	started bool
+	acCh    chan []*AccountBlock
+	mCh     chan *Momentum
+
+	// subsMu guards subscriptions. The worker installs entries and takes
+	// snapshots to broadcast to; each entry's watcher goroutine removes it
+	// when its client unsubscribes or disconnects, so capacity returns
+	// without waiting for the worker or for an event matching the entry.
+	subsMu        sync.Mutex
 	subscriptions map[SubscriptionType]map[rpc.ID]*Subscription
 
 	wg sync.WaitGroup
@@ -205,18 +204,16 @@ func (s *Server) work() {
 	defer common.RecoverStack()
 	log.Info("start event loop")
 	defer log.Info("stop event loop")
-	sweep := time.NewTicker(sweepInterval)
-	defer sweep.Stop()
 	for {
 		select {
 		case <-s.stopped:
 			log.Info("stopped")
+			s.subsMu.Lock()
 			s.subscriptions = nil
+			s.subsMu.Unlock()
 			return
 		case sub := <-s.installCh:
 			s.install(sub)
-		case <-sweep.C:
-			s.sweep()
 		case momentums := <-s.mCh:
 			s.broadcastMomentums(momentums)
 		case blocks := <-s.acCh:
@@ -232,9 +229,33 @@ type BroadcastStats struct {
 
 func (s *Server) install(subscription *Subscription) {
 	s.log.Info("install", "id", subscription.rpc.ID)
+	s.subsMu.Lock()
 	s.subscriptions[subscription.options.subscriptionType][subscription.rpc.ID] = subscription
+	s.subsMu.Unlock()
+	s.wg.Add(1)
+	go s.watch(subscription)
 }
+
+// watch removes the subscription as soon as its client unsubscribes or its
+// connection closes. It waits on the same signals Closed reports, but on
+// copies taken here: the worker owns subscription.notifier and clears it in
+// Closed, so the watcher never reads the field again. A client that went
+// away while the entry was still queued is removed right after install.
+func (s *Server) watch(subscription *Subscription) {
+	defer s.wg.Done()
+	rpcSub, notifier := subscription.rpc, subscription.notifier
+	select {
+	case <-s.stopped:
+		return
+	case <-rpcSub.Err():
+	case <-notifier.Closed():
+	}
+	s.uninstall(subscription)
+}
+
 func (s *Server) uninstall(subscription *Subscription) {
+	s.subsMu.Lock()
+	defer s.subsMu.Unlock()
 	installed := s.subscriptions[subscription.options.subscriptionType]
 	if _, ok := installed[subscription.rpc.ID]; !ok {
 		return
@@ -245,22 +266,18 @@ func (s *Server) uninstall(subscription *Subscription) {
 	s.live.Add(-1)
 }
 
-// sweep uninstalls every subscription whose client has unsubscribed or
-// disconnected, regardless of whether an event for it has arrived.
-func (s *Server) sweep() {
-	startTime := common.Clock.Now()
-	stats := &BroadcastStats{}
-	for _, installed := range s.subscriptions {
-		for _, subscription := range installed {
-			if subscription.Closed() {
-				stats.NumUninstalls += 1
-				s.uninstall(subscription)
-			}
-		}
+// installed returns the subscriptions of one type for the worker to
+// broadcast to. Notifications are network writes, so they must not run
+// under subsMu or a slow client would block every watcher's uninstall.
+func (s *Server) installed(subscriptionType SubscriptionType) []*Subscription {
+	s.subsMu.Lock()
+	defer s.subsMu.Unlock()
+	entries := s.subscriptions[subscriptionType]
+	snapshot := make([]*Subscription, 0, len(entries))
+	for _, subscription := range entries {
+		snapshot = append(snapshot, subscription)
 	}
-	if stats.NumUninstalls > 0 {
-		s.log.Info("finish sweeping subscriptions", "elapsed", common.Clock.Now().Sub(startTime), "stats", stats)
-	}
+	return snapshot
 }
 func (s *Server) broadcast(subscription *Subscription, data interface{}, stats *BroadcastStats) {
 	if subscription.Closed() {
@@ -278,7 +295,7 @@ func (s *Server) broadcastMomentums(momentum *Momentum) {
 	startTime := common.Clock.Now()
 	stats := &BroadcastStats{}
 
-	for _, f := range s.subscriptions[MomentumsSubscription] {
+	for _, f := range s.installed(MomentumsSubscription) {
 		s.broadcast(f, []interface{}{momentum}, stats)
 	}
 
@@ -306,15 +323,15 @@ func (s *Server) broadcastBlocks(blocks []*AccountBlock) {
 		}
 	}
 
-	for _, f := range s.subscriptions[AllAccountBlocksSubscription] {
+	for _, f := range s.installed(AllAccountBlocksSubscription) {
 		s.broadcast(f, blocks, stats)
 	}
-	for _, f := range s.subscriptions[AccountBlocksSubscriptionByAddress] {
+	for _, f := range s.installed(AccountBlocksSubscriptionByAddress) {
 		if blocks, ok := byAddress[f.options.address]; ok {
 			s.broadcast(f, blocks, stats)
 		}
 	}
-	for _, f := range s.subscriptions[UnreceivedAccountBlocksSubscriptionByAddress] {
+	for _, f := range s.installed(UnreceivedAccountBlocksSubscriptionByAddress) {
 		if blocks, ok := unreceivedByAddress[f.options.address]; ok {
 			s.broadcast(f, blocks, stats)
 		}
@@ -355,8 +372,9 @@ func (s *Api) subscribe(ctx context.Context, options *subscriptionOptions) (*rpc
 	// producers and the worker only drains, so once there is room the send
 	// below cannot block.
 	// The slot is claimed here, before the entry is handed to the worker, so
-	// the count covers queued and installed subscriptions alike; the worker
-	// returns it when it uninstalls the entry.
+	// the count covers queued and installed subscriptions alike; it is
+	// returned when the entry is uninstalled, which the entry's watcher does
+	// as soon as the client unsubscribes or disconnects.
 	if s.live.Load() >= maxSubscriptions {
 		return nil, ErrSubscriptionLimitReached
 	}

--- a/rpc/api/subscribe/api_internal_test.go
+++ b/rpc/api/subscribe/api_internal_test.go
@@ -5,7 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/zenon-network/go-zenon/chain"
+	"github.com/zenon-network/go-zenon/chain/nom"
 	"github.com/zenon-network/go-zenon/common"
+	"github.com/zenon-network/go-zenon/common/types"
 	rpc "github.com/zenon-network/go-zenon/rpc/server"
 )
 
@@ -99,4 +102,163 @@ func TestRejectedSubscribeLeavesNoHandlerOwnedSubscription(t *testing.T) {
 	if !probe.rejectedWithoutSubscri {
 		t.Fatal("a subscription was created on the notifier before the backlog rejection")
 	}
+}
+
+type stubChain struct{ chain.Chain }
+
+func (stubChain) Register(chain.MomentumEventListener)   {}
+func (stubChain) UnRegister(chain.MomentumEventListener) {}
+
+// startTestServer builds the singleton server the way zenon.Zenon does and
+// exposes it through an in-process RPC server, the same path a WebSocket
+// client takes after the codec layer.
+func startTestServer(t *testing.T) (*Server, *rpc.Server) {
+	t.Helper()
+	server := GetSubscribeServer(stubChain{})
+	if err := server.Init(); err != nil {
+		t.Fatal(err)
+	}
+	if err := server.Start(); err != nil {
+		t.Fatal(err)
+	}
+	rpcServer := rpc.NewServer()
+	if err := rpcServer.RegisterName("ledger", GetSubscribeApi()); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		rpcServer.Stop()
+		if err := server.Stop(); err != nil {
+			t.Error(err)
+		}
+	})
+	return server, rpcServer
+}
+
+// fillSubscriptions opens connections and subscribes on each until the
+// connection's own budget is exhausted, continuing on new connections until
+// the server reports its global limit. It returns the open clients and the
+// number of accepted subscriptions.
+func fillSubscriptions(t *testing.T, rpcServer *rpc.Server, args ...interface{}) ([]*rpc.Client, int) {
+	t.Helper()
+	var clients []*rpc.Client
+	accepted := 0
+	for {
+		client := rpc.DialInProc(rpcServer)
+		clients = append(clients, client)
+		for {
+			_, err := client.Subscribe(context.Background(), "ledger", make(chan interface{}, 1), args...)
+			if err == nil {
+				accepted++
+				continue
+			}
+			switch err.Error() {
+			case ErrSubscribeBacklogFull.Error():
+				// transient: the worker has not drained installCh yet
+				time.Sleep(time.Millisecond)
+				continue
+			case rpc.ErrTooManySubscriptions.Error():
+				// this connection is full, move to the next one
+			case ErrSubscriptionLimitReached.Error():
+				return clients, accepted
+			default:
+				t.Fatalf("unexpected subscribe error after %d subscriptions: %v", accepted, err)
+			}
+			break
+		}
+		if len(clients) > maxSubscriptions {
+			t.Fatalf("opened %d connections without reaching the global limit", len(clients))
+		}
+	}
+}
+
+func closeAll(clients []*rpc.Client) {
+	for _, c := range clients {
+		c.Close()
+	}
+}
+
+// waitForCapacity retries a subscribe on a fresh connection until it is
+// accepted or the deadline passes; capacity is returned by the worker, which
+// runs asynchronously to the caller.
+func waitForCapacity(t *testing.T, rpcServer *rpc.Server, args ...interface{}) *rpc.Client {
+	t.Helper()
+	client := rpc.DialInProc(rpcServer)
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		_, err := client.Subscribe(context.Background(), "ledger", make(chan interface{}, 1), args...)
+		if err == nil {
+			return client
+		}
+		if err.Error() != ErrSubscriptionLimitReached.Error() {
+			t.Fatalf("unexpected subscribe error: %v", err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("capacity was not returned")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// The server accepts exactly maxSubscriptions live subscriptions across all
+// connections; reservations are taken synchronously in subscribe, so the
+// count is exact even though installation is asynchronous.
+func TestGlobalSubscriptionLimit(t *testing.T) {
+	_, rpcServer := startTestServer(t)
+
+	clients, accepted := fillSubscriptions(t, rpcServer, "momentums")
+	defer closeAll(clients)
+	if accepted != maxSubscriptions {
+		t.Fatalf("accepted %d subscriptions, want %d", accepted, maxSubscriptions)
+	}
+
+	// Still full on a fresh connection.
+	extra := rpc.DialInProc(rpcServer)
+	defer extra.Close()
+	_, err := extra.Subscribe(context.Background(), "ledger", make(chan interface{}, 1), "momentums")
+	if err == nil || err.Error() != ErrSubscriptionLimitReached.Error() {
+		t.Fatalf("expected %v, got %v", ErrSubscriptionLimitReached, err)
+	}
+}
+
+// Unsubscribing returns capacity once the worker visits the subscription
+// during a broadcast of its event type.
+func TestUnsubscribeReturnsGlobalCapacity(t *testing.T) {
+	server, rpcServer := startTestServer(t)
+
+	first := rpc.DialInProc(rpcServer)
+	defer first.Close()
+	ch := make(chan *Momentum, 1)
+	sub, err := first.Subscribe(context.Background(), "ledger", ch, "momentums")
+	if err != nil {
+		t.Fatal(err)
+	}
+	clients, _ := fillSubscriptions(t, rpcServer, "momentums")
+	defer closeAll(clients)
+
+	sub.Unsubscribe()
+	server.InsertMomentum(&nom.DetailedMomentum{Momentum: &nom.Momentum{Height: 1}})
+
+	client := waitForCapacity(t, rpcServer, "momentums")
+	defer client.Close()
+}
+
+// A connection that goes away without unsubscribing must return its
+// capacity even when no event ever matches its subscriptions: address
+// filtered subscriptions are only visited by broadcasts that carry a block
+// for that address, so the worker sweeps them on a timer.
+func TestClosedConnectionsReturnGlobalCapacity(t *testing.T) {
+	old := sweepInterval
+	sweepInterval = 20 * time.Millisecond
+	defer func() { sweepInterval = old }()
+	_, rpcServer := startTestServer(t)
+
+	address := types.PillarContract
+	clients, accepted := fillSubscriptions(t, rpcServer, "accountBlocksByAddress", address)
+	if accepted != maxSubscriptions {
+		t.Fatalf("accepted %d subscriptions, want %d", accepted, maxSubscriptions)
+	}
+	closeAll(clients)
+
+	client := waitForCapacity(t, rpcServer, "accountBlocksByAddress", address)
+	defer client.Close()
 }

--- a/rpc/api/subscribe/api_internal_test.go
+++ b/rpc/api/subscribe/api_internal_test.go
@@ -245,11 +245,8 @@ func TestUnsubscribeReturnsGlobalCapacity(t *testing.T) {
 // A connection that goes away without unsubscribing must return its
 // capacity even when no event ever matches its subscriptions: address
 // filtered subscriptions are only visited by broadcasts that carry a block
-// for that address, so the worker sweeps them on a timer.
+// for that address, so removal must not depend on a broadcast.
 func TestClosedConnectionsReturnGlobalCapacity(t *testing.T) {
-	old := sweepInterval
-	sweepInterval = 20 * time.Millisecond
-	defer func() { sweepInterval = old }()
 	_, rpcServer := startTestServer(t)
 
 	address := types.PillarContract
@@ -259,6 +256,40 @@ func TestClosedConnectionsReturnGlobalCapacity(t *testing.T) {
 	}
 	closeAll(clients)
 
+	client := waitForCapacity(t, rpcServer, "accountBlocksByAddress", address)
+	defer client.Close()
+}
+
+// A client that repeatedly subscribes and unsubscribes on one connection
+// stays within its own budget. Each unsubscribe must return the global slot
+// as well, without waiting for a matching event: closed entries must not
+// count against the global limit in the meantime.
+func TestUnsubscribeChurnDoesNotStarveGlobalCapacity(t *testing.T) {
+	_, rpcServer := startTestServer(t)
+
+	address := types.PillarContract
+	churner := rpc.DialInProc(rpcServer)
+	defer churner.Close()
+	const perRound = 64
+	for round := 0; round*perRound < maxSubscriptions; round++ {
+		subs := make([]*rpc.ClientSubscription, 0, perRound)
+		for len(subs) < perRound {
+			sub, err := churner.Subscribe(context.Background(), "ledger", make(chan interface{}, 1), "accountBlocksByAddress", address)
+			if err != nil {
+				if err.Error() == ErrSubscribeBacklogFull.Error() {
+					time.Sleep(time.Millisecond)
+					continue
+				}
+				t.Fatalf("round %d: subscribe %d failed: %v", round, len(subs), err)
+			}
+			subs = append(subs, sub)
+		}
+		for _, sub := range subs {
+			sub.Unsubscribe()
+		}
+	}
+
+	// The churner holds nothing now; a fresh client must be admitted.
 	client := waitForCapacity(t, rpcServer, "accountBlocksByAddress", address)
 	defer client.Close()
 }

--- a/rpc/server/handler.go
+++ b/rpc/server/handler.go
@@ -64,6 +64,10 @@ type handler struct {
 
 	subLock    sync.Mutex
 	serverSubs map[ID]*Subscription
+	// pendingSubs counts subscribe calls that have been accepted against the
+	// per-connection limit but whose notifier has not been collected by
+	// addSubscriptions yet. Guarded by subLock together with serverSubs.
+	pendingSubs int
 }
 
 type callProc struct {
@@ -198,10 +202,30 @@ func (h *handler) addSubscriptions(nn []*Notifier) {
 	defer h.subLock.Unlock()
 
 	for _, n := range nn {
+		// Every notifier handed out by handleSubscribe holds one reservation,
+		// whether or not the service created a subscription with it.
+		h.pendingSubs--
 		if sub := n.takeSubscription(); sub != nil {
 			h.serverSubs[sub.ID] = sub
 		}
 	}
+}
+
+// reserveSubscription claims one slot of the connection's subscription budget
+// for a subscribe call that is about to run. Slots held by calls still in
+// flight count as well, so neither a batch nor concurrent single requests can
+// exceed maxSubscriptionsPerConn. The slot is released by addSubscriptions
+// when the call's notifier is collected, and the installed subscription's
+// slot is released by unsubscribe or cancelServerSubscriptions.
+func (h *handler) reserveSubscription() error {
+	h.subLock.Lock()
+	defer h.subLock.Unlock()
+
+	if len(h.serverSubs)+h.pendingSubs >= maxSubscriptionsPerConn {
+		return ErrTooManySubscriptions
+	}
+	h.pendingSubs++
+	return nil
 }
 
 // cancelServerSubscriptions removes all subscriptions and closes their error channels.
@@ -379,6 +403,14 @@ func (h *handler) handleSubscribe(cp *callProc, msg *jsonrpcMessage) *jsonrpcMes
 		return msg.errorResponse(&invalidParamsError{err.Error()})
 	}
 	args = args[1:]
+
+	// Reserve the connection's budget only for well-formed requests, and
+	// before the notifier exists: the notifier is collected by
+	// addSubscriptions unconditionally, so a reservation and a notifier must
+	// always be created together.
+	if err := h.reserveSubscription(); err != nil {
+		return msg.errorResponse(err)
+	}
 
 	// Install notifier in context so the subscription handler can find it.
 	n := &Notifier{h: h, namespace: namespace}

--- a/rpc/server/handler.go
+++ b/rpc/server/handler.go
@@ -202,8 +202,8 @@ func (h *handler) addSubscriptions(nn []*Notifier) {
 	defer h.subLock.Unlock()
 
 	for _, n := range nn {
-		// Every notifier handed out by handleSubscribe holds one reservation,
-		// whether or not the service created a subscription with it.
+		// Every notifier collected by handleSubscribe holds one reservation
+		// and a subscription to convert it into.
 		h.pendingSubs--
 		if sub := n.takeSubscription(); sub != nil {
 			h.serverSubs[sub.ID] = sub
@@ -211,12 +211,21 @@ func (h *handler) addSubscriptions(nn []*Notifier) {
 	}
 }
 
+// releaseSubscription returns a reservation taken by reserveSubscription for
+// a call that ended without creating a subscription.
+func (h *handler) releaseSubscription() {
+	h.subLock.Lock()
+	defer h.subLock.Unlock()
+	h.pendingSubs--
+}
+
 // reserveSubscription claims one slot of the connection's subscription budget
 // for a subscribe call that is about to run. Slots held by calls still in
 // flight count as well, so neither a batch nor concurrent single requests can
-// exceed maxSubscriptionsPerConn. The slot is released by addSubscriptions
-// when the call's notifier is collected, and the installed subscription's
-// slot is released by unsubscribe or cancelServerSubscriptions.
+// exceed maxSubscriptionsPerConn. The slot is released by releaseSubscription
+// if the call creates no subscription, converted by addSubscriptions when
+// the call's notifier is collected, and the installed subscription's slot is
+// released by unsubscribe or cancelServerSubscriptions.
 func (h *handler) reserveSubscription() error {
 	h.subLock.Lock()
 	defer h.subLock.Unlock()
@@ -414,10 +423,20 @@ func (h *handler) handleSubscribe(cp *callProc, msg *jsonrpcMessage) *jsonrpcMes
 
 	// Install notifier in context so the subscription handler can find it.
 	n := &Notifier{h: h, namespace: namespace}
-	cp.notifiers = append(cp.notifiers, n)
 	ctx := context.WithValue(cp.ctx, notifierKey{}, n)
 
-	return h.runMethod(ctx, msg, callb, args)
+	answer := h.runMethod(ctx, msg, callb, args)
+
+	// A call that returned without creating a subscription has nothing to
+	// install, so its reservation is returned now rather than when the whole
+	// batch has run: later elements of the same batch must not be rejected
+	// on behalf of slots that nothing holds.
+	if !n.hasSubscription() {
+		h.releaseSubscription()
+		return answer
+	}
+	cp.notifiers = append(cp.notifiers, n)
+	return answer
 }
 
 // runMethod runs the Go callback for an RPC method.

--- a/rpc/server/subscription.go
+++ b/rpc/server/subscription.go
@@ -36,7 +36,14 @@ var (
 	ErrNotificationsUnsupported = errors.New("notifications not supported")
 	// ErrNotificationNotFound is returned when the notification for the given id is not found
 	ErrSubscriptionNotFound = errors.New("subscription not found")
+	// ErrTooManySubscriptions is returned when a connection already holds
+	// maxSubscriptionsPerConn server subscriptions.
+	ErrTooManySubscriptions = errors.New("too many subscriptions on this connection")
 )
+
+// maxSubscriptionsPerConn bounds the server subscriptions one connection can
+// hold at a time; a client that needs more must unsubscribe first.
+const maxSubscriptionsPerConn = 64
 
 var globalGen = randomIDGenerator()
 

--- a/rpc/server/subscription.go
+++ b/rpc/server/subscription.go
@@ -163,6 +163,15 @@ func (n *Notifier) takeSubscription() *Subscription {
 	return n.sub
 }
 
+// hasSubscription reports whether the subscribe call created a subscription.
+// It marks the call as returned, so no subscription can be created afterwards.
+func (n *Notifier) hasSubscription() bool {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.callReturned = true
+	return n.sub != nil
+}
+
 // activate is called after the subscription ID was sent to client. Notifications are
 // buffered before activation. This prevents notifications being sent to the client before
 // the subscription ID is sent to the client.

--- a/rpc/server/subscription_test.go
+++ b/rpc/server/subscription_test.go
@@ -1,0 +1,212 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// subscriptionTestService exposes one subscription method that behaves like
+// a normal service callback: it creates the notifier subscription and returns
+// it. failBeforeCreate makes it return an error without creating anything,
+// which is how a service reports a rejected request.
+type subscriptionTestService struct {
+	failBeforeCreate bool
+	failAfterCreate  bool
+}
+
+var errServiceRejected = errors.New("service rejected the subscription")
+
+func (s *subscriptionTestService) Events(ctx context.Context) (*Subscription, error) {
+	notifier, ok := NotifierFromContext(ctx)
+	if !ok {
+		return nil, ErrNotificationsUnsupported
+	}
+	if s.failBeforeCreate {
+		return nil, errServiceRejected
+	}
+	sub := notifier.CreateSubscription()
+	if s.failAfterCreate {
+		return nil, errServiceRejected
+	}
+	return sub, nil
+}
+
+func newSubscriptionTestServer(t *testing.T, svc *subscriptionTestService) *Server {
+	t.Helper()
+	server := NewServer()
+	if err := server.RegisterName("test", svc); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(server.Stop)
+	return server
+}
+
+func subscribeN(t *testing.T, client *Client, n int) []*ClientSubscription {
+	t.Helper()
+	subs := make([]*ClientSubscription, 0, n)
+	for i := 0; i < n; i++ {
+		sub, err := client.Subscribe(context.Background(), "test", make(chan int, 1), "events")
+		if err != nil {
+			t.Fatalf("subscription %d of %d failed: %v", i+1, n, err)
+		}
+		subs = append(subs, sub)
+	}
+	return subs
+}
+
+func assertLimitError(t *testing.T, err error) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected the per-connection subscription limit to reject the request")
+	}
+	if err.Error() != ErrTooManySubscriptions.Error() {
+		t.Fatalf("expected %q, got %q", ErrTooManySubscriptions, err)
+	}
+}
+
+// One connection may hold at most maxSubscriptionsPerConn server
+// subscriptions. Unsubscribing frees a slot and other connections keep their
+// own budget.
+func TestSubscriptionLimitPerConnection(t *testing.T) {
+	server := newSubscriptionTestServer(t, &subscriptionTestService{})
+	client := DialInProc(server)
+	defer client.Close()
+
+	subs := subscribeN(t, client, maxSubscriptionsPerConn)
+
+	_, err := client.Subscribe(context.Background(), "test", make(chan int, 1), "events")
+	assertLimitError(t, err)
+
+	subs[0].Unsubscribe()
+	subscribeN(t, client, 1)
+
+	other := DialInProc(server)
+	defer other.Close()
+	subscribeN(t, other, maxSubscriptionsPerConn)
+}
+
+// A batch cannot exceed the limit either: the reservation is taken per call
+// before the service runs, not when the batch's subscriptions are recorded
+// at the end.
+func TestSubscriptionLimitCoversBatches(t *testing.T) {
+	server := newSubscriptionTestServer(t, &subscriptionTestService{})
+	client := DialInProc(server)
+	defer client.Close()
+
+	const extra = 5
+	batch := make([]BatchElem, maxSubscriptionsPerConn+extra)
+	ids := make([]string, len(batch))
+	for i := range batch {
+		batch[i] = BatchElem{
+			Method: "test.subscribe",
+			Args:   []interface{}{"events"},
+			Result: &ids[i],
+		}
+	}
+	if err := client.BatchCall(batch); err != nil {
+		t.Fatal(err)
+	}
+	accepted, rejected := 0, 0
+	for i, elem := range batch {
+		switch {
+		case elem.Error == nil:
+			if ids[i] == "" {
+				t.Fatalf("batch element %d has no error but no subscription ID", i)
+			}
+			accepted++
+		case elem.Error.Error() == ErrTooManySubscriptions.Error():
+			rejected++
+		default:
+			t.Fatalf("batch element %d: unexpected error %v", i, elem.Error)
+		}
+	}
+	if accepted != maxSubscriptionsPerConn || rejected != extra {
+		t.Fatalf("accepted %d rejected %d, want %d and %d", accepted, rejected, maxSubscriptionsPerConn, extra)
+	}
+
+	// The connection is full now.
+	_, err := client.Subscribe(context.Background(), "test", make(chan int, 1), "events")
+	assertLimitError(t, err)
+
+	// Unsubscribing an ID accepted in the batch frees its slot.
+	var ok bool
+	if err := client.Call(&ok, "test.unsubscribe", ids[0]); err != nil || !ok {
+		t.Fatalf("unsubscribe failed: ok=%v err=%v", ok, err)
+	}
+	subscribeN(t, client, 1)
+}
+
+// A request the service rejects before creating a subscription must not
+// consume the connection's budget.
+func TestRejectedSubscriptionReleasesReservation(t *testing.T) {
+	svc := &subscriptionTestService{failBeforeCreate: true}
+	server := newSubscriptionTestServer(t, svc)
+	client := DialInProc(server)
+	defer client.Close()
+
+	for i := 0; i < maxSubscriptionsPerConn+1; i++ {
+		_, err := client.Subscribe(context.Background(), "test", make(chan int, 1), "events")
+		if err == nil || !strings.Contains(err.Error(), errServiceRejected.Error()) {
+			t.Fatalf("attempt %d: expected the service error, got %v", i, err)
+		}
+	}
+
+	svc.failBeforeCreate = false
+	subscribeN(t, client, maxSubscriptionsPerConn)
+}
+
+// A subscription the service created before returning an error is still
+// recorded by the handler (existing behavior), so it holds a slot until the
+// connection closes: the reservation is converted, not dropped.
+func TestSubscriptionCreatedBeforeErrorHoldsSlot(t *testing.T) {
+	svc := &subscriptionTestService{failAfterCreate: true}
+	server := newSubscriptionTestServer(t, svc)
+	client := DialInProc(server)
+	defer client.Close()
+
+	for i := 0; i < maxSubscriptionsPerConn; i++ {
+		_, err := client.Subscribe(context.Background(), "test", make(chan int, 1), "events")
+		if err == nil || !strings.Contains(err.Error(), errServiceRejected.Error()) {
+			t.Fatalf("attempt %d: expected the service error, got %v", i, err)
+		}
+	}
+	_, err := client.Subscribe(context.Background(), "test", make(chan int, 1), "events")
+	assertLimitError(t, err)
+
+	// A fresh connection is unaffected.
+	other := DialInProc(server)
+	defer other.Close()
+	svc.failAfterCreate = false
+	subscribeN(t, other, maxSubscriptionsPerConn)
+}
+
+// Requests that fail argument validation are answered with their own errors,
+// not the limit error, and do not consume budget.
+func TestSubscriptionLimitCheckedAfterValidation(t *testing.T) {
+	server := newSubscriptionTestServer(t, &subscriptionTestService{})
+	client := DialInProc(server)
+	defer client.Close()
+
+	for i := 0; i < maxSubscriptionsPerConn+1; i++ {
+		_, err := client.Subscribe(context.Background(), "test", make(chan int, 1), "missing")
+		if err == nil || err.Error() == ErrTooManySubscriptions.Error() {
+			t.Fatalf("attempt %d: expected a not-found error, got %v", i, err)
+		}
+	}
+	subscribeN(t, client, maxSubscriptionsPerConn)
+}
+
+// Closing the connection releases everything, so a server that has seen many
+// full connections keeps accepting new ones.
+func TestSubscriptionLimitResetsPerConnection(t *testing.T) {
+	server := newSubscriptionTestServer(t, &subscriptionTestService{})
+	for round := 0; round < 3; round++ {
+		client := DialInProc(server)
+		subscribeN(t, client, maxSubscriptionsPerConn)
+		_, err := client.Subscribe(context.Background(), "test", make(chan int, 1), "events")
+		assertLimitError(t, err)
+		client.Close()
+	}
+}

--- a/rpc/server/subscription_test.go
+++ b/rpc/server/subscription_test.go
@@ -14,6 +14,9 @@ import (
 type subscriptionTestService struct {
 	failBeforeCreate bool
 	failAfterCreate  bool
+	// rejectFirst makes the first n calls fail before creating a
+	// subscription, then clears itself.
+	rejectFirst int
 }
 
 var errServiceRejected = errors.New("service rejected the subscription")
@@ -24,6 +27,10 @@ func (s *subscriptionTestService) Events(ctx context.Context) (*Subscription, er
 		return nil, ErrNotificationsUnsupported
 	}
 	if s.failBeforeCreate {
+		return nil, errServiceRejected
+	}
+	if s.rejectFirst > 0 {
+		s.rejectFirst--
 		return nil, errServiceRejected
 	}
 	sub := notifier.CreateSubscription()
@@ -155,6 +162,47 @@ func TestRejectedSubscriptionReleasesReservation(t *testing.T) {
 
 	svc.failBeforeCreate = false
 	subscribeN(t, client, maxSubscriptionsPerConn)
+}
+
+// Within one batch, a request the service rejected must not hold its
+// reservation against later elements of the same batch: a batch of
+// maxSubscriptionsPerConn rejections followed by one accepted request must
+// accept that last request.
+func TestRejectedSubscriptionInBatchFreesSlotForLaterElement(t *testing.T) {
+	svc := &subscriptionTestService{rejectFirst: maxSubscriptionsPerConn}
+	server := newSubscriptionTestServer(t, svc)
+	client := DialInProc(server)
+	defer client.Close()
+
+	batch := make([]BatchElem, maxSubscriptionsPerConn+1)
+	ids := make([]string, len(batch))
+	for i := range batch {
+		batch[i] = BatchElem{
+			Method: "test.subscribe",
+			Args:   []interface{}{"events"},
+			Result: &ids[i],
+		}
+	}
+	if err := client.BatchCall(batch); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < maxSubscriptionsPerConn; i++ {
+		if batch[i].Error == nil || !strings.Contains(batch[i].Error.Error(), errServiceRejected.Error()) {
+			t.Fatalf("batch element %d: expected the service error, got %v", i, batch[i].Error)
+		}
+	}
+	last := batch[maxSubscriptionsPerConn]
+	if last.Error != nil {
+		t.Fatalf("last batch element: expected success after rejected elements, got %v", last.Error)
+	}
+	if ids[maxSubscriptionsPerConn] == "" {
+		t.Fatal("last batch element has no subscription ID")
+	}
+
+	// Exactly one slot is in use afterwards.
+	subscribeN(t, client, maxSubscriptionsPerConn-1)
+	_, err := client.Subscribe(context.Background(), "test", make(chan int, 1), "events")
+	assertLimitError(t, err)
 }
 
 // A subscription the service created before returning an error is still


### PR DESCRIPTION
## Summary

The `ledger` subscription API kept every accepted subscription with no ceiling, in two places: the RPC handler's per-connection map and the subscribe server's per-type maps that every matching chain event is fanned out to from the single worker goroutine. The 100-entry install backlog only bounds entries the worker has not drained yet. Closed subscriptions were also only reclaimed when a broadcast happened to visit them, which for address-filtered subscriptions means when a block for that exact address arrives.

This PR adds two bounds, enforced through the existing entry points and released exactly once, and makes reclamation independent of the worker:

- **Per connection (rpc/server):** at most 64 server subscriptions. The slot is reserved in `handleSubscribe` after argument validation and before the notifier is created, and counts calls still in flight, so a batch or concurrent requests cannot exceed it. If the callback returns without creating a subscription the reservation is released right away, so rejected elements of a batch do not count against later elements of the same batch; otherwise `addSubscriptions` converts it into a map entry. Rejections return `ErrTooManySubscriptions` and create no notifier.
- **Server-wide (rpc/api/subscribe):** at most 4096 live subscriptions, counted from acceptance in `subscribe` (under `stopLock`) until `uninstall`, which is idempotent and releases the slot under `subsMu` together with the map entry. Reported as `ErrSubscriptionLimitReached` ahead of the transient backlog check.
- **Reclamation:** each installed subscription gets a watcher goroutine that waits on the RPC subscription's error channel and the connection's closed channel (the same signals `Closed` reports) and uninstalls the entry as soon as either fires. Capacity therefore returns when the client unsubscribes or disconnects, without waiting for the worker or for an event that matches the entry. The subscription maps are guarded by `subsMu`; the worker broadcasts to a snapshot so notification writes never hold the lock. Watchers are bounded by the global limit and exit on `Stop`.

The limits are constants for now; the subscribe server is created by the core without access to the RPC config. Current official clients stay well below them (Syrius opens two subscriptions per connection; the SDK exposes four subscription methods with no automatic address fan-out).

Out of scope, tracked in #96: notification fan-out still runs synchronously on the worker with no slow-consumer policy, and the `Notifier.Notify` doc comment claims a connection close on error that does not happen.

## Tests

- `rpc/server/subscription_test.go` (new): limit reached exactly at 64 and unsubscribe frees a slot; a batch larger than the limit accepts exactly 64; service-side rejections and argument errors consume no budget; a batch of 64 rejections followed by one acceptable request accepts it and uses one slot; a subscription created before the service errors keeps its slot; per-connection budgets are independent and closing a connection releases everything.
- `rpc/api/subscribe/api_internal_test.go`: through `GetSubscribeServer`, `GetSubscribeApi` and an in-process RPC client, exactly 4096 subscriptions are accepted and the next is rejected; an unsubscribed momentum subscription returns capacity; 4096 address-filtered subscriptions whose connections all close return capacity with no matching event; subscribe/unsubscribe churn on one connection totalling 4096 address-filtered subscriptions leaves a fresh client admitted.

All new tests fail on the unpatched code.

## Verification

- `GOWORK=off go vet ./rpc/...`
- `GOWORK=off go test -race -count=3 ./rpc/server/ ./rpc/api/subscribe/`
- `GOWORK=off golangci-lint run ./rpc/...` unchanged from baseline
- `GOWORK=off go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAfAxvtiPqYU6873a9K4uH
