### PR TITLE
app: map the --host flag to the P2P listen host

### DIFF
--- a/app/config.go
+++ b/app/config.go
@@ -71,7 +71,7 @@ func applyFlagsToConfig(ctx *cli.Context, cfg *node.Config) {
 	}
 
 	if listenHost := ctx.String(ListenHostFlag.Name); ctx.IsSet(ListenHostFlag.Name) && len(listenHost) > 0 {
-		cfg.RPC.HTTPHost = listenHost
+		cfg.Net.ListenHost = listenHost
 	}
 
 	if ctx.IsSet(ListenPortFlag.Name) {

--- a/app/flags_test.go
+++ b/app/flags_test.go
@@ -1,0 +1,65 @@
+package app
+
+import (
+	"flag"
+	"testing"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/zenon-network/go-zenon/node"
+)
+
+// applyFlags parses args against the given flags and applies them to a
+// default configuration, the way MakeConfig does after reading the file.
+func applyFlags(t *testing.T, flags []cli.Flag, args ...string) node.Config {
+	t.Helper()
+	set := flag.NewFlagSet("znnd", flag.ContinueOnError)
+	for _, f := range flags {
+		if err := f.Apply(set); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := set.Parse(args); err != nil {
+		t.Fatal(err)
+	}
+	cfg := node.DefaultNodeConfig
+	applyFlagsToConfig(cli.NewContext(cli.NewApp(), set, nil), &cfg)
+	return cfg
+}
+
+// Each listen flag sets the field its name and usage describe and nothing
+// else: the network flags the P2P listener, the RPC flags the RPC hosts.
+func TestListenFlagsMapToTheirFields(t *testing.T) {
+	flags := []cli.Flag{ListenHostFlag, ListenPortFlag, RPCListenAddrFlag, RPCPortFlag, WSListenAddrFlag, WSPortFlag}
+	def := node.DefaultNodeConfig
+
+	cfg := applyFlags(t, flags, "--"+ListenHostFlag.Name, "10.0.0.5")
+	if cfg.Net.ListenHost != "10.0.0.5" {
+		t.Errorf("--%s left Net.ListenHost at %q", ListenHostFlag.Name, cfg.Net.ListenHost)
+	}
+	if cfg.RPC.HTTPHost != def.RPC.HTTPHost || cfg.RPC.WSHost != def.RPC.WSHost {
+		t.Errorf("--%s changed the RPC hosts to %q / %q", ListenHostFlag.Name, cfg.RPC.HTTPHost, cfg.RPC.WSHost)
+	}
+
+	cfg = applyFlags(t, flags, "--"+ListenPortFlag.Name, "40000")
+	if cfg.Net.ListenPort != 40000 || cfg.RPC.HTTPPort != def.RPC.HTTPPort || cfg.RPC.WSPort != def.RPC.WSPort {
+		t.Errorf("--%s: Net.ListenPort %d, HTTPPort %d, WSPort %d", ListenPortFlag.Name, cfg.Net.ListenPort, cfg.RPC.HTTPPort, cfg.RPC.WSPort)
+	}
+
+	cfg = applyFlags(t, flags, "--"+RPCListenAddrFlag.Name, "10.0.0.6")
+	if cfg.RPC.HTTPHost != "10.0.0.6" || cfg.Net.ListenHost != def.Net.ListenHost || cfg.RPC.WSHost != def.RPC.WSHost {
+		t.Errorf("--%s: HTTPHost %q, Net.ListenHost %q, WSHost %q", RPCListenAddrFlag.Name, cfg.RPC.HTTPHost, cfg.Net.ListenHost, cfg.RPC.WSHost)
+	}
+
+	cfg = applyFlags(t, flags, "--"+WSListenAddrFlag.Name, "10.0.0.7")
+	if cfg.RPC.WSHost != "10.0.0.7" || cfg.Net.ListenHost != def.Net.ListenHost || cfg.RPC.HTTPHost != def.RPC.HTTPHost {
+		t.Errorf("--%s: WSHost %q, Net.ListenHost %q, HTTPHost %q", WSListenAddrFlag.Name, cfg.RPC.WSHost, cfg.Net.ListenHost, cfg.RPC.HTTPHost)
+	}
+
+	// Flags that are not passed leave everything at the file/default values,
+	// including the flags that carry a default of their own.
+	cfg = applyFlags(t, flags)
+	if cfg.Net.ListenHost != def.Net.ListenHost || cfg.RPC.HTTPHost != def.RPC.HTTPHost || cfg.RPC.WSHost != def.RPC.WSHost {
+		t.Errorf("no flags: Net.ListenHost %q, HTTPHost %q, WSHost %q", cfg.Net.ListenHost, cfg.RPC.HTTPHost, cfg.RPC.WSHost)
+	}
+}


### PR DESCRIPTION
## Summary

The `--host` flag is documented as "Network listening host", sits next to `--port` and defaults to the P2P listen host, but `applyFlagsToConfig` wrote its value into `RPC.HTTPHost`. Nothing on the command line ever set `Net.ListenHost`, so the flag could not confine the P2P listener, and an explicit `--host` silently re-bound HTTP-RPC to the address given for P2P, overriding whatever `HTTPHost` the configuration file specified. `--port` already reached `Net.ListenPort`, and `--http-addr` / `--ws-addr` already reached the RPC hosts. The mapping dates from the initial commit.

The flag now writes `Net.ListenHost`, which flows through `makeNetConfig` and the switcher into both the legacy and the libp2p listener. Anyone who had discovered the old behaviour and used `--host` to set the HTTP-RPC address should use `--http-addr`, which has always been the documented flag. No deployment command in the repository passes `--host`, and znn-controller starts a bare `znnd`.

## Tests

`app/flags_test.go` (new): each of `--host`, `--port`, `--http-addr` and `--ws-addr` is applied on its own to a default configuration through a real `cli.Context` and must change exactly the field its name describes; with no flags passed, all three hosts keep their defaults, so the flags' own default values do not leak into the configuration. On the unpatched code `--host` leaves `Net.ListenHost` untouched and changes `RPC.HTTPHost`.

## Verification

- `GOWORK=off go vet ./app/`
- `GOWORK=off go test -race -count=3 ./app/`
- `GOWORK=off go test ./...`
- Combined tree with #90 (`fix/redact-producer-password`, which also adds a test file to `app/`): identical trees in both merge orders, app and node packages race-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAfAxvtiPqYU6873a9K4uH
