### PR TITLE
p2p/legacy: bound the RLPx frame size before allocating it

### DIFF
--- a/p2p/legacy/rlpx.go
+++ b/p2p/legacy/rlpx.go
@@ -46,6 +46,14 @@ import (
 const (
 	maxUint24 = ^uint32(0) >> 8
 
+	// maxMessageSize matches protocol.ProtocolMaxMsgSize, the largest
+	// payload the protocol layer accepts, and maxFrameSize adds the
+	// RLP-encoded message code (at most 9 bytes) that shares the frame
+	// with the payload. A frame header announcing more is rejected before
+	// any buffer of the announced size is allocated.
+	maxMessageSize = 10 * 1024 * 1024
+	maxFrameSize   = maxMessageSize + 9
+
 	sskLen = 16 // ecies.MaxSharedKeyLength(pubKey) / 2
 	sigLen = 65 // elliptic S256
 	pubLen = 64 // 512 bit pubkey in uncompressed representation without format byte
@@ -585,6 +593,12 @@ func (rw *rlpxFrameRW) ReadMsg() (msg p2p.Msg, err error) {
 	rw.dec.XORKeyStream(headbuf[:16], headbuf[:16]) // first half is now decrypted
 	fsize := readInt24(headbuf)
 	// ignore protocol type for now
+
+	// The header is authenticated but its length is the sender's choice;
+	// bound it before sizing anything by it.
+	if fsize > maxFrameSize {
+		return msg, fmt.Errorf("frame size %d exceeds maximum %d", fsize, maxFrameSize)
+	}
 
 	// read the frame content
 	var rsize = fsize // frame size rounded up to 16 byte boundary

--- a/p2p/legacy/rlpx_test.go
+++ b/p2p/legacy/rlpx_test.go
@@ -1,0 +1,156 @@
+package legacy
+
+import (
+	"bytes"
+	"crypto/rand"
+	"io"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rlp"
+	"golang.org/x/crypto/sha3"
+
+	"github.com/zenon-network/go-zenon/p2p"
+)
+
+// countingConn is the wire between a frame writer and reader. It records
+// how many bytes the reader asked for after the 32-byte header, so a test
+// can tell whether the reader tried to read a frame body at all.
+type countingConn struct {
+	bytes.Buffer
+	read      int
+	bodyReads int
+}
+
+func (c *countingConn) Read(p []byte) (int, error) {
+	if c.read >= 32 {
+		c.bodyReads++
+	}
+	n, err := c.Buffer.Read(p)
+	c.read += n
+	return n, err
+}
+
+func (c *countingConn) bodyRequested() bool { return c.bodyReads > 0 }
+
+// newFramePair returns a writer and a reader over one wire that share the
+// same secrets, so frames written by one are decrypted and authenticated
+// by the other.
+func newFramePair() (writer, reader *rlpxFrameRW, wire *countingConn) {
+	wire = new(countingConn)
+	s := secrets{
+		AES:        crypto.Keccak256(),
+		MAC:        crypto.Keccak256(),
+		EgressMAC:  sha3.NewLegacyKeccak256(),
+		IngressMAC: sha3.NewLegacyKeccak256(),
+	}
+	return newRLPXFrameRW(wire, s), newRLPXFrameRW(wire, s), wire
+}
+
+// writeHeader sends an authenticated frame header announcing fsize bytes of
+// content and nothing else, the way WriteMsg starts a frame.
+func writeHeader(w *rlpxFrameRW, fsize uint32) {
+	headbuf := make([]byte, 32)
+	putInt24(fsize, headbuf)
+	copy(headbuf[3:], zeroHeader)
+	w.enc.XORKeyStream(headbuf[:16], headbuf[:16])
+	copy(headbuf[16:], updateMAC(w.egressMAC, w.macCipher, headbuf[:16]))
+	w.conn.Write(headbuf)
+}
+
+func totalAlloc() uint64 {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	return m.TotalAlloc
+}
+
+// A header announcing more content than any message can carry is rejected
+// on the strength of the header alone: no body is read and no buffer of
+// the announced size is allocated.
+func TestReadMsgRejectsOversizedFrameBeforeReadingBody(t *testing.T) {
+	for _, fsize := range []uint32{maxFrameSize + 1, maxUint24} {
+		writer, reader, wire := newFramePair()
+		writeHeader(writer, fsize)
+
+		before := totalAlloc()
+		_, err := reader.ReadMsg()
+		allocated := totalAlloc() - before
+
+		if err == nil || !strings.Contains(err.Error(), "frame") {
+			t.Fatalf("fsize %d: expected a frame size error, got %v", fsize, err)
+		}
+		if wire.bodyRequested() {
+			t.Fatalf("fsize %d: the body was requested after an oversized header", fsize)
+		}
+		if allocated > 1<<20 {
+			t.Fatalf("fsize %d: %d bytes allocated while handling the header", fsize, allocated)
+		}
+	}
+}
+
+// The largest message the protocol layer accepts still passes the
+// transport, and one byte more does not.
+func TestReadMsgFrameLimitMatchesLargestMessage(t *testing.T) {
+	ptype, _ := rlp.EncodeToBytes(uint64(0x10))
+	largest := maxFrameSize - uint32(len(ptype))
+
+	writer, reader, _ := newFramePair()
+	payload := make([]byte, largest)
+	rand.Read(payload)
+	if err := writer.WriteMsg(p2p.Msg{Code: 0x10, Size: largest, Payload: bytes.NewReader(payload)}); err != nil {
+		t.Fatal(err)
+	}
+	msg, err := reader.ReadMsg()
+	if err != nil {
+		t.Fatalf("frame at the limit rejected: %v", err)
+	}
+	if msg.Size != largest {
+		t.Fatalf("size %d, want %d", msg.Size, largest)
+	}
+	got, _ := io.ReadAll(msg.Payload)
+	if !bytes.Equal(got, payload) {
+		t.Fatal("payload mismatch")
+	}
+
+	writer, reader, wire := newFramePair()
+	payload = make([]byte, largest+1)
+	if err := writer.WriteMsg(p2p.Msg{Code: 0x10, Size: largest + 1, Payload: bytes.NewReader(payload)}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := reader.ReadMsg(); err == nil || !strings.Contains(err.Error(), "frame") {
+		t.Fatalf("frame one byte over the limit accepted: %v", err)
+	}
+	if wire.bodyRequested() {
+		t.Fatal("the body was requested for a frame over the limit")
+	}
+}
+
+// The existing controls are unchanged: a header with a bad MAC is rejected
+// before anything else, and an ordinary frame round-trips.
+func TestReadMsgHeaderControls(t *testing.T) {
+	writer, reader, wire := newFramePair()
+	writeHeader(writer, 64)
+	wire.Bytes()[20] ^= 0xff
+	if _, err := reader.ReadMsg(); err == nil || !strings.Contains(err.Error(), "bad header MAC") {
+		t.Fatalf("tampered header accepted: %v", err)
+	}
+	if wire.bodyRequested() {
+		t.Fatal("the body was requested after a bad header MAC")
+	}
+
+	writer, reader, _ = newFramePair()
+	body := []byte("hello")
+	if err := writer.WriteMsg(p2p.Msg{Code: 7, Size: uint32(len(body)), Payload: bytes.NewReader(body)}); err != nil {
+		t.Fatal(err)
+	}
+	msg, err := reader.ReadMsg()
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, _ := io.ReadAll(msg.Payload)
+	if msg.Code != 7 || string(got) != "hello" {
+		t.Fatalf("round trip: code %d payload %q", msg.Code, got)
+	}
+}


### PR DESCRIPTION
## Summary

The RLPx frame reader authenticated and decrypted the 32-byte header, took the 24-bit content length from it and allocated a buffer of that length (rounded up to 16 bytes) before reading the body. The length is the sender's choice, so a peer that has completed the handshakes could announce the wire maximum and cause a 16 MiB allocation with a single header, then send nothing and hold it until the 30 second read deadline. The protocol layer's 10 MiB message limit runs only after the whole frame and its MAC have been read into that buffer. The libp2p backend already checks its length before allocating; the legacy backend, which runs until the transport spork activates, did not.

Change (`p2p/legacy/rlpx.go`): `ReadMsg` rejects a header whose content length exceeds `maxFrameSize` before computing the padded size or allocating anything. `maxFrameSize` is the protocol layer's 10 MiB message limit (repeated here as `maxMessageSize`, the same way `p2p/libp2p/stream_rw.go` does, since the transport cannot import the protocol package) plus the RLP-encoded message code of at most 9 bytes that shares the frame with the payload. The header MAC check still comes first, and the protocol layer's own check remains as defense in depth: it still rejects a frame that fits the transport bound but carries a payload over its limit.

Compatibility: every protocol-valid payload remains readable, including a 10 MiB payload with a maximal 9-byte code. No legitimate message class occupies the 10 to 16 MiB range; such a frame was previously read in full and then rejected by the protocol layer with a disconnect, and is now rejected by the transport with a read error and the same disconnect. The encryption handshake uses raw fixed-size I/O and is untouched; the protocol handshake uses the framed reader with its own stricter 2 KiB limit.

## Tests

`p2p/legacy/rlpx_test.go` (new): a writer and a reader share one in-memory wire and the same secrets, as the upstream fake-frame test does; the wire records whether the reader ever asked for bytes past the header.

- A header announcing one byte over the limit, and one announcing the 24-bit maximum, are each rejected with a frame size error, no body byte is requested and less than 1 MiB is allocated in the process.
- The largest message the protocol layer accepts (10 MiB payload) still passes the transport and round-trips, while one byte more is rejected without a body read.
- A header with a tampered MAC is still rejected first, and an ordinary frame round-trips.

On the unpatched code the oversized headers lead to a body read that fails on the empty wire after the allocation, and the frame one byte over the limit is accepted.

## Verification

- `GOWORK=off go vet ./p2p/legacy/` (only the pre-existing unkeyed `ecdsa.PublicKey` literal warning, present at the base)
- `GOWORK=off go test -race -count=3 ./p2p/legacy/`
- `GOWORK=off go test ./...`
- Combined tree with #91 (`fix/coalesce-peer-pongs`, same package): identical trees in both merge orders, vet, build and race-tested package pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAfAxvtiPqYU6873a9K4uH
