### PR TITLE
node: keep the producer password out of printed and logged config

### DIFF
--- a/app/config_test.go
+++ b/app/config_test.go
@@ -1,0 +1,116 @@
+package app
+
+import (
+	"encoding/json"
+	"flag"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+)
+
+const sentinel = "sentinel-producer-password-7f3a"
+
+// MakeConfig prints the effective configuration to stdout and logs it; a
+// configured producer password must reach neither sink, while the rest of
+// the configuration still does.
+func TestMakeConfigDoesNotRevealProducerPassword(t *testing.T) {
+	dataPath := t.TempDir()
+	cfgPath := filepath.Join(dataPath, "config.json")
+	file := map[string]interface{}{
+		"DataPath": dataPath,
+		"Producer": map[string]interface{}{
+			"Address":     "z1qqjnwjjpnue8xmmpanz6csze6tcmtzzdtfsww7",
+			"Index":       0,
+			"KeyFilePath": "producer",
+			"Password":    sentinel,
+		},
+	}
+	raw, err := json.Marshal(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cfgPath, raw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	set := flag.NewFlagSet("znnd", flag.ContinueOnError)
+	ConfigFileFlag.Apply(set)
+	if err := set.Parse([]string{"--" + ConfigFileFlag.Name, cfgPath}); err != nil {
+		t.Fatal(err)
+	}
+	ctx := cli.NewContext(cli.NewApp(), set, nil)
+
+	stdout := captureStdout(t)
+	cfg, err := MakeConfig(ctx)
+	out := stdout()
+	if err != nil {
+		t.Fatalf("MakeConfig: %v", err)
+	}
+
+	if !strings.Contains(out, "Using the following znnd config") {
+		t.Fatalf("configuration was not printed: %q", out)
+	}
+	if strings.Contains(out, sentinel) {
+		t.Fatalf("stdout reveals the producer password:\n%s", out)
+	}
+	if !strings.Contains(out, `"KeyFilePath"`) {
+		t.Fatalf("stdout lost the producer section:\n%s", out)
+	}
+
+	logs := readLogs(t, dataPath)
+	if !strings.Contains(logs, "using znnd config") {
+		t.Fatalf("configuration was not logged:\n%s", logs)
+	}
+	if strings.Contains(logs, sentinel) {
+		t.Fatalf("log file reveals the producer password:\n%s", logs)
+	}
+
+	// The value is still available for the unlock.
+	if cfg.Producer == nil || string(cfg.Producer.Password) != sentinel {
+		t.Fatalf("configured password was lost: %+v", cfg.Producer)
+	}
+}
+
+func captureStdout(t *testing.T) func() string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	done := make(chan string)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	return func() string {
+		os.Stdout = old
+		w.Close()
+		return <-done
+	}
+}
+
+func readLogs(t *testing.T, dataPath string) string {
+	t.Helper()
+	var all strings.Builder
+	err := filepath.Walk(filepath.Join(dataPath, "log"), func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		b, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		all.Write(b)
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return all.String()
+}

--- a/node/config.go
+++ b/node/config.go
@@ -1,9 +1,12 @@
 package node
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -16,12 +19,87 @@ import (
 	"github.com/zenon-network/go-zenon/zenon"
 )
 
+// Secret is a string that does not reveal itself: every fmt verb and JSON
+// encoding renders it as a fixed marker, so a configuration carrying one
+// can be printed or logged whole. The value is read from JSON as a plain
+// string and is obtained with a string conversion where it is used.
+type Secret string
+
+const redactedMarker = "<redacted>"
+
+// String implements fmt.Stringer.
+func (s Secret) String() string {
+	if s == "" {
+		return ""
+	}
+	return redactedMarker
+}
+
+// GoString implements fmt.GoStringer.
+func (s Secret) GoString() string {
+	return fmt.Sprintf("node.Secret(%q)", s.String())
+}
+
+// Format implements fmt.Formatter so that every verb, including the
+// numeric, float and rune verbs for which fmt would otherwise print a
+// diagnostic containing the raw value, renders the marker. The one verb
+// this cannot cover is %p applied to a non-pointer Secret: fmt handles %p
+// before consulting the operand's methods and prints its diagnostic with
+// the raw value.
+func (s Secret) Format(f fmt.State, verb rune) {
+	switch verb {
+	case 'q':
+		fmt.Fprintf(f, "%q", s.String())
+	case 'v':
+		if f.Flag('#') {
+			io.WriteString(f, s.GoString())
+			return
+		}
+		io.WriteString(f, s.String())
+	default:
+		io.WriteString(f, s.String())
+	}
+}
+
+// MarshalJSON writes the marker in place of the value.
+func (s Secret) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}
+
+// UnmarshalJSON reads the value like a plain string.
+func (s *Secret) UnmarshalJSON(data []byte) error {
+	var v string
+	if err := json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	*s = Secret(v)
+	return nil
+}
+
 type ProducerConfig struct {
 	Address     string
 	Index       uint32
 	KeyFilePath string
-	Password    string
+	Password    Secret
 }
+
+// Format implements fmt.Formatter. A pointer to this struct nested in
+// another value and printed with a verb that is invalid for pointers would
+// otherwise be re-printed by fmt's diagnostic path, which does not consult
+// the fields' own formatting; rendering the struct here keeps Password
+// redacted under every verb.
+func (c ProducerConfig) Format(f fmt.State, verb rune) {
+	type view ProducerConfig // same fields, no methods: default struct rendering
+	switch {
+	case verb == 'v' && f.Flag('#'):
+		fmt.Fprintf(f, "node.ProducerConfig%s", strings.TrimPrefix(fmt.Sprintf("%#v", view(c)), "node.view"))
+	case verb == 'v' && f.Flag('+'):
+		fmt.Fprintf(f, "%+v", view(c))
+	default:
+		fmt.Fprintf(f, "%v", view(c))
+	}
+}
+
 type RPCConfig struct {
 	EnableHTTP bool
 	EnableWS   bool
@@ -175,7 +253,7 @@ func (c *Config) parseProducer(walletManager *wallet.Manager) (*wallet.KeyPair, 
 		log.Error("unable to get keyFile", "keyFilePath", c.Producer.KeyFilePath, "reason", err)
 		return nil, err
 	}
-	if err := walletManager.Unlock(c.Producer.KeyFilePath, c.Producer.Password); err != nil {
+	if err := walletManager.Unlock(c.Producer.KeyFilePath, string(c.Producer.Password)); err != nil {
 		log.Error("unable to unlock keyFile", "keyFilePath", c.Producer.KeyFilePath, "reason", err)
 		return nil, err
 	}

--- a/node/secret_test.go
+++ b/node/secret_test.go
@@ -1,0 +1,118 @@
+package node
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+const sentinel = "sentinel-producer-password-7f3a"
+
+func producerConfig() Config {
+	cfg := DefaultNodeConfig
+	cfg.Producer = &ProducerConfig{
+		Address:     "z1qqjnwjjpnue8xmmpanz6csze6tcmtzzdtfsww7",
+		Index:       3,
+		KeyFilePath: "/keys/producer",
+		Password:    sentinel,
+	}
+	return cfg
+}
+
+// allVerbs covers the string, numeric, float, rune, pointer and boolean
+// verbs, with the flags fmt treats specially for structs and strings.
+var allVerbs = []string{"%v", "%+v", "%#v", "%s", "%q", "%x", "%X", "%d", "%p", "%e", "%f", "%g", "%c", "%t", "%b", "%o", "%U", "%T"}
+
+// Every generic rendering of the configuration, of the producer section and
+// of the field itself, directly or through pointers and enclosing values,
+// must hide the password under every verb; only an explicit conversion
+// yields the value.
+func TestProducerPasswordIsRedactedWhenFormatted(t *testing.T) {
+	cfg := producerConfig()
+	type wrapsProducer struct{ P *ProducerConfig }
+	type wrapsConfig struct{ C *Config }
+	type wrapsConfigValue struct{ C Config }
+	subjects := map[string]interface{}{
+		"secret":               cfg.Producer.Password,
+		"secret ptr":           &cfg.Producer.Password,
+		"producer":             *cfg.Producer,
+		"producer ptr":         cfg.Producer,
+		"config":               cfg,
+		"config ptr":           &cfg,
+		"wrapped producer":     wrapsProducer{cfg.Producer},
+		"wrapped config":       wrapsConfig{&cfg},
+		"wrapped config ptr":   &wrapsConfig{&cfg},
+		"wrapped config value": &wrapsConfigValue{cfg},
+		"slice of producers":   []*ProducerConfig{cfg.Producer},
+		"map of configs":       map[string]Config{"a": cfg},
+	}
+	for name, subject := range subjects {
+		for _, verb := range allVerbs {
+			// fmt handles %p before consulting any method of the operand and,
+			// for a non-pointer, prints a diagnostic with the raw value; no
+			// type can intercept that, so %p is only checked on pointers,
+			// where it prints an address.
+			if verb == "%p" && !strings.Contains(name, "ptr") {
+				continue
+			}
+			out := fmt.Sprintf(verb, subject)
+			if strings.Contains(out, sentinel) {
+				t.Errorf("%s with %s reveals the password: %s", name, verb, out)
+			}
+		}
+	}
+	for _, verb := range []string{"%v", "%+v", "%#v", "%s"} {
+		if out := fmt.Sprintf(verb, *cfg.Producer); !strings.Contains(out, "/keys/producer") {
+			t.Errorf("producer %s lost non-secret fields: %s", verb, out)
+		}
+		if out := fmt.Sprintf(verb, cfg); !strings.Contains(out, "znn-node") {
+			t.Errorf("config %s lost non-secret fields: %s", verb, out)
+		}
+	}
+	if out := fmt.Sprintf("%v", cfg.Producer.Password); out != "<redacted>" {
+		t.Errorf("secret renders as %q", out)
+	}
+	if out := fmt.Sprintf("%v", Secret("")); out != "" {
+		t.Errorf("empty secret renders as %q", out)
+	}
+	if got := string(cfg.Producer.Password); got != sentinel {
+		t.Errorf("conversion yields %q", got)
+	}
+}
+
+// JSON output redacts the password; JSON input still carries it, so
+// config.json keeps working.
+func TestProducerPasswordJSON(t *testing.T) {
+	cfg := producerConfig()
+	for name, marshal := range map[string]func(interface{}) ([]byte, error){
+		"Marshal":       json.Marshal,
+		"MarshalIndent": func(v interface{}) ([]byte, error) { return json.MarshalIndent(v, "", "  ") },
+	} {
+		out, err := marshal(cfg)
+		if err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if strings.Contains(string(out), sentinel) {
+			t.Errorf("%s reveals the password: %s", name, out)
+		}
+		if !strings.Contains(string(out), `"KeyFilePath": "/keys/producer"`) && !strings.Contains(string(out), `"KeyFilePath":"/keys/producer"`) {
+			t.Errorf("%s lost non-secret fields: %s", name, out)
+		}
+	}
+
+	var parsed Config
+	if err := json.Unmarshal([]byte(`{"Producer":{"Address":"a","KeyFilePath":"k","Password":"`+sentinel+`"}}`), &parsed); err != nil {
+		t.Fatal(err)
+	}
+	if parsed.Producer == nil || string(parsed.Producer.Password) != sentinel {
+		t.Fatalf("password did not round-trip from JSON: %+v", parsed.Producer)
+	}
+
+	// An empty password stays empty rather than becoming a marker.
+	empty := Config{Producer: &ProducerConfig{}}
+	out, _ := json.Marshal(empty)
+	if !strings.Contains(string(out), `"Password":""`) {
+		t.Errorf("empty password rendered as %s", out)
+	}
+}


### PR DESCRIPTION
## Summary

`MakeConfig` prints the effective configuration to standard output as JSON and hands the same value to the info log. `ProducerConfig.Password`, the password used to unlock the producer key file, was a plain exported string, so the JSON print carried it verbatim into whatever collects the node's output (terminal, service manager, container logs, support bundles). The structured log line did not carry it, but only because the configuration is logged as a value whose `Producer` field is a pointer, which `fmt` renders as an address; that is an accident of the field layout, not a guarantee.

The password is now a `node.Secret`, a string type that renders as a fixed marker under every `fmt` verb and under JSON encoding while still reading from `config.json` as a plain string. The one place that needs the value, `parseProducer`, converts it explicitly. This protects both existing sinks and any later rendering of the configuration or of the producer section, instead of patching two call sites.

Details:

- `Stringer` and `GoStringer` alone are not enough: `fmt` consults them only for the string-like verbs, and while it prints the diagnostic for a verb that is invalid for the operand it disables method lookup entirely. `Secret` therefore implements `fmt.Formatter` for every verb, and `ProducerConfig` implements it too (rendering through a method-less alias type so its layout is unchanged), so that a pointer to it nested in another value is rendered by the struct itself rather than by the diagnostic path.
- The one verb no type can intercept is `%p` applied to a non-pointer value, which `fmt` handles before consulting any method. It is documented on the type; pointer forms print an address and nothing in the repository uses the invalid form.
- The printed configuration still shows the producer section with `Password: "<redacted>"`; an empty password stays empty. The JSON key and `config.json` format are unchanged, and the whole repository builds unchanged, so no Go code assigned or read the field as a string.

**Operators:** treat existing startup output and log archives as containing the password. Restrict or remove retained copies and rotate the producer wallet password.

## Tests

- `node/secret_test.go` (new): 18 `fmt` verbs applied to the field, the producer section, the configuration, pointers to each, and wrappers, slices and maps holding them, all hide the password while non-secret fields remain; `json.Marshal` and `MarshalIndent` hide it and keep the other fields; the value round-trips from JSON and an explicit conversion yields it; an empty password renders empty.
- `app/config_test.go` (new): `MakeConfig` driven through a real `cli.Context` with a config file that sets a producer password, standard output captured and the log directory under a temporary data path read back; the configuration is printed and logged, neither sink contains the password, the producer section is still printed, and the returned configuration still carries the value.

On the unpatched code the node tests fail for the producer section, the field and both JSON encoders, and the app test fails on standard output. With `Stringer` alone, 77 subject/verb combinations still fail; the `Formatter` implementations close them.

## Verification

- `GOWORK=off go vet ./node/ ./app/`
- `GOWORK=off go build ./...`
- `GOWORK=off go test -race -count=3 ./node/ ./app/`
- `GOWORK=off go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAfAxvtiPqYU6873a9K4uH
