### PR TITLE
node: serve RPC to local clients only by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Since version `0.0.2`, `znnd` is configured with the Alphanet Genesis and defaul
 
 Use [znn-controller](https://github.com/zenon-network/znn_controller_dart) to configure your full node. For more information please consult the [Wiki](https://github.com/zenon-network/znn-wiki).
 
+By default the HTTP (`35997`) and WebSocket (`35998`) JSON-RPC servers listen on `127.0.0.1` only and grant no cross-origin browser access. To serve other hosts, set `RPC.HTTPHost` / `RPC.WSHost` in `config.json` (or pass `--http-addr` / `--ws-addr`), and add `RPC.HTTPCors` / `RPC.WSOrigins` entries for any browser origins that need access. `znnd` logs a warning at startup for each setting that reaches beyond the local machine; put a firewall or a proxy in front of a public endpoint.
+
 ## Local devnet
 
 This branch includes a dockerized five-node local devnet with three

--- a/node/defaults.go
+++ b/node/defaults.go
@@ -20,16 +20,21 @@ var DefaultNodeConfig = Config{
 
 	LogLevel: "info",
 
+	// RPC serves local clients only unless the operator opts in: the
+	// listeners bind to loopback, HTTP accepts the localhost hostname and IP
+	// literals as Host, and no cross-origin browser access is granted (the
+	// WebSocket validator still admits localhost origins and non-browser
+	// clients when the list is empty). A public endpoint needs explicit
+	// hosts, and usually origins, in config.json or on the command line.
 	RPC: RPCConfig{
 		HTTPPort:   p2p.DefaultHTTPPort,
-		HTTPHost:   "0.0.0.0",
+		HTTPHost:   "127.0.0.1",
 		EnableHTTP: true,
 		WSPort:     p2p.DefaultWSPort,
-		WSHost:     "0.0.0.0",
+		WSHost:     "127.0.0.1",
 		EnableWS:   true,
 
-		HTTPCors:  []string{"*"},
-		WSOrigins: []string{"*"},
+		HTTPVirtualHosts: []string{"localhost"},
 	},
 	Net: NetConfig{
 		ListenHost:        p2p.DefaultListenHost,

--- a/node/node.go
+++ b/node/node.go
@@ -154,6 +154,7 @@ func (node *Node) Start() error {
 		log.Error("failed to start rpc", "reason", err)
 		return err
 	}
+	node.warnRPCExposure()
 
 	return nil
 }

--- a/node/rpc_defaults_test.go
+++ b/node/rpc_defaults_test.go
@@ -1,0 +1,258 @@
+package node
+
+import (
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/inconshreveable/log15"
+
+	rpc "github.com/zenon-network/go-zenon/rpc/server"
+)
+
+// defaultsProbe is the only API registered by these tests so a successful
+// JSON-RPC round trip proves the handler is live.
+type defaultsProbe struct{}
+
+func (defaultsProbe) Ping() string { return "pong" }
+
+// startDefaultsNode starts the RPC stack with the shipped defaults, except
+// that ports are ephemeral so the test never collides with a running node.
+func startDefaultsNode(t *testing.T, mutate func(*RPCConfig)) *Node {
+	t.Helper()
+	cfg := DefaultNodeConfig.RPC
+	cfg.HTTPPort, cfg.WSPort = 0, 0
+	if mutate != nil {
+		mutate(&cfg)
+	}
+	n := &Node{
+		config:  &Config{RPC: cfg},
+		http:    newHTTPServer(rpc.DefaultHTTPTimeouts),
+		ws:      newHTTPServer(rpc.DefaultHTTPTimeouts),
+		rpcAPIs: []rpc.API{{Namespace: "probe", Service: defaultsProbe{}, Public: true}},
+	}
+	if err := n.startRPC(); err != nil {
+		t.Fatalf("startRPC: %v", err)
+	}
+	t.Cleanup(n.stopRPC)
+	return n
+}
+
+// wsServerOf returns the server that has the WebSocket handler installed,
+// whichever one startRPC chose; it fails if there is none.
+func wsServerOf(t *testing.T, n *Node) *httpServer {
+	t.Helper()
+	for _, h := range []*httpServer{n.http, n.ws} {
+		if h.wsAllowed() {
+			return h
+		}
+	}
+	t.Fatal("WebSocket is not enabled on either server")
+	return nil
+}
+
+func listenerIP(t *testing.T, h *httpServer) net.IP {
+	t.Helper()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.listener == nil {
+		t.Fatal("server has no listener")
+	}
+	return h.listener.Addr().(*net.TCPAddr).IP
+}
+
+func postJSONRPC(t *testing.T, addr string, headers map[string]string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, "http://"+addr, strings.NewReader(
+		`{"jsonrpc":"2.0","id":1,"method":"probe.ping","params":[]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	for k, v := range headers {
+		if k == "Host" {
+			req.Host = v
+			continue
+		}
+		req.Header.Set(k, v)
+	}
+	resp, err := (&http.Client{Timeout: 2 * time.Second}).Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	return resp
+}
+
+func dialWS(t *testing.T, addr string, origin string) error {
+	t.Helper()
+	var header http.Header
+	if origin != "" {
+		header = http.Header{"Origin": {origin}}
+	}
+	conn, _, err := (&websocket.Dialer{HandshakeTimeout: 2 * time.Second}).Dial("ws://"+addr, header)
+	if err == nil {
+		conn.Close()
+	}
+	return err
+}
+
+// The shipped defaults must not expose RPC beyond the local machine or to
+// arbitrary browser origins; an operator opts into either explicitly.
+func TestDefaultRPCConfigIsLocalOnly(t *testing.T) {
+	cfg := DefaultNodeConfig.RPC
+	for name, host := range map[string]string{"HTTPHost": cfg.HTTPHost, "WSHost": cfg.WSHost} {
+		if ip := net.ParseIP(host); ip == nil || !ip.IsLoopback() {
+			t.Errorf("%s defaults to %q, want a loopback address", name, host)
+		}
+	}
+	if !cfg.EnableHTTP || !cfg.EnableWS {
+		t.Error("HTTP and WebSocket RPC should stay enabled for local clients")
+	}
+	if len(cfg.HTTPCors) != 0 {
+		t.Errorf("HTTPCors defaults to %v, want none", cfg.HTTPCors)
+	}
+	if len(cfg.WSOrigins) != 0 {
+		t.Errorf("WSOrigins defaults to %v, want none", cfg.WSOrigins)
+	}
+	if len(cfg.HTTPVirtualHosts) != 1 || cfg.HTTPVirtualHosts[0] != "localhost" {
+		t.Errorf("HTTPVirtualHosts defaults to %v, want [localhost]", cfg.HTTPVirtualHosts)
+	}
+}
+
+// Under the defaults the listeners are loopback-only, HTTP serves local
+// hostnames and IP literals but grants no cross-origin access, and the
+// WebSocket upgrade accepts local origins and non-browser clients only.
+func TestDefaultRPCServesLocalClientsOnly(t *testing.T) {
+	n := startDefaultsNode(t, nil)
+
+	if ip := listenerIP(t, n.http); !ip.IsLoopback() {
+		t.Fatalf("HTTP bound to %v", ip)
+	}
+	wsServer := wsServerOf(t, n)
+	if ip := listenerIP(t, wsServer); !ip.IsLoopback() {
+		t.Fatalf("WS bound to %v", ip)
+	}
+	httpAddr := n.http.listenAddr()
+	wsAddr := wsServer.listenAddr()
+
+	if resp := postJSONRPC(t, httpAddr, nil); resp.StatusCode != http.StatusOK {
+		t.Fatalf("IP-literal host: status %d", resp.StatusCode)
+	}
+	if resp := postJSONRPC(t, httpAddr, map[string]string{"Host": "localhost"}); resp.StatusCode != http.StatusOK {
+		t.Fatalf("Host localhost: status %d", resp.StatusCode)
+	}
+	if resp := postJSONRPC(t, httpAddr, map[string]string{"Host": "node.example"}); resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("Host node.example: status %d, want 403", resp.StatusCode)
+	}
+
+	resp := postJSONRPC(t, httpAddr, map[string]string{"Origin": "https://site.example"})
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "" {
+		t.Fatalf("cross-origin request was granted Access-Control-Allow-Origin %q", got)
+	}
+
+	if err := dialWS(t, wsAddr, ""); err != nil {
+		t.Fatalf("WebSocket without Origin rejected: %v", err)
+	}
+	if err := dialWS(t, wsAddr, "http://localhost"); err != nil {
+		t.Fatalf("WebSocket from http://localhost rejected: %v", err)
+	}
+	if err := dialWS(t, wsAddr, "https://site.example"); err == nil {
+		t.Fatal("WebSocket from https://site.example accepted")
+	}
+}
+
+// captureWarnings routes the node logger through a recorder for the test.
+func captureWarnings(t *testing.T) func() []string {
+	t.Helper()
+	var msgs []string
+	old := log.GetHandler()
+	log.SetHandler(log15.FuncHandler(func(r *log15.Record) error {
+		if r.Lvl == log15.LvlWarn {
+			msgs = append(msgs, r.Msg)
+		}
+		return nil
+	}))
+	t.Cleanup(func() { log.SetHandler(old) })
+	return func() []string { return msgs }
+}
+
+func hasWarning(msgs []string, substr string) bool {
+	for _, m := range msgs {
+		if strings.Contains(m, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// Listeners that reach beyond the local machine are announced once they are
+// up, based on what is actually bound rather than on the configuration; the
+// defaults are silent.
+func TestRPCExposureWarning(t *testing.T) {
+	t.Run("defaults are silent", func(t *testing.T) {
+		got := captureWarnings(t)
+		n := startDefaultsNode(t, nil)
+		n.warnRPCExposure()
+		if msgs := got(); len(msgs) != 0 {
+			t.Fatalf("unexpected warnings: %v", msgs)
+		}
+	})
+	t.Run("non-loopback binds and wildcard origins warn", func(t *testing.T) {
+		got := captureWarnings(t)
+		n := startDefaultsNode(t, func(cfg *RPCConfig) {
+			cfg.HTTPHost, cfg.WSHost = "0.0.0.0", "0.0.0.0"
+			cfg.HTTPCors, cfg.WSOrigins = []string{"*"}, []string{"*"}
+		})
+		n.warnRPCExposure()
+		msgs := got()
+		for _, want := range []string{"HTTP-RPC", "WS-RPC"} {
+			if !hasWarning(msgs, want+" listens on a non-loopback address") {
+				t.Errorf("missing bind warning for %s in %v", want, msgs)
+			}
+			if !hasWarning(msgs, want+" accepts any browser origin") {
+				t.Errorf("missing origin warning for %s in %v", want, msgs)
+			}
+		}
+	})
+	t.Run("protocols without a listener do not warn", func(t *testing.T) {
+		got := captureWarnings(t)
+		n := startDefaultsNode(t, func(cfg *RPCConfig) {
+			cfg.HTTPHost, cfg.WSHost = "", ""
+			cfg.HTTPCors, cfg.WSOrigins = []string{"*"}, []string{"*"}
+		})
+		n.warnRPCExposure()
+		if msgs := got(); len(msgs) != 0 {
+			t.Fatalf("unexpected warnings: %v", msgs)
+		}
+	})
+	t.Run("a public listener warns whatever the flags say", func(t *testing.T) {
+		got := captureWarnings(t)
+		n := startDefaultsNode(t, func(cfg *RPCConfig) {
+			cfg.EnableHTTP, cfg.HTTPHost = false, "0.0.0.0"
+			cfg.EnableWS, cfg.WSHost = false, "0.0.0.0"
+		})
+		n.warnRPCExposure()
+		msgs := got()
+		// Whether these listeners exist depends on whether startRPC honors
+		// the enable flags; the warning must track the listener either way.
+		bound := map[string]bool{}
+		for _, server := range []*httpServer{n.http, n.ws} {
+			addr, cors, origins := server.exposure()
+			if addr != nil && cors != nil {
+				bound["HTTP-RPC"] = true
+			}
+			if addr != nil && origins != nil {
+				bound["WS-RPC"] = true
+			}
+		}
+		for _, proto := range []string{"HTTP-RPC", "WS-RPC"} {
+			if bound[proto] != hasWarning(msgs, proto+" listens on a non-loopback address") {
+				t.Errorf("%s: listener bound=%v but warnings were %v", proto, bound[proto], msgs)
+			}
+		}
+	})
+}

--- a/node/rpc_exposure.go
+++ b/node/rpc_exposure.go
@@ -1,0 +1,67 @@
+package node
+
+import "net"
+
+// warnRPCExposure logs, once after the RPC servers are started, every live
+// listener that reaches beyond the local machine and every wildcard browser
+// origin list installed on it, so an operator running a public endpoint has
+// made that choice knowingly. It reads the servers' actual state rather than
+// the configuration, so it reports exactly what is bound. The shipped
+// defaults are silent.
+func (node *Node) warnRPCExposure() {
+	for _, server := range []*httpServer{node.http, node.ws} {
+		addr, cors, origins := server.exposure()
+		if addr == nil {
+			continue
+		}
+		public := !addr.IP.IsLoopback()
+		if cors != nil {
+			if public {
+				log.Warn("HTTP-RPC listens on a non-loopback address and is reachable from other hosts", "endpoint", addr)
+			}
+			if hasWildcard(cors) {
+				log.Warn("HTTP-RPC accepts any browser origin", "cors", "*")
+			}
+		}
+		if origins != nil {
+			if public {
+				log.Warn("WS-RPC listens on a non-loopback address and is reachable from other hosts", "endpoint", addr)
+			}
+			if hasWildcard(origins) {
+				log.Warn("WS-RPC accepts any browser origin", "origins", "*")
+			}
+		}
+	}
+}
+
+// exposure returns the bound address (nil when not listening) and, for each
+// protocol served on it, its origin allow-list. A protocol that is not
+// enabled on this server yields a nil slice; an enabled one with no
+// configured origins yields an empty, non-nil slice.
+func (h *httpServer) exposure() (addr *net.TCPAddr, cors []string, origins []string) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if h.listener == nil {
+		return nil, nil, nil
+	}
+	addr, _ = h.listener.Addr().(*net.TCPAddr)
+	if addr == nil {
+		return nil, nil, nil
+	}
+	if h.rpcAllowed() {
+		cors = append([]string{}, h.httpConfig.CorsAllowedOrigins...)
+	}
+	if h.wsAllowed() {
+		origins = append([]string{}, h.wsConfig.Origins...)
+	}
+	return addr, cors, origins
+}
+
+func hasWildcard(list []string) bool {
+	for _, item := range list {
+		if item == "*" {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

The shipped defaults bound both JSON-RPC servers to `0.0.0.0`, granted cross-origin access to every browser origin (`HTTPCors` and `WSOrigins` `"*"`), and registered every public namespace, so a node started without a config file served the whole public RPC surface to any host with a network path and to any website the operator's browser visited. The same defaults also rejected a plain `http://localhost:35997` request with 403, because the empty virtual-host list only admits IP-literal `Host` headers.

Changes:

- **Local-only defaults** (`node/defaults.go`): both servers bind to `127.0.0.1`, the virtual-host list admits `localhost` (IP literals were always admitted), and no CORS or WebSocket origin list is set. With an empty list the CORS middleware is not installed, so no cross-origin grant is issued, and the WebSocket validator falls back to admitting localhost origins and non-browser clients, which keeps wallets and local tools working unchanged. HTTP and WebSocket stay enabled; ports are unchanged.
- **Startup warning** (`node/rpc_exposure.go`, called from `Node.Start` after `startRPC`): one warning per live listener bound to a non-loopback address and per wildcard origin list installed on it. It is derived from the servers' actual state (listener address and installed handlers), not from the configuration, so it reports exactly what is bound regardless of how the enable flags are interpreted. The defaults are silent. `startRPC` itself is untouched; this merges cleanly with #87 in either order.
- **README**: a paragraph on the defaults and how to expose an endpoint.

## Compatibility

- `config.json` files that set the hosts and origins keep working unchanged. The devnet role configs and `devnet-keygen` set them explicitly.
- A node that relied on the bare defaults for remote access must now set `RPC.HTTPHost` / `RPC.WSHost` (or `--http-addr` / `--ws-addr`).
- A `config.json` that sets a host but omits `HTTPCors` / `WSOrigins` no longer inherits the wildcard for browser clients and must list the origins it serves. Non-browser clients (znn-cli, SDK, Syrius over WebSocket) send no `Origin` and are unaffected.

## Tests

`node/rpc_defaults_test.go` (new):

- the default RPC config has loopback hosts, both protocols enabled, no CORS or WebSocket origins, and the `localhost` virtual host;
- the RPC stack started from the defaults (ephemeral ports) binds loopback only, answers with `Host: 127.0.0.1` and `Host: localhost`, rejects an unlisted hostname, issues no `Access-Control-Allow-Origin` for a foreign origin, and accepts WebSocket upgrades without an `Origin` or from `http://localhost` while rejecting a foreign origin;
- the exposure warning is silent for the defaults and for protocols without a listener, names each non-loopback bind and wildcard origin list, and tracks the listener rather than the enable flags when the two disagree.

All fail on the unpatched defaults.

## Verification

- `GOWORK=off go vet ./node/`
- `GOWORK=off go test -race -count=3 ./node/`
- `GOWORK=off go test ./...`
- Combined tree with #87 (`fix/honor-rpc-enable-flags`) merged in both orders: vet, build and race-tested node package pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAfAxvtiPqYU6873a9K4uH
