### PR TITLE
rpc: bound batch size, batch response size and in-flight calls

### DIFF
--- a/rpc/server/batch_test.go
+++ b/rpc/server/batch_test.go
@@ -1,0 +1,453 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// batchTestService counts invocations and can hand back large results or
+// block until released, so the tests can observe execution rather than
+// only responses.
+type batchTestService struct {
+	calls   int32
+	inside  int32
+	release chan struct{}
+}
+
+func (s *batchTestService) Echo(v string) string {
+	atomic.AddInt32(&s.calls, 1)
+	return v
+}
+
+func (s *batchTestService) Big(n int) string {
+	atomic.AddInt32(&s.calls, 1)
+	return strings.Repeat("x", n)
+}
+
+// Reverse calls back into the client on the same connection; the reply
+// can only be delivered if the connection's dispatch loop keeps running.
+func (s *batchTestService) Reverse(ctx context.Context) (string, error) {
+	atomic.AddInt32(&s.calls, 1)
+	client, ok := ClientFromContext(ctx)
+	if !ok {
+		return "", fmt.Errorf("no client in context")
+	}
+	<-s.release
+	var res string
+	if err := client.CallContext(ctx, &res, "peer.echo", "back"); err != nil {
+		return "", err
+	}
+	return res, nil
+}
+
+// Fail returns an error carrying n bytes of data.
+func (s *batchTestService) Fail(n int) (string, error) {
+	atomic.AddInt32(&s.calls, 1)
+	return "", &bigDataError{strings.Repeat("e", n)}
+}
+
+type bigDataError struct{ data string }
+
+func (e *bigDataError) Error() string          { return "failed with data" }
+func (e *bigDataError) ErrorData() interface{} { return e.data }
+
+type peerService struct{}
+
+func (peerService) Echo(v string) string { return v }
+
+func (s *batchTestService) Block() string {
+	atomic.AddInt32(&s.calls, 1)
+	atomic.AddInt32(&s.inside, 1)
+	defer atomic.AddInt32(&s.inside, -1)
+	<-s.release
+	return "released"
+}
+
+func newBatchTestServer(t *testing.T) (*Server, *batchTestService) {
+	t.Helper()
+	svc := &batchTestService{release: make(chan struct{})}
+	server := NewServer()
+	if err := server.RegisterName("test", svc); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(server.Stop)
+	return server, svc
+}
+
+// batchOf builds a JSON array of n test.echo calls.
+func batchOf(n int) []byte {
+	var b bytes.Buffer
+	b.WriteByte('[')
+	for i := 0; i < n; i++ {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		fmt.Fprintf(&b, `{"jsonrpc":"2.0","id":%d,"method":"test.echo","params":["a"]}`, i+1)
+	}
+	b.WriteByte(']')
+	return b.Bytes()
+}
+
+// isBatchTooLarge reports whether body is the single invalid-request error
+// the server sends for an oversized batch.
+func isBatchTooLarge(t *testing.T, body []byte) bool {
+	t.Helper()
+	var msg jsonrpcMessage
+	if err := json.Unmarshal(body, &msg); err != nil {
+		return false // an array, or garbage
+	}
+	return msg.Error != nil && msg.Error.Code == -32600 && strings.Contains(msg.Error.Message, "batch too large")
+}
+
+func postHTTP(t *testing.T, url string, body []byte) []byte {
+	t.Helper()
+	resp, err := http.Post(url, "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	out, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return out
+}
+
+// A batch of exactly maxBatchRequests runs; one more is answered with a
+// single invalid-request error before any of its calls run. HTTP path.
+func TestBatchRequestLimitHTTP(t *testing.T) {
+	server, svc := newBatchTestServer(t)
+	ts := httptest.NewServer(server)
+	defer ts.Close()
+
+	out := postHTTP(t, ts.URL, batchOf(maxBatchRequests))
+	var answers []jsonrpcMessage
+	if err := json.Unmarshal(out, &answers); err != nil || len(answers) != maxBatchRequests {
+		t.Fatalf("batch at the limit: got %d answers (err %v)", len(answers), err)
+	}
+	if got := atomic.LoadInt32(&svc.calls); got != maxBatchRequests {
+		t.Fatalf("batch at the limit executed %d calls", got)
+	}
+
+	atomic.StoreInt32(&svc.calls, 0)
+	out = postHTTP(t, ts.URL, batchOf(maxBatchRequests+1))
+	if !isBatchTooLarge(t, out) {
+		t.Fatalf("batch over the limit was not rejected: %.200s", out)
+	}
+	if got := atomic.LoadInt32(&svc.calls); got != 0 {
+		t.Fatalf("rejected batch still executed %d calls", got)
+	}
+}
+
+// Same over a persistent WebSocket connection, which must stay usable after
+// the rejection.
+func TestBatchRequestLimitWebSocket(t *testing.T) {
+	server, svc := newBatchTestServer(t)
+	ts := httptest.NewServer(server.WebsocketHandler([]string{"*"}))
+	defer ts.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(ts.URL, "http"), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+
+	if err := conn.WriteMessage(websocket.TextMessage, batchOf(maxBatchRequests+1)); err != nil {
+		t.Fatal(err)
+	}
+	_, out, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("no reply to the oversized batch: %v", err)
+	}
+	if !isBatchTooLarge(t, out) {
+		t.Fatalf("batch over the limit was not rejected: %.200s", out)
+	}
+	if got := atomic.LoadInt32(&svc.calls); got != 0 {
+		t.Fatalf("rejected batch still executed %d calls", got)
+	}
+
+	// The connection is still served.
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(`{"jsonrpc":"2.0","id":"after","method":"test.echo","params":["ok"]}`)); err != nil {
+		t.Fatal(err)
+	}
+	_, out, err = conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("connection unusable after the rejection: %v", err)
+	}
+	var msg jsonrpcMessage
+	if err := json.Unmarshal(out, &msg); err != nil || msg.Error != nil || string(msg.Result) != `"ok"` {
+		t.Fatalf("unexpected reply after the rejection: %s", out)
+	}
+}
+
+// Compact invalid elements count like any other: they cannot be used to
+// slip past the limit, and they do not need a method to be executed.
+func TestBatchRequestLimitCountsInvalidElements(t *testing.T) {
+	server, _ := newBatchTestServer(t)
+	ts := httptest.NewServer(server)
+	defer ts.Close()
+
+	body := []byte("[" + strings.Repeat("1,", maxBatchRequests) + "1]")
+	if out := postHTTP(t, ts.URL, body); !isBatchTooLarge(t, out) {
+		t.Fatalf("oversized batch of invalid elements was not rejected: %.200s", out)
+	}
+	body = []byte("[" + strings.Repeat("1,", maxBatchRequests-1) + "1]")
+	out := postHTTP(t, ts.URL, body)
+	var answers []jsonrpcMessage
+	if err := json.Unmarshal(out, &answers); err != nil || len(answers) != maxBatchRequests {
+		t.Fatalf("batch of invalid elements at the limit: got %d answers (err %v)", len(answers), err)
+	}
+}
+
+// Once the results accumulated for a batch exceed the response budget, the
+// remaining calls are not executed and are answered with an error instead.
+func TestBatchResponseSizeLimit(t *testing.T) {
+	server, svc := newBatchTestServer(t)
+	client := DialInProc(server)
+	defer client.Close()
+
+	const each = 4 * 1000 * 1000
+	n := maxBatchResponseBytes/each + 4
+	batch := make([]BatchElem, n)
+	results := make([]string, n)
+	for i := range batch {
+		batch[i] = BatchElem{Method: "test.big", Args: []interface{}{each}, Result: &results[i]}
+	}
+	if err := client.BatchCall(batch); err != nil {
+		t.Fatal(err)
+	}
+	served, rejected, total := 0, 0, 0
+	for i, elem := range batch {
+		switch {
+		case elem.Error == nil:
+			served++
+			total += len(results[i])
+		case strings.Contains(elem.Error.Error(), "batch response too large"):
+			rejected++
+		default:
+			t.Fatalf("element %d: unexpected error %v", i, elem.Error)
+		}
+	}
+	if rejected == 0 {
+		t.Fatalf("all %d results (%d bytes) were served", served, total)
+	}
+	// The overflowing result is still delivered; nothing beyond it is.
+	if total > maxBatchResponseBytes+each {
+		t.Fatalf("served %d bytes, budget is %d", total, maxBatchResponseBytes)
+	}
+	if got := int(atomic.LoadInt32(&svc.calls)); got != served {
+		t.Fatalf("%d calls executed for %d served results", got, served)
+	}
+}
+
+// Error payloads count against the budget like results do.
+func TestBatchResponseSizeLimitCountsErrors(t *testing.T) {
+	server, svc := newBatchTestServer(t)
+	client := DialInProc(server)
+	defer client.Close()
+
+	const each = 4 * 1000 * 1000
+	n := maxBatchResponseBytes/each + 4
+	batch := make([]BatchElem, n)
+	for i := range batch {
+		batch[i] = BatchElem{Method: "test.fail", Args: []interface{}{each}, Result: new(string)}
+	}
+	if err := client.BatchCall(batch); err != nil {
+		t.Fatal(err)
+	}
+	served, rejected := 0, 0
+	for i, elem := range batch {
+		switch {
+		case elem.Error == nil:
+			t.Fatalf("element %d succeeded", i)
+		case strings.Contains(elem.Error.Error(), "batch response too large"):
+			rejected++
+		case strings.Contains(elem.Error.Error(), "failed with data"):
+			served++
+		default:
+			t.Fatalf("element %d: unexpected error %v", i, elem.Error)
+		}
+	}
+	if rejected == 0 {
+		t.Fatalf("all %d error payloads were served", served)
+	}
+	if got := int(atomic.LoadInt32(&svc.calls)); got != served {
+		t.Fatalf("%d calls executed for %d served errors", got, served)
+	}
+}
+
+// The client refuses to send a batch the server would reject as a whole,
+// because the server's single error carries no IDs it could resolve.
+func TestClientRefusesOversizedBatch(t *testing.T) {
+	server, svc := newBatchTestServer(t)
+	client := DialInProc(server)
+	defer client.Close()
+
+	batch := make([]BatchElem, maxBatchRequests+1)
+	for i := range batch {
+		batch[i] = BatchElem{Method: "test.echo", Args: []interface{}{"a"}, Result: new(string)}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err := client.BatchCallContext(ctx, batch)
+	if err == nil || ctx.Err() != nil {
+		t.Fatalf("expected an immediate error, got %v (ctx %v)", err, ctx.Err())
+	}
+	if got := atomic.LoadInt32(&svc.calls); got != 0 {
+		t.Fatalf("%d calls executed", got)
+	}
+}
+
+// Callbacks that call back into the client need the connection's dispatch
+// loop to deliver their replies, so waiting for a call slot must never
+// happen on that loop. More calls than slots, all of them reverse calls,
+// have to complete.
+func TestReverseCallsBeyondSlotsComplete(t *testing.T) {
+	server, svc := newBatchTestServer(t)
+	client := DialInProc(server)
+	defer client.Close()
+	if err := client.RegisterName("peer", peerService{}); err != nil {
+		t.Fatal(err)
+	}
+
+	n := maxInFlightCalls + 1
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			var res string
+			errs <- client.CallContext(ctx, &res, "test.reverse")
+		}()
+	}
+	// Let every request reach the server before the callbacks proceed.
+	deadline := time.Now().Add(5 * time.Second)
+	for atomic.LoadInt32(&svc.calls) < maxInFlightCalls {
+		if time.Now().After(deadline) {
+			t.Fatalf("only %d calls reached the service", atomic.LoadInt32(&svc.calls))
+		}
+		time.Sleep(time.Millisecond)
+	}
+	time.Sleep(50 * time.Millisecond)
+	close(svc.release)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("reverse call failed: %v", err)
+		}
+	}
+}
+
+// Beyond the outstanding-message cap, a message is answered at once with an
+// overload error instead of being queued; earlier calls still complete.
+func TestPendingCallsOverloadIsRejected(t *testing.T) {
+	server, svc := newBatchTestServer(t)
+	client := DialInProc(server)
+	defer client.Close()
+
+	const extra = 5
+	n := maxPendingCalls + extra
+	var wg sync.WaitGroup
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var res string
+			errs <- client.CallContext(context.Background(), &res, "test.block")
+		}()
+	}
+	// Wait until the rejections have come back, which happens while the
+	// accepted calls are still blocked.
+	deadline := time.Now().Add(5 * time.Second)
+	var rejected []error
+	for len(rejected) < extra {
+		if time.Now().After(deadline) {
+			t.Fatalf("only %d messages were rejected", len(rejected))
+		}
+		select {
+		case err := <-errs:
+			if err == nil || !strings.Contains(err.Error(), "too many pending requests") {
+				t.Fatalf("unexpected early result: %v", err)
+			}
+			rejected = append(rejected, err)
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+	if got := atomic.LoadInt32(&svc.inside); got != maxInFlightCalls {
+		t.Fatalf("%d calls executing, want %d", got, maxInFlightCalls)
+	}
+	close(svc.release)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("accepted call failed: %v", err)
+		}
+	}
+	if got := atomic.LoadInt32(&svc.calls); got != maxPendingCalls {
+		t.Fatalf("%d calls executed, want %d", got, maxPendingCalls)
+	}
+}
+
+// One connection runs at most maxInFlightCalls call procedures at a time;
+// further messages wait for a slot and run once earlier calls finish.
+func TestInFlightCallsPerConnection(t *testing.T) {
+	server, svc := newBatchTestServer(t)
+	client := DialInProc(server)
+	defer client.Close()
+
+	const extra = 8
+	var wg sync.WaitGroup
+	errs := make(chan error, maxInFlightCalls+extra)
+	for i := 0; i < maxInFlightCalls+extra; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			var res string
+			errs <- client.CallContext(context.Background(), &res, "test.block")
+		}()
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for atomic.LoadInt32(&svc.inside) < maxInFlightCalls {
+		if time.Now().After(deadline) {
+			t.Fatalf("only %d calls entered the service", atomic.LoadInt32(&svc.inside))
+		}
+		time.Sleep(time.Millisecond)
+	}
+	time.Sleep(100 * time.Millisecond)
+	if got := atomic.LoadInt32(&svc.inside); got != maxInFlightCalls {
+		t.Fatalf("%d calls in flight on one connection, limit is %d", got, maxInFlightCalls)
+	}
+
+	close(svc.release)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("call failed: %v", err)
+		}
+	}
+	if got := atomic.LoadInt32(&svc.calls); got != maxInFlightCalls+extra {
+		t.Fatalf("%d calls executed in total", got)
+	}
+}

--- a/rpc/server/client.go
+++ b/rpc/server/client.go
@@ -345,6 +345,12 @@ func (c *Client) BatchCall(b []BatchElem) error {
 //
 // Note that batch calls may not be executed atomically on the server side.
 func (c *Client) BatchCallContext(ctx context.Context, b []BatchElem) error {
+	// The server answers a batch beyond its limit with a single error that
+	// carries no IDs, which this client could not resolve against b; refuse
+	// it here instead of waiting for replies that will not come.
+	if len(b) > maxBatchRequests {
+		return errBatchTooLarge
+	}
 	msgs := make([]*jsonrpcMessage, len(b))
 	op := &requestOp{
 		ids:  make([]json.RawMessage, len(b)),
@@ -635,6 +641,12 @@ func (c *Client) drainRead() {
 func (c *Client) read(codec ServerCodec) {
 	for {
 		msgs, batch, err := codec.readBatch()
+		if err == errBatchTooLarge {
+			// The value was consumed whole; answer it and keep serving the
+			// connection.
+			codec.writeJSON(context.Background(), errorMessage(err))
+			continue
+		}
 		if _, ok := err.(*json.SyntaxError); ok {
 			codec.writeJSON(context.Background(), errorMessage(&parseError{err.Error()}))
 		}

--- a/rpc/server/errors.go
+++ b/rpc/server/errors.go
@@ -54,9 +54,27 @@ var (
 	_ Error = new(invalidRequestError)
 	_ Error = new(invalidMessageError)
 	_ Error = new(invalidParamsError)
+	_ Error = new(batchResponseTooLargeError)
+	_ Error = new(tooManyPendingError)
 )
 
 const defaultErrorCode = -32000
+
+// tooManyPendingError answers a message received while the connection already
+// has maxPendingCalls messages accepted but not finished.
+type tooManyPendingError struct{}
+
+func (e *tooManyPendingError) ErrorCode() int { return -32005 }
+
+func (e *tooManyPendingError) Error() string { return "too many pending requests on this connection" }
+
+// batchResponseTooLargeError answers the calls of a batch that are skipped
+// once the batch's accumulated results exceed maxBatchResponseBytes.
+type batchResponseTooLargeError struct{}
+
+func (e *batchResponseTooLargeError) ErrorCode() int { return -32003 }
+
+func (e *batchResponseTooLargeError) Error() string { return "batch response too large" }
 
 type methodNotFoundError struct{ method string }
 

--- a/rpc/server/handler.go
+++ b/rpc/server/handler.go
@@ -23,6 +23,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -56,6 +57,9 @@ type handler struct {
 	respWait       map[string]*requestOp          // active client requests
 	clientSubs     map[string]*ClientSubscription // active client subscriptions
 	callWG         sync.WaitGroup                 // pending call goroutines
+	callSlots      chan struct{}                  // bounds running call goroutines, see startCallProc
+	callsPending   int32                          // accepted but unfinished messages, see startCallProc
+	callsClosed    chan struct{}                  // closed by close(); releases goroutines waiting for a slot
 	rootCtx        context.Context                // canceled by close()
 	cancelRoot     func()                         // cancel function for rootCtx
 	conn           jsonWriter                     // where responses will be sent
@@ -82,6 +86,8 @@ func newHandler(connCtx context.Context, conn jsonWriter, idgen func() ID, reg *
 		rootCtx:        rootCtx,
 		cancelRoot:     cancelRoot,
 		allowSubscribe: true,
+		callSlots:      make(chan struct{}, maxInFlightCalls),
+		callsClosed:    make(chan struct{}),
 		serverSubs:     make(map[ID]*Subscription),
 		log:            log.Root(),
 	}
@@ -113,11 +119,24 @@ func (h *handler) handleBatch(msgs []*jsonrpcMessage) {
 		return
 	}
 	// Process calls on a goroutine because they may block indefinitely:
-	h.startCallProc(func(cp *callProc) {
+	started := h.startCallProc(func(cp *callProc) {
 		answers := make([]*jsonrpcMessage, 0, len(msgs))
-		for _, msg := range calls {
+		responseBytes := 0
+		for i, msg := range calls {
 			if answer := h.handleCallMsg(cp, msg); answer != nil {
 				answers = append(answers, answer)
+				responseBytes += answer.payloadSize()
+			}
+			// The answer that crosses the budget is still delivered; the
+			// calls after it are answered without being executed.
+			if responseBytes > maxBatchResponseBytes {
+				h.log.Warn("Batch response too large", "responseBytes", responseBytes, "skipped", len(calls)-i-1)
+				for _, rest := range calls[i+1:] {
+					if rest.hasValidID() {
+						answers = append(answers, rest.errorResponse(new(batchResponseTooLargeError)))
+					}
+				}
+				break
 			}
 		}
 		h.addSubscriptions(cp.notifiers)
@@ -128,6 +147,17 @@ func (h *handler) handleBatch(msgs []*jsonrpcMessage) {
 			n.activate()
 		}
 	})
+	if !started {
+		answers := make([]*jsonrpcMessage, 0, len(calls))
+		for _, msg := range calls {
+			if msg.hasValidID() {
+				answers = append(answers, msg.errorResponse(new(tooManyPendingError)))
+			}
+		}
+		if len(answers) > 0 {
+			h.conn.writeJSON(h.rootCtx, answers)
+		}
+	}
 }
 
 // handleMsg handles a single message.
@@ -135,7 +165,7 @@ func (h *handler) handleMsg(msg *jsonrpcMessage) {
 	if ok := h.handleImmediate(msg); ok {
 		return
 	}
-	h.startCallProc(func(cp *callProc) {
+	started := h.startCallProc(func(cp *callProc) {
 		answer := h.handleCallMsg(cp, msg)
 		h.addSubscriptions(cp.notifiers)
 		if answer != nil {
@@ -145,12 +175,16 @@ func (h *handler) handleMsg(msg *jsonrpcMessage) {
 			n.activate()
 		}
 	})
+	if !started && msg.hasValidID() {
+		h.conn.writeJSON(h.rootCtx, msg.errorResponse(new(tooManyPendingError)))
+	}
 }
 
 // close cancels all requests except for inflightReq and waits for
 // call goroutines to shut down.
 func (h *handler) close(err error, inflightReq *requestOp) {
 	h.cancelAllRequests(err, inflightReq)
+	close(h.callsClosed)
 	h.callWG.Wait()
 	h.cancelRoot()
 	h.cancelServerSubscriptions(err)
@@ -217,14 +251,44 @@ func (h *handler) cancelServerSubscriptions(err error) {
 }
 
 // startCallProc runs fn in a new goroutine and starts tracking it in the h.calls wait group.
-func (h *handler) startCallProc(fn func(*callProc)) {
+//
+// The connection may have at most maxPendingCalls messages accepted but not
+// finished; beyond that startCallProc returns false without starting
+// anything and the caller answers the message with an overload error. Of
+// the accepted messages, at most maxInFlightCalls run at a time: the
+// goroutine waits for one of the connection's call slots before running fn
+// and returns it when fn is done. The wait happens on the new goroutine,
+// never on the caller: the caller is the connection's dispatch loop, which
+// running calls need to deliver replies to their reverse calls, so blocking
+// it could leave every slot holder waiting on the loop that waits on them.
+func (h *handler) startCallProc(fn func(*callProc)) bool {
+	if atomic.AddInt32(&h.callsPending, 1) > maxPendingCalls {
+		atomic.AddInt32(&h.callsPending, -1)
+		return false
+	}
 	h.callWG.Add(1)
 	go func() {
-		ctx, cancel := context.WithCancel(h.rootCtx)
 		defer h.callWG.Done()
+		defer atomic.AddInt32(&h.callsPending, -1)
+		// A free slot is taken even if the handler is already closing: the
+		// HTTP path closes the handler right after dispatch and waits for
+		// the call, and select would otherwise pick between the two ready
+		// cases at random.
+		select {
+		case h.callSlots <- struct{}{}:
+		default:
+			select {
+			case h.callSlots <- struct{}{}:
+			case <-h.callsClosed:
+				return
+			}
+		}
+		defer func() { <-h.callSlots }()
+		ctx, cancel := context.WithCancel(h.rootCtx)
 		defer cancel()
 		fn(&callProc{ctx: ctx})
 	}()
+	return true
 }
 
 // handleImmediate executes non-call messages. It returns false if the message is a

--- a/rpc/server/json.go
+++ b/rpc/server/json.go
@@ -39,6 +39,25 @@ const (
 	defaultWriteTimeout = 10 * time.Second // used if context has no deadline
 )
 
+// Bounds on the work one connection can hand the server at a time.
+const (
+	// maxBatchRequests bounds the number of calls one batch may carry;
+	// larger batches are rejected while parsing, before any element is
+	// allocated or executed.
+	maxBatchRequests = 1000
+	// maxBatchResponseBytes bounds the result bytes accumulated for one
+	// batch; once exceeded, the remaining calls are answered with an error
+	// instead of being executed.
+	maxBatchResponseBytes = 25 * 1000 * 1000
+	// maxInFlightCalls bounds the call procedures one connection may have
+	// running at a time; further messages wait for a free slot.
+	maxInFlightCalls = 32
+	// maxPendingCalls bounds the messages one connection may have accepted
+	// but not yet finished (running or waiting for a slot); beyond it a
+	// message is answered with an overload error immediately.
+	maxPendingCalls = 64
+)
+
 var null = json.RawMessage("null")
 
 type subscriptionResult struct {
@@ -89,6 +108,18 @@ func (msg *jsonrpcMessage) namespace() string {
 func (msg *jsonrpcMessage) String() string {
 	b, _ := json.Marshal(msg)
 	return string(b)
+}
+
+// payloadSize is the size of the message's result or error as it will be
+// encoded, used to account a batch's responses against maxBatchResponseBytes.
+func (msg *jsonrpcMessage) payloadSize() int {
+	size := len(msg.Result)
+	if msg.Error != nil {
+		if enc, err := json.Marshal(msg.Error); err == nil {
+			size += len(enc)
+		}
+	}
+	return size
 }
 
 func (msg *jsonrpcMessage) errorResponse(err error) *jsonrpcMessage {
@@ -202,6 +233,11 @@ func (c *jsonCodec) remoteAddr() string {
 	return c.remote
 }
 
+// errBatchTooLarge is returned by readBatch for a batch with more than
+// maxBatchRequests elements. The whole JSON value has been consumed from
+// the stream by then, so the caller can answer it and keep reading.
+var errBatchTooLarge = &invalidRequestError{"batch too large"}
+
 func (c *jsonCodec) readBatch() (messages []*jsonrpcMessage, batch bool, err error) {
 	// Decode the next JSON object in the input stream.
 	// This verifies basic syntax, etc.
@@ -209,7 +245,10 @@ func (c *jsonCodec) readBatch() (messages []*jsonrpcMessage, batch bool, err err
 	if err := c.decode(&rawmsg); err != nil {
 		return nil, false, err
 	}
-	messages, batch = parseMessage(rawmsg)
+	messages, batch, err = parseMessage(rawmsg)
+	if err != nil {
+		return nil, batch, err
+	}
 	for i, msg := range messages {
 		if msg == nil {
 			// Message is JSON 'null'. Replace with zero value so it
@@ -248,20 +287,25 @@ func (c *jsonCodec) closed() <-chan interface{} {
 // checks in this function because the raw message has already been syntax-checked when it
 // is called. Any non-JSON-RPC messages in the input return the zero value of
 // jsonrpcMessage.
-func parseMessage(raw json.RawMessage) ([]*jsonrpcMessage, bool) {
+func parseMessage(raw json.RawMessage) ([]*jsonrpcMessage, bool, error) {
 	if !isBatch(raw) {
 		msgs := []*jsonrpcMessage{{}}
 		json.Unmarshal(raw, &msgs[0])
-		return msgs, false
+		return msgs, false, nil
 	}
 	dec := json.NewDecoder(bytes.NewReader(raw))
 	dec.Token() // skip '['
 	var msgs []*jsonrpcMessage
 	for dec.More() {
+		// Counted before the element is allocated, so a batch beyond the
+		// limit costs nothing per element past it.
+		if len(msgs) == maxBatchRequests {
+			return nil, true, errBatchTooLarge
+		}
 		msgs = append(msgs, new(jsonrpcMessage))
 		dec.Decode(&msgs[len(msgs)-1])
 	}
-	return msgs, true
+	return msgs, true, nil
 }
 
 // isBatch returns true when the first non-whitespace characters is '['

--- a/rpc/server/server.go
+++ b/rpc/server/server.go
@@ -103,7 +103,9 @@ func (s *Server) serveSingleRequest(ctx context.Context, codec ServerCodec) {
 
 	reqs, batch, err := codec.readBatch()
 	if err != nil {
-		if err != io.EOF {
+		if err == errBatchTooLarge {
+			codec.writeJSON(ctx, errorMessage(err))
+		} else if err != io.EOF {
 			codec.writeJSON(ctx, errorMessage(&invalidMessageError{"parse error"}))
 		}
 		return


### PR DESCRIPTION
## Summary

The JSON-RPC server bounded the bytes of one request (5 MiB over HTTP, 15 MiB over WebSocket) but nothing past that: a batch was decoded into one message per element however many there were, every element was executed and its response retained until the whole array was written, and on a persistent connection each incoming message started another call goroutine with no cap. Compact calls therefore turned a bounded request into an unbounded number of allocations, method invocations, response bytes and goroutines.

This PR adds the bounds the upstream RPC stack this code derives from adopted later, plus a per-connection admission cap:

| Bound | Value | Behaviour |
| --- | --- | --- |
| Batch size | 1000 calls | Counted in `parseMessage` before each element is allocated. The batch is answered with a single invalid-request error (`-32600`, "batch too large", id null, as the spec prescribes for a batch rejected as a whole) and nothing executes. Persistent connections keep serving. Invalid elements count like valid ones. |
| Batch response size | 25 MB | `handleBatch` sums the encoded size of each answer's result or error. The answer crossing the budget is still delivered; every call after it gets `-32003` "batch response too large" instead of executing. |
| Running calls | 32 per connection | Accepted messages wait for a run slot inside their own goroutine, never on the connection's dispatch loop (callbacks that make reverse calls through `ClientFromContext` need that loop to deliver their replies). |
| Accepted messages | 64 per connection | Beyond it a message (or each call of a batch) is answered at once with `-32005` "too many pending requests on this connection". |

Waiting goroutines exit when the handler closes, but take a free slot in preference to that signal because the HTTP path closes the handler right after dispatch and waits for the call. The Go client refuses to send a batch over 1000 elements itself, since the server's rejection carries no IDs it could resolve.

Known clients are unaffected: Syrius and `znn_sdk_dart` do not batch node RPC requests, and 64 outstanding messages on one socket is far beyond their concurrency.

## Tests

`rpc/server/batch_test.go` (new):

- HTTP (`httptest` over `Server.ServeHTTP`): a batch of exactly 1000 calls is served in full; 1001 is answered with the single error and executes no call; 1001 compact invalid elements are rejected while 1000 are answered individually.
- WebSocket (`Server.WebsocketHandler`): the oversized batch is rejected and the connection stays usable.
- In-process: 4 MB results are cut off after the budget with the remaining elements carrying the response-too-large error and no further execution, and the same for 4 MB error payloads; the client refuses a 1001-element batch without a round trip; 33 concurrent calls whose callbacks call back into the client all complete; 69 concurrent blocking calls see exactly 5 rejected with the overload error while 32 run and the rest wait, and every accepted call completes; 40 concurrent blocking calls leave exactly 32 inside the service.

The limit tests fail on the unpatched code; the reverse-call, error-accounting and client-refusal tests were written against the first version of this change, which they failed.

## Verification

- `GOWORK=off go vet ./rpc/server/`
- `GOWORK=off go test -race -count=5 ./rpc/server/` and `-count=3 ./rpc/api/subscribe/`
- `GOWORK=off go test ./...`
- Combined tree with #85 (`fix/bound-rpc-subscriptions`, which also edits `handler.go`) merged in both orders: identical trees, vet, build and race-tested rpc packages pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAfAxvtiPqYU6873a9K4uH
