### PR TITLE
rpc/embedded: enrich only the requested page of projects and requests

### DIFF
--- a/rpc/api/embedded/accelerator.go
+++ b/rpc/api/embedded/accelerator.go
@@ -171,7 +171,10 @@ func (a *AcceleratorApi) GetAll(pageIndex, pageSize uint32) (*ProjectList, error
 	if err != nil {
 		return nil, err
 	}
+	return a.getAll(context, pageIndex, pageSize)
+}
 
+func (a *AcceleratorApi) getAll(context vm_context.AccountVmContext, pageIndex, pageSize uint32) (*ProjectList, error) {
 	projects, err := definition.GetProjectList(context.Storage())
 	if err != nil {
 		return nil, err
@@ -181,17 +184,16 @@ func (a *AcceleratorApi) GetAll(pageIndex, pageSize uint32) (*ProjectList, error
 		return projects[i].LastUpdateTimestamp > projects[j].LastUpdateTimestamp
 	})
 
+	// The listing and the sort need every project; the vote and phase
+	// lookups are only done for the page that is returned.
+	start, end := api.GetRange(pageIndex, pageSize, uint32(len(projects)))
 	result := &ProjectList{
 		Count: len(projects),
-		List:  make([]*Project, len(projects)),
+		List:  make([]*Project, 0, end-start),
 	}
-
-	for index, project := range projects {
-		result.List[index] = a.toProject(context, project)
+	for _, project := range projects[start:end] {
+		result.List = append(result.List, a.toProject(context, project))
 	}
-
-	start, end := api.GetRange(pageIndex, pageSize, uint32(len(result.List)))
-	result.List = result.List[start:end]
 
 	return result, nil
 }
@@ -233,6 +235,7 @@ func (a *AcceleratorApi) GetVoteBreakdown(id types.Hash) (*definition.VoteBreakd
 	}
 	return voteBreakdown, nil
 }
+
 func (a *AcceleratorApi) GetPillarVotes(name string, hashes []types.Hash) ([]*definition.PillarVote, error) {
 	_, context, err := api.GetFrontierContext(a.chain, types.AcceleratorContract)
 	if err != nil {

--- a/rpc/api/embedded/bridge.go
+++ b/rpc/api/embedded/bridge.go
@@ -455,7 +455,6 @@ func (a *BridgeApi) GetAllUnsignedWrapTokenRequests(pageIndex, pageSize uint32) 
 	if err != nil {
 		return nil, err
 	}
-	var unsignedRequests []*WrapTokenRequest
 
 	momentum, err := context.GetFrontierMomentum()
 	if err != nil {
@@ -466,28 +465,35 @@ func (a *BridgeApi) GetAllUnsignedWrapTokenRequests(pageIndex, pageSize uint32) 
 		return nil, err
 	}
 
-	for _, request := range requests {
-		if request.Signature == "" {
-			token, err := a.getToken(request.TokenStandard)
-			if err != nil {
-				return nil, err
-			}
-			confirmationsToFinality := a.getConfirmationsToFinality(*request, orchestratorInfo.ConfirmationsToFinality, *momentum)
-			wrapRequest := &WrapTokenRequest{request, token, confirmationsToFinality}
-			unsignedRequests = append(unsignedRequests, wrapRequest)
-		}
-	}
-
-	for i, j := 0, len(unsignedRequests)-1; i < j; i, j = i+1, j-1 {
-		unsignedRequests[i], unsignedRequests[j] = unsignedRequests[j], unsignedRequests[i]
-	}
-
-	start, end := api.GetRange(pageIndex, pageSize, uint32(len(unsignedRequests)))
+	// Select the page first; token and finality lookups are only done for
+	// the requests on it.
+	page, count := selectUnsignedWrapRequests(requests, pageIndex, pageSize)
 	result := &WrapTokenRequestList{
-		Count: len(unsignedRequests),
-		List:  unsignedRequests[start:end],
+		Count: count,
+		List:  make([]*WrapTokenRequest, 0, len(page)),
+	}
+	for _, request := range page {
+		token, err := a.getToken(request.TokenStandard)
+		if err != nil {
+			return nil, err
+		}
+		confirmationsToFinality := a.getConfirmationsToFinality(*request, orchestratorInfo.ConfirmationsToFinality, *momentum)
+		result.List = append(result.List, &WrapTokenRequest{request, token, confirmationsToFinality})
 	}
 	return result, nil
+}
+
+// selectUnsignedWrapRequests keeps the requests without a signature, newest
+// first, and returns the requested page of them with the total count.
+func selectUnsignedWrapRequests(requests []*definition.WrapTokenRequest, pageIndex, pageSize uint32) ([]*definition.WrapTokenRequest, int) {
+	unsigned := make([]*definition.WrapTokenRequest, 0, len(requests))
+	for i := len(requests) - 1; i >= 0; i-- {
+		if requests[i].Signature == "" {
+			unsigned = append(unsigned, requests[i])
+		}
+	}
+	start, end := api.GetRange(pageIndex, pageSize, uint32(len(unsigned)))
+	return unsigned[start:end], len(unsigned)
 }
 
 type UnwrapTokenRequest struct {

--- a/rpc/api/embedded/collection_work_test.go
+++ b/rpc/api/embedded/collection_work_test.go
@@ -1,0 +1,171 @@
+package embedded
+
+import (
+	"fmt"
+	"math/big"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	g "github.com/zenon-network/go-zenon/chain/genesis/mock"
+	"github.com/zenon-network/go-zenon/chain/nom"
+	"github.com/zenon-network/go-zenon/common/db"
+	"github.com/zenon-network/go-zenon/common/types"
+	"github.com/zenon-network/go-zenon/rpc/api"
+	"github.com/zenon-network/go-zenon/vm/constants"
+	"github.com/zenon-network/go-zenon/vm/embedded/definition"
+	"github.com/zenon-network/go-zenon/vm/vm_context"
+	"github.com/zenon-network/go-zenon/zenon/mock"
+)
+
+// countingDB counts point lookups and prefix scans on the contract storage
+// so a test can tell how much of a collection a call touched beyond
+// listing it.
+type countingDB struct {
+	db.DB
+	gets int32
+}
+
+func (c *countingDB) Get(key []byte) ([]byte, error) {
+	atomic.AddInt32(&c.gets, 1)
+	return c.DB.Get(key)
+}
+
+func (c *countingDB) NewIterator(prefix []byte) db.StorageIterator {
+	atomic.AddInt32(&c.gets, 1)
+	return c.DB.NewIterator(prefix)
+}
+
+type countingContext struct {
+	vm_context.AccountVmContext
+	store *countingDB
+}
+
+func (c *countingContext) Storage() db.DB { return c.store }
+
+func newCountingContext(t *testing.T, z mock.MockZenon, contract types.Address) *countingContext {
+	t.Helper()
+	_, context, err := api.GetFrontierContext(z.Chain(), contract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &countingContext{context, &countingDB{DB: context.Storage()}}
+}
+
+func (c *countingContext) reset()       { atomic.StoreInt32(&c.store.gets, 0) }
+func (c *countingContext) lookups() int { return int(atomic.LoadInt32(&c.store.gets)) }
+
+func activateAcceleratorSpork(t *testing.T, z mock.MockZenon) {
+	t.Helper()
+	sporkAPI := NewSporkApi(z)
+	z.InsertSendBlock(&nom.AccountBlock{
+		Address:   g.Spork.Address,
+		ToAddress: types.SporkContract,
+		Data: definition.ABISpork.PackMethodPanic(definition.SporkCreateMethodName,
+			"spork-accelerator", "activate spork for accelerator"),
+	}, nil, mock.SkipVmChanges)
+	z.InsertNewMomentum()
+	sporkList, err := sporkAPI.GetAll(0, 10)
+	if err != nil || len(sporkList.List) == 0 {
+		t.Fatalf("spork not created: %v", err)
+	}
+	id := sporkList.List[0].Id
+	z.InsertSendBlock(&nom.AccountBlock{
+		Address:   g.Spork.Address,
+		ToAddress: types.SporkContract,
+		Data:      definition.ABISpork.PackMethodPanic(definition.SporkActivateMethodName, id),
+	}, nil, mock.SkipVmChanges)
+	z.InsertNewMomentum()
+	types.AcceleratorSpork.SporkId = id
+	types.ImplementedSporksMap[id] = true
+	z.InsertMomentumsTo(20)
+}
+
+func createProjects(t *testing.T, z mock.MockZenon, n int) {
+	t.Helper()
+	for i := 0; i < n; i++ {
+		call := z.CallContract(&nom.AccountBlock{
+			Address:       g.User1.Address,
+			ToAddress:     types.AcceleratorContract,
+			TokenStandard: types.ZnnTokenStandard,
+			Amount:        constants.ProjectCreationAmount,
+			Data: definition.ABIAccelerator.PackMethodPanic(definition.CreateProjectMethodName,
+				fmt.Sprintf("Project %d", i), "description", "test.com", big.NewInt(100), big.NewInt(1000)),
+		})
+		z.InsertNewMomentum() // cements the send block
+		z.InsertNewMomentum() // cements the contract's receive block
+		call.Error(t, nil)
+	}
+}
+
+// GetAll lists every project (the sort needs them all) but must only look
+// up votes and phases for the projects on the requested page.
+func TestAcceleratorGetAllEnrichesOnlyThePage(t *testing.T) {
+	types.ImplementedSporksMap[types.AcceleratorSpork.SporkId] = true
+	z := mock.NewMockZenonWithCustomEpochDuration(t, time.Hour)
+	defer z.StopPanic()
+	activateAcceleratorSpork(t, z)
+	const projects = 6
+	createProjects(t, z, projects)
+
+	a := NewAcceleratorApi(z)
+	ctx := newCountingContext(t, z, types.AcceleratorContract)
+	lookups := func(pageIndex, pageSize uint32) int {
+		ctx.reset()
+		list, err := a.getAll(ctx, pageIndex, pageSize)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if list.Count != projects {
+			t.Fatalf("count %d, want %d", list.Count, projects)
+		}
+		return ctx.lookups()
+	}
+
+	full := lookups(0, projects)
+	one := lookups(0, 1)
+	empty := lookups(projects, 1)
+	if !(empty < one && one < full) {
+		t.Fatalf("lookups: empty page %d, one item %d, full page %d; expected them to grow with the page", empty, one, full)
+	}
+	perProject := (full - empty) / projects
+	if one-empty > perProject {
+		t.Fatalf("one-item page cost %d lookups beyond the listing, %d per project", one-empty, perProject)
+	}
+
+	// Page contents are unchanged: the sort and the slicing still apply.
+	list, err := a.getAll(ctx, 1, 4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list.List) != 2 || list.List[0].Votes == nil {
+		t.Fatalf("page 1 of size 4 over %d projects: %d items, votes present=%v", projects, len(list.List), list.List[0].Votes != nil)
+	}
+}
+
+// The unsigned wrap request page is chosen before any request is enriched:
+// newest first, counted over all unsigned requests, sliced to the page.
+func TestSelectUnsignedWrapRequests(t *testing.T) {
+	requests := make([]*definition.WrapTokenRequest, 0, 10)
+	for i := 0; i < 10; i++ {
+		r := &definition.WrapTokenRequest{Id: types.NewHash([]byte{byte(i)})}
+		if i%3 == 0 {
+			r.Signature = "signed"
+		}
+		requests = append(requests, r)
+	}
+	// unsigned: 1 2 4 5 7 8 -> newest first: 8 7 5 4 2 1
+	page, count := selectUnsignedWrapRequests(requests, 1, 2)
+	if count != 6 {
+		t.Fatalf("count %d, want 6", count)
+	}
+	if len(page) != 2 || page[0].Id != types.NewHash([]byte{5}) || page[1].Id != types.NewHash([]byte{4}) {
+		t.Fatalf("page 1 of size 2: %v", page)
+	}
+	if page, _ := selectUnsignedWrapRequests(requests, 3, 2); len(page) != 0 {
+		t.Fatalf("page past the end returned %d items", len(page))
+	}
+	if page, _ := selectUnsignedWrapRequests(requests, 0, 6); len(page) != 6 || page[0].Id != types.NewHash([]byte{8}) || page[5].Id != types.NewHash([]byte{1}) {
+		t.Fatalf("full page: %v", page)
+	}
+}


### PR DESCRIPTION
## Summary

Two public embedded RPC listings did per-entry work for the whole collection and only then sliced the requested page.

- **`embedded.accelerator.getAll`** listed every project, sorted them, then ran the vote breakdown scan and the phase lookups for every project before slicing. The listing and the sort still need every project (the order is by last update, which is not the storage order), but the lookups are now done only for the projects on the page, so an empty or one-item page costs the listing and nothing more. Page contents, order and `count` are unchanged.
- **`embedded.bridge.getAllUnsignedWrapTokenRequests`** built the enriched entry (token lookup and confirmations to finality) for every unsigned request before reversing and slicing. The selection (unsigned only, newest first, the requested page, the total count) is now a separate function run first, and the lookups are done for the page only. The other listing methods already enriched only their page.

One output difference: an empty unsigned-request page now serializes as `"list": []` rather than `"list": null`, because the page slice is always allocated. The pinned Dart SDK model and the Go consumers accept both. Non-empty output is byte-for-byte unchanged.

## Scope

The remaining full-collection cost in these methods is the storage scan that lists the collection, which the sort and the total count require. Moving that into indexed or paginated storage would change how the contracts lay out their state and is out of scope.

The caller-sized hash list of `getPillarVotes` is deliberately left as it is. Syrius sends every phase ID of a full page of projects in one call and nothing on-chain caps phases per project, so any finite server bound has to follow a client-side batching change in the SDK and Syrius. That is tracked as a follow-up.

## Tests

`rpc/api/embedded/collection_work_test.go` (new): on a mock node with the accelerator spork active and six projects created, `getAll` is driven through a context whose storage counts point lookups and prefix scans. The cost grows from an empty page to a one-item page to the full page, the one-item page costs at most one project's lookups beyond the listing, and a later page still returns the right slice with votes. The unsigned wrap selection is checked for order, count, paging past the end and the full page.

On the unpatched code the `getAll` cost is the same for every page size (one scan per project plus the listing).

## Verification

- `GOWORK=off go vet ./rpc/api/embedded/`
- `GOWORK=off go test -race -count=3 ./rpc/api/embedded/`
- `GOWORK=off go test ./vm/embedded/tests/ ./rpc/...` (golden embedded API suite)
- `GOWORK=off go test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAfAxvtiPqYU6873a9K4uH
