### PR TITLE
fetcher: keep the per-peer announce counter exact across a fetch

### DIFF
--- a/protocol/fetcher/fetcher.go
+++ b/protocol/fetcher/fetcher.go
@@ -231,13 +231,18 @@ func (f *Fetcher) Filter(peer string, blocks []*nom.DetailedMomentum) []*nom.Det
 func (f *Fetcher) loop() {
 	// Iterate the block fetching until a quit is requested
 	fetch := time.NewTimer(0)
+	expire := time.NewTimer(0)
 	for {
-		// Clean up any expired block fetches
+		// Clean up any expired block fetches. Expired entries still count
+		// against their peer's announce allowance, so the sweep must also
+		// run when nothing else wakes the loop: arm a timer for the oldest
+		// fetch so the allowance is released on time.
 		for hash, announce := range f.fetching {
 			if time.Since(announce.time) > fetchTimeout {
 				f.forgetHash(hash)
 			}
 		}
+		f.rescheduleExpiry(expire)
 		// Import any queued blocks that could potentially fit
 		height := f.chainHeight()
 		for !f.queue.Empty() {
@@ -335,6 +340,10 @@ func (f *Fetcher) loop() {
 			// Schedule the next fetch if blocks are still pending
 			f.reschedule(fetch)
 
+		case <-expire.C:
+			// The oldest fetch has timed out; the sweep at the top of the
+			// loop removes it and releases the peer's allowance.
+
 		case req := <-f.filter:
 			// Blocks arrived, extract any explicit fetches, return all else
 			var blocks []*nom.DetailedMomentum
@@ -394,6 +403,23 @@ func (f *Fetcher) reschedule(fetch *time.Timer) {
 		}
 	}
 	fetch.Reset(arriveTimeout - time.Since(earliest))
+}
+
+// rescheduleExpiry resets the expiry timer to the moment the oldest pending
+// fetch times out, so expired fetches are swept even while the loop is idle.
+func (f *Fetcher) rescheduleExpiry(expire *time.Timer) {
+	// Short circuit if no fetches are pending
+	if len(f.fetching) == 0 {
+		return
+	}
+	// Otherwise find the oldest fetch still waiting on a reply
+	earliest := time.Now()
+	for _, announce := range f.fetching {
+		if earliest.After(announce.time) {
+			earliest = announce.time
+		}
+	}
+	expire.Reset(fetchTimeout - time.Since(earliest))
 }
 
 // enqueue schedules a new future import operation, if the block to be imported

--- a/protocol/fetcher/fetcher.go
+++ b/protocol/fetcher/fetcher.go
@@ -37,7 +37,7 @@ const (
 	fetchTimeout  = 5 * time.Second        // Maximum alloted time to return an explicitly requested block
 	maxUncleDist  = 7                      // Maximum allowed backward distance from the chain head
 	maxQueueDist  = 32                     // Maximum allowed distance from the chain head to queue
-	hashLimit     = 256                    // Maximum number of unique blocks a peer may have announced
+	HashLimit     = 256                    // Maximum number of unique blocks a peer may have announced; also the largest batch one fetch request names
 	blockLimit    = 64                     // Maximum number of unique blocks a per may have delivered
 )
 
@@ -267,8 +267,8 @@ func (f *Fetcher) loop() {
 		case notification := <-f.notify:
 			// A block was announced, make sure the peer isn't DOSing us
 			count := f.announces[notification.origin] + 1
-			if count > hashLimit {
-				log.Info("Peer exceeded outstanding announces", "peer", notification.origin, "hash-limit", hashLimit)
+			if count > HashLimit {
+				log.Info("Peer exceeded outstanding announces", "peer", notification.origin, "hash-limit", HashLimit)
 				break
 			}
 			// All is well, schedule the announce if block's not yet downloading
@@ -300,10 +300,15 @@ func (f *Fetcher) loop() {
 					announce := announces[rand.Intn(len(announces))]
 					f.forgetHash(hash)
 
-					// If the block still didn't arrive, queue for fetching
+					// If the block still didn't arrive, queue for fetching.
+					// The fetching entry is outstanding work for the chosen
+					// peer, so count it again: forgetHash just released the
+					// announce and will release this entry when the fetch
+					// completes or times out.
 					if f.getBlock(hash) == nil {
 						request[announce.origin] = append(request[announce.origin], hash)
 						f.fetching[hash] = announce
+						f.announces[announce.origin]++
 					}
 				}
 			}
@@ -468,10 +473,12 @@ func (f *Fetcher) insert(peer string, detailed *nom.DetailedMomentum) {
 // forgetHash removes all traces of a block announcement from the fetcher's
 // internal state.
 func (f *Fetcher) forgetHash(hash types.Hash) {
-	// Remove all pending announces and decrement DOS counters
+	// Remove all pending announces and decrement DOS counters. A counter
+	// that reaches zero is dropped rather than kept, so it can never sit
+	// below zero and grant a peer extra announces.
 	for _, announce := range f.announced[hash] {
 		f.announces[announce.origin]--
-		if f.announces[announce.origin] == 0 {
+		if f.announces[announce.origin] <= 0 {
 			delete(f.announces, announce.origin)
 		}
 	}
@@ -480,7 +487,7 @@ func (f *Fetcher) forgetHash(hash types.Hash) {
 	// Remove any pending fetches and decrement the DOS counters
 	if announce := f.fetching[hash]; announce != nil {
 		f.announces[announce.origin]--
-		if f.announces[announce.origin] == 0 {
+		if f.announces[announce.origin] <= 0 {
 			delete(f.announces, announce.origin)
 		}
 		delete(f.fetching, hash)

--- a/protocol/fetcher/fetcher.go
+++ b/protocol/fetcher/fetcher.go
@@ -104,9 +104,10 @@ type Fetcher struct {
 	quit   chan struct{}
 
 	// Announce states
-	announces map[string]int             // Per peer announce counts to prevent memory exhaustion
-	announced map[types.Hash][]*announce // Announced blocks, scheduled for fetching
-	fetching  map[types.Hash]*announce   // Announced blocks, currently fetching
+	announces   map[string]int             // Per peer announce counts to prevent memory exhaustion
+	announced   map[types.Hash][]*announce // Announced blocks, scheduled for fetching
+	fetching    map[types.Hash]*announce   // Announced blocks, currently fetching
+	oldestFetch time.Time                  // Announce time of the oldest pending fetch as of the last sweep, zero when none
 
 	// Block cache
 	queue  *prque.Prque           // Queue containing the import operations (block number sorted)
@@ -238,23 +239,9 @@ func (f *Fetcher) loop() {
 		// against their peer's announce allowance, so the sweep must also
 		// run when nothing else wakes the loop: arm a timer for the oldest
 		// surviving fetch so the allowance is released on time.
-		var expired []types.Hash
-		var oldest time.Time
-		for hash, announce := range f.fetching {
-			if time.Since(announce.time) > fetchTimeout {
-				f.forgetHash(hash)
-				if f.expiredHook != nil {
-					expired = append(expired, hash)
-				}
-			} else if oldest.IsZero() || announce.time.Before(oldest) {
-				oldest = announce.time
-			}
-		}
-		if !oldest.IsZero() {
-			expire.Reset(fetchTimeout - time.Since(oldest))
-		}
-		if len(expired) > 0 {
-			f.expiredHook(expired)
+		f.sweepExpired()
+		if !f.oldestFetch.IsZero() {
+			expire.Reset(fetchTimeout - time.Since(f.oldestFetch))
 		}
 		// Import any queued blocks that could potentially fit
 		height := f.chainHeight()
@@ -283,7 +270,10 @@ func (f *Fetcher) loop() {
 			return
 
 		case notification := <-f.notify:
-			// A block was announced, make sure the peer isn't DOSing us
+			// A block was announced, make sure the peer isn't DOSing us.
+			// Release fetches that timed out since the last sweep first,
+			// so a peer at its limit is judged on live entries only.
+			f.releaseExpired(notification.origin)
 			count := f.announces[notification.origin] + 1
 			if count > HashLimit {
 				log.Info("Peer exceeded outstanding announces", "peer", notification.origin, "hash-limit", HashLimit)
@@ -400,6 +390,42 @@ func (f *Fetcher) loop() {
 			}
 		}
 	}
+}
+
+// sweepExpired forgets every pending fetch older than fetchTimeout, records
+// the announce time of the oldest survivor for the expiry timer and for
+// admission, and reports the expired hashes to the test hook.
+func (f *Fetcher) sweepExpired() {
+	var expired []types.Hash
+	f.oldestFetch = time.Time{}
+	for hash, announce := range f.fetching {
+		if time.Since(announce.time) > fetchTimeout {
+			f.forgetHash(hash)
+			if f.expiredHook != nil {
+				expired = append(expired, hash)
+			}
+		} else if f.oldestFetch.IsZero() || announce.time.Before(f.oldestFetch) {
+			f.oldestFetch = announce.time
+		}
+	}
+	if len(expired) > 0 {
+		f.expiredHook(expired)
+	}
+}
+
+// releaseExpired sweeps timed-out fetches when peer is at its announce
+// allowance and the oldest pending fetch has passed its timeout since the
+// last sweep. The sweep runs before the loop blocks in select, so when the
+// timeout passes while the loop is blocked and a notification is selected
+// ahead of the expiry timer, the peer would otherwise be judged against
+// fetches that have already timed out. The sweep only runs when something
+// has actually expired, and each fetch expires once, so a peer at its limit
+// cannot make refused announces cost repeated walks of the table.
+func (f *Fetcher) releaseExpired(peer string) {
+	if f.announces[peer] < HashLimit || f.oldestFetch.IsZero() || time.Since(f.oldestFetch) <= fetchTimeout {
+		return
+	}
+	f.sweepExpired()
 }
 
 // reschedule resets the specified fetch timer to the next announce timeout.

--- a/protocol/fetcher/fetcher.go
+++ b/protocol/fetcher/fetcher.go
@@ -243,7 +243,9 @@ func (f *Fetcher) loop() {
 		for hash, announce := range f.fetching {
 			if time.Since(announce.time) > fetchTimeout {
 				f.forgetHash(hash)
-				expired = append(expired, hash)
+				if f.expiredHook != nil {
+					expired = append(expired, hash)
+				}
 			} else if oldest.IsZero() || announce.time.Before(oldest) {
 				oldest = announce.time
 			}
@@ -251,7 +253,7 @@ func (f *Fetcher) loop() {
 		if !oldest.IsZero() {
 			expire.Reset(fetchTimeout - time.Since(oldest))
 		}
-		if len(expired) > 0 && f.expiredHook != nil {
+		if len(expired) > 0 {
 			f.expiredHook(expired)
 		}
 		// Import any queued blocks that could potentially fit

--- a/protocol/fetcher/fetcher.go
+++ b/protocol/fetcher/fetcher.go
@@ -123,6 +123,7 @@ type Fetcher struct {
 
 	// Testing hooks
 	fetchingHook func([]types.Hash)  // Method to call upon starting a block fetch
+	expiredHook  func([]types.Hash)  // Method to call after timed-out fetches are swept
 	importedHook func(*nom.Momentum) // Method to call upon successful block import
 
 	wg sync.WaitGroup
@@ -236,13 +237,23 @@ func (f *Fetcher) loop() {
 		// Clean up any expired block fetches. Expired entries still count
 		// against their peer's announce allowance, so the sweep must also
 		// run when nothing else wakes the loop: arm a timer for the oldest
-		// fetch so the allowance is released on time.
+		// surviving fetch so the allowance is released on time.
+		var expired []types.Hash
+		var oldest time.Time
 		for hash, announce := range f.fetching {
 			if time.Since(announce.time) > fetchTimeout {
 				f.forgetHash(hash)
+				expired = append(expired, hash)
+			} else if oldest.IsZero() || announce.time.Before(oldest) {
+				oldest = announce.time
 			}
 		}
-		f.rescheduleExpiry(expire)
+		if !oldest.IsZero() {
+			expire.Reset(fetchTimeout - time.Since(oldest))
+		}
+		if len(expired) > 0 && f.expiredHook != nil {
+			f.expiredHook(expired)
+		}
 		// Import any queued blocks that could potentially fit
 		height := f.chainHeight()
 		for !f.queue.Empty() {
@@ -403,23 +414,6 @@ func (f *Fetcher) reschedule(fetch *time.Timer) {
 		}
 	}
 	fetch.Reset(arriveTimeout - time.Since(earliest))
-}
-
-// rescheduleExpiry resets the expiry timer to the moment the oldest pending
-// fetch times out, so expired fetches are swept even while the loop is idle.
-func (f *Fetcher) rescheduleExpiry(expire *time.Timer) {
-	// Short circuit if no fetches are pending
-	if len(f.fetching) == 0 {
-		return
-	}
-	// Otherwise find the oldest fetch still waiting on a reply
-	earliest := time.Now()
-	for _, announce := range f.fetching {
-		if earliest.After(announce.time) {
-			earliest = announce.time
-		}
-	}
-	expire.Reset(fetchTimeout - time.Since(earliest))
 }
 
 // enqueue schedules a new future import operation, if the block to be imported

--- a/protocol/fetcher/fetcher_test.go
+++ b/protocol/fetcher/fetcher_test.go
@@ -31,12 +31,13 @@ type testHarness struct {
 }
 
 func newTestHarness(getBlock blockRetrievalFn, verifyBlock blockVerifierFn, insertChain chainInsertFn) *testHarness {
-	return newHookedTestHarness(getBlock, verifyBlock, insertChain, nil)
+	return newHookedTestHarness(getBlock, verifyBlock, insertChain, nil, nil)
 }
 
-// newHookedTestHarness is newTestHarness with the fetcher's fetchingHook set
-// before the loop starts, so a test can observe when hashes begin fetching.
-func newHookedTestHarness(getBlock blockRetrievalFn, verifyBlock blockVerifierFn, insertChain chainInsertFn, fetchingHook func([]types.Hash)) *testHarness {
+// newHookedTestHarness is newTestHarness with the fetcher's fetchingHook and
+// expiredHook set before the loop starts, so a test can observe when hashes
+// begin fetching and when timed-out fetches are swept.
+func newHookedTestHarness(getBlock blockRetrievalFn, verifyBlock blockVerifierFn, insertChain chainInsertFn, fetchingHook, expiredHook func([]types.Hash)) *testHarness {
 	h := &testHarness{
 		droppedPeers: make(chan string, 10),
 		broadcasts:   make(chan *nom.DetailedMomentum, 10),
@@ -56,6 +57,7 @@ func newHookedTestHarness(getBlock blockRetrievalFn, verifyBlock blockVerifierFn
 		func(id string) { h.droppedPeers <- id },
 	)
 	h.f.fetchingHook = fetchingHook
+	h.f.expiredHook = expiredHook
 
 	go func() {
 		h.f.loop()
@@ -414,17 +416,27 @@ func (s *importedSet) add(blocks []*nom.DetailedMomentum) {
 	}
 }
 
+// accountingEvents carries the fetcher's test hooks: each batch of hashes as
+// it begins fetching, and each batch swept after timing out.
+type accountingEvents struct {
+	fetching chan []types.Hash
+	expired  chan []types.Hash
+}
+
 // newAccountingHarness returns a harness whose chain knows only what the test
-// marks imported, a channel that receives each batch of hashes as it begins
-// fetching, and n distinct blocks to announce.
-func newAccountingHarness(n int) (*testHarness, *importedSet, <-chan []types.Hash, []*nom.DetailedMomentum) {
+// marks imported, the hook events, and n distinct blocks to announce.
+func newAccountingHarness(n int) (*testHarness, *importedSet, *accountingEvents, []*nom.DetailedMomentum) {
 	imported := &importedSet{blocks: make(map[types.Hash]*nom.DetailedMomentum)}
-	fetching := make(chan []types.Hash, 16)
+	events := &accountingEvents{
+		fetching: make(chan []types.Hash, 16),
+		expired:  make(chan []types.Hash, 16),
+	}
 	h := newHookedTestHarness(
 		imported.get,
 		func(*nom.DetailedMomentum) error { return nil },
 		func([]*nom.DetailedMomentum) (int, error) { return 0, nil },
-		func(hashes []types.Hash) { fetching <- hashes },
+		func(hashes []types.Hash) { events.fetching <- hashes },
+		func(hashes []types.Hash) { events.expired <- hashes },
 	)
 	blocks := make([]*nom.DetailedMomentum, n)
 	prev := types.Hash{}
@@ -433,7 +445,7 @@ func newAccountingHarness(n int) (*testHarness, *importedSet, <-chan []types.Has
 		blocks[i] = &nom.DetailedMomentum{Momentum: m}
 		prev = m.Hash
 	}
-	return h, imported, fetching, blocks
+	return h, imported, events, blocks
 }
 
 // announceAll sends every block's hash to the fetcher on behalf of peer with a
@@ -447,19 +459,33 @@ func announceAll(t *testing.T, h *testHarness, peer string, blocks []*nom.Detail
 	}
 }
 
-// waitForFetching blocks until n hashes have been handed to a fetch request,
-// which happens after the loop has moved them into the fetching table.
-func waitForFetching(t *testing.T, fetching <-chan []types.Hash, n int) {
+// waitForHashes blocks until n hashes have been reported on events, or fails
+// the test once the deadline passes.
+func waitForHashes(t *testing.T, events <-chan []types.Hash, n int, deadline time.Duration, what string) {
 	t.Helper()
-	deadline := time.After(10 * arriveTimeout)
+	timeout := time.After(deadline)
 	for got := 0; got < n; {
 		select {
-		case hashes := <-fetching:
+		case hashes := <-events:
 			got += len(hashes)
-		case <-deadline:
-			t.Fatalf("only %d of %d hashes began fetching before the deadline", got, n)
+		case <-timeout:
+			t.Fatalf("only %d of %d hashes %s before the deadline", got, n, what)
 		}
 	}
+}
+
+// waitForFetching blocks until n hashes have been handed to a fetch request,
+// which happens after the loop has moved them into the fetching table.
+func waitForFetching(t *testing.T, events *accountingEvents, n int) {
+	t.Helper()
+	waitForHashes(t, events.fetching, n, 10*arriveTimeout, "began fetching")
+}
+
+// waitForExpiry blocks until n fetches have timed out and been swept, which
+// happens after the loop has removed them and released their allowance.
+func waitForExpiry(t *testing.T, events *accountingEvents, n int) {
+	t.Helper()
+	waitForHashes(t, events.expired, n, fetchTimeout+10*arriveTimeout, "expired")
 }
 
 // checkAccounting compares, on a stopped fetcher, each peer's counter with the
@@ -494,11 +520,11 @@ func checkAccounting(t *testing.T, f *Fetcher) {
 // A hash that is announced, fetched and then found imported at delivery must
 // leave the announcing peer's counter exactly where it started.
 func TestAnnounces_ExactThroughFetchAndCompletion(t *testing.T) {
-	h, imported, fetching, blocks := newAccountingHarness(8)
+	h, imported, events, blocks := newAccountingHarness(8)
 	defer h.stop()
 
 	announceAll(t, h, "announcer", blocks)
-	waitForFetching(t, fetching, len(blocks))
+	waitForFetching(t, events, len(blocks))
 
 	// Delivery finds every block already imported, which is the completion
 	// path that does not go through the import queue.
@@ -523,15 +549,14 @@ func TestAnnounces_ExactThroughFetchTimeout(t *testing.T) {
 	if testing.Short() {
 		t.Skip("waits out fetchTimeout")
 	}
-	h, _, fetching, blocks := newAccountingHarness(8)
+	h, _, events, blocks := newAccountingHarness(8)
 	defer h.stop()
 
 	announceAll(t, h, "announcer", blocks)
-	waitForFetching(t, fetching, len(blocks))
-	// Fetch age is measured from the announce, so by now every fetch is
-	// older than fetchTimeout and the expiry timer has swept it without any
-	// other event waking the loop.
-	time.Sleep(fetchTimeout + 250*time.Millisecond)
+	waitForFetching(t, events, len(blocks))
+	// Nothing else wakes the loop from here on, so the sweep that reports
+	// these hashes ran off the expiry timer.
+	waitForExpiry(t, events, len(blocks))
 
 	h.stop()
 	if len(h.f.fetching) != 0 {
@@ -546,11 +571,11 @@ func TestAnnounces_ExactThroughFetchTimeout(t *testing.T) {
 // Hashes in the fetching table are still outstanding work for the peer that
 // announced them, so they count toward HashLimit.
 func TestAnnounces_FetchingCountsTowardHashLimit(t *testing.T) {
-	h, _, fetching, blocks := newAccountingHarness(HashLimit + 8)
+	h, _, events, blocks := newAccountingHarness(HashLimit + 8)
 	defer h.stop()
 
 	announceAll(t, h, "announcer", blocks[:HashLimit])
-	waitForFetching(t, fetching, HashLimit)
+	waitForFetching(t, events, HashLimit)
 	announceAll(t, h, "announcer", blocks[HashLimit:])
 
 	h.stop()
@@ -566,13 +591,13 @@ func TestAnnounces_FetchingCountsTowardHashLimit(t *testing.T) {
 // Repeated lifecycles must not widen the set of announces a peer may hold:
 // after a full batch completes, the next batch is still bounded by HashLimit.
 func TestAnnounces_LimitHoldsAcrossLifecycles(t *testing.T) {
-	h, imported, fetching, blocks := newAccountingHarness(2*HashLimit + 8)
+	h, imported, events, blocks := newAccountingHarness(2*HashLimit + 8)
 	defer h.stop()
 
 	for round := 0; round < 2; round++ {
 		batch := blocks[round*HashLimit : (round+1)*HashLimit]
 		announceAll(t, h, "announcer", batch)
-		waitForFetching(t, fetching, HashLimit)
+		waitForFetching(t, events, HashLimit)
 		imported.add(batch)
 		h.f.Filter("deliverer", batch)
 	}
@@ -595,14 +620,14 @@ func TestAnnounces_ExpiredFetchesFreeAllowanceBeforeNextAnnounce(t *testing.T) {
 	if testing.Short() {
 		t.Skip("waits out fetchTimeout")
 	}
-	h, _, fetching, blocks := newAccountingHarness(HashLimit + 8)
+	h, _, events, blocks := newAccountingHarness(HashLimit + 8)
 	defer h.stop()
 
 	announceAll(t, h, "announcer", blocks[:HashLimit])
-	waitForFetching(t, fetching, HashLimit)
+	waitForFetching(t, events, HashLimit)
 	// Let every fetch expire with the loop otherwise idle: nothing else
 	// wakes it between here and the next announce.
-	time.Sleep(fetchTimeout + 250*time.Millisecond)
+	waitForExpiry(t, events, HashLimit)
 	announceAll(t, h, "announcer", blocks[HashLimit:])
 
 	h.stop()

--- a/protocol/fetcher/fetcher_test.go
+++ b/protocol/fetcher/fetcher_test.go
@@ -427,9 +427,12 @@ type accountingEvents struct {
 // marks imported, the hook events, and n distinct blocks to announce.
 func newAccountingHarness(n int) (*testHarness, *importedSet, *accountingEvents, []*nom.DetailedMomentum) {
 	imported := &importedSet{blocks: make(map[types.Hash]*nom.DetailedMomentum)}
+	// Each hash begins fetching at most once and expires at most once, so
+	// n slots guarantee the hooks never block the loop however the events
+	// are batched.
 	events := &accountingEvents{
-		fetching: make(chan []types.Hash, 16),
-		expired:  make(chan []types.Hash, 16),
+		fetching: make(chan []types.Hash, n),
+		expired:  make(chan []types.Hash, n),
 	}
 	h := newHookedTestHarness(
 		imported.get,

--- a/protocol/fetcher/fetcher_test.go
+++ b/protocol/fetcher/fetcher_test.go
@@ -27,9 +27,16 @@ type testHarness struct {
 	droppedPeers chan string
 	broadcasts   chan *nom.DetailedMomentum
 	quit         chan struct{}
+	stopOnce     sync.Once
 }
 
 func newTestHarness(getBlock blockRetrievalFn, verifyBlock blockVerifierFn, insertChain chainInsertFn) *testHarness {
+	return newHookedTestHarness(getBlock, verifyBlock, insertChain, nil)
+}
+
+// newHookedTestHarness is newTestHarness with the fetcher's fetchingHook set
+// before the loop starts, so a test can observe when hashes begin fetching.
+func newHookedTestHarness(getBlock blockRetrievalFn, verifyBlock blockVerifierFn, insertChain chainInsertFn, fetchingHook func([]types.Hash)) *testHarness {
 	h := &testHarness{
 		droppedPeers: make(chan string, 10),
 		broadcasts:   make(chan *nom.DetailedMomentum, 10),
@@ -48,6 +55,7 @@ func newTestHarness(getBlock blockRetrievalFn, verifyBlock blockVerifierFn, inse
 		insertChain,
 		func(id string) { h.droppedPeers <- id },
 	)
+	h.f.fetchingHook = fetchingHook
 
 	go func() {
 		h.f.loop()
@@ -58,7 +66,7 @@ func newTestHarness(getBlock blockRetrievalFn, verifyBlock blockVerifierFn, inse
 }
 
 func (h *testHarness) stop() {
-	h.f.Stop()
+	h.stopOnce.Do(h.f.Stop)
 	<-h.quit
 }
 
@@ -378,4 +386,208 @@ func TestInsert_ParentUnknown_Aborts(t *testing.T) {
 	if insertCalled {
 		t.Error("insertChain should not be called when parent is unknown")
 	}
+}
+
+// The per-peer announce counter is the fetcher's only guard against a peer
+// filling its announced and fetching tables. The tests below drive whole
+// announce lifecycles through the real loop and then, with the loop stopped,
+// compare the counter with the entries it is supposed to count.
+
+// importedSet lets a test flip getBlock from "unknown" to "known" for chosen
+// hashes while the loop is running.
+type importedSet struct {
+	mu     sync.Mutex
+	blocks map[types.Hash]*nom.DetailedMomentum
+}
+
+func (s *importedSet) get(hash types.Hash) *nom.DetailedMomentum {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.blocks[hash]
+}
+
+func (s *importedSet) add(blocks []*nom.DetailedMomentum) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, b := range blocks {
+		s.blocks[b.Momentum.Hash] = b
+	}
+}
+
+// newAccountingHarness returns a harness whose chain knows only what the test
+// marks imported, a channel that receives each batch of hashes as it begins
+// fetching, and n distinct blocks to announce.
+func newAccountingHarness(n int) (*testHarness, *importedSet, <-chan []types.Hash, []*nom.DetailedMomentum) {
+	imported := &importedSet{blocks: make(map[types.Hash]*nom.DetailedMomentum)}
+	fetching := make(chan []types.Hash, 16)
+	h := newHookedTestHarness(
+		imported.get,
+		func(*nom.DetailedMomentum) error { return nil },
+		func([]*nom.DetailedMomentum) (int, error) { return 0, nil },
+		func(hashes []types.Hash) { fetching <- hashes },
+	)
+	blocks := make([]*nom.DetailedMomentum, n)
+	prev := types.Hash{}
+	for i := range blocks {
+		m := newTestMomentum(uint64(i+2), prev)
+		blocks[i] = &nom.DetailedMomentum{Momentum: m}
+		prev = m.Hash
+	}
+	return h, imported, fetching, blocks
+}
+
+// announceAll sends every block's hash to the fetcher on behalf of peer with a
+// request function that never delivers, and returns how many were accepted.
+func announceAll(t *testing.T, h *testHarness, peer string, blocks []*nom.DetailedMomentum) {
+	t.Helper()
+	for _, b := range blocks {
+		if err := h.f.Notify(peer, b.Momentum.Hash, time.Now(), func([]types.Hash) error { return nil }); err != nil {
+			t.Fatalf("Notify: %v", err)
+		}
+	}
+}
+
+// waitForFetching blocks until n hashes have been handed to a fetch request,
+// which happens after the loop has moved them into the fetching table.
+func waitForFetching(t *testing.T, fetching <-chan []types.Hash, n int) {
+	t.Helper()
+	deadline := time.After(10 * arriveTimeout)
+	for got := 0; got < n; {
+		select {
+		case hashes := <-fetching:
+			got += len(hashes)
+		case <-deadline:
+			t.Fatalf("only %d of %d hashes began fetching before the deadline", got, n)
+		}
+	}
+}
+
+// checkAccounting compares, on a stopped fetcher, each peer's counter with the
+// announced and fetching entries attributed to it, and fails on any negative
+// or stale counter.
+func checkAccounting(t *testing.T, f *Fetcher) {
+	t.Helper()
+	want := make(map[string]int)
+	for _, announces := range f.announced {
+		for _, a := range announces {
+			want[a.origin]++
+		}
+	}
+	for _, a := range f.fetching {
+		want[a.origin]++
+	}
+	for peer, count := range f.announces {
+		if count <= 0 {
+			t.Errorf("peer %q: counter %d is not positive", peer, count)
+		}
+		if count != want[peer] {
+			t.Errorf("peer %q: counter %d, but %d announced or fetching entries", peer, count, want[peer])
+		}
+	}
+	for peer, count := range want {
+		if _, ok := f.announces[peer]; !ok {
+			t.Errorf("peer %q: no counter, but %d announced or fetching entries", peer, count)
+		}
+	}
+}
+
+// A hash that is announced, fetched and then found imported at delivery must
+// leave the announcing peer's counter exactly where it started.
+func TestAnnounces_ExactThroughFetchAndCompletion(t *testing.T) {
+	h, imported, fetching, blocks := newAccountingHarness(8)
+	defer h.stop()
+
+	announceAll(t, h, "announcer", blocks)
+	waitForFetching(t, fetching, len(blocks))
+
+	// Delivery finds every block already imported, which is the completion
+	// path that does not go through the import queue.
+	imported.add(blocks)
+	if rest := h.f.Filter("deliverer", blocks); len(rest) != 0 {
+		t.Fatalf("%d explicitly fetched blocks were not consumed", len(rest))
+	}
+
+	h.stop()
+	if len(h.f.announced) != 0 || len(h.f.fetching) != 0 {
+		t.Fatalf("%d announced and %d fetching entries remain", len(h.f.announced), len(h.f.fetching))
+	}
+	checkAccounting(t, h.f)
+	if count, ok := h.f.announces["announcer"]; ok {
+		t.Fatalf("announcer's counter is %d after all its hashes completed, want no entry", count)
+	}
+}
+
+// A hash whose fetch times out must be forgotten with the same effect on the
+// counter as a completed one.
+func TestAnnounces_ExactThroughFetchTimeout(t *testing.T) {
+	if testing.Short() {
+		t.Skip("waits out fetchTimeout")
+	}
+	h, _, fetching, blocks := newAccountingHarness(8)
+	defer h.stop()
+
+	announceAll(t, h, "announcer", blocks)
+	waitForFetching(t, fetching, len(blocks))
+	// Fetch age is measured from the announce, so by now every fetch is
+	// older than fetchTimeout.
+	time.Sleep(fetchTimeout + 250*time.Millisecond)
+
+	// Expired fetches are swept at the top of the loop, so nudge it with an
+	// empty delivery.
+	h.f.Filter("nobody", nil)
+
+	h.stop()
+	if len(h.f.fetching) != 0 {
+		t.Fatalf("%d fetching entries survived fetchTimeout", len(h.f.fetching))
+	}
+	checkAccounting(t, h.f)
+	if count, ok := h.f.announces["announcer"]; ok {
+		t.Fatalf("announcer's counter is %d after all its fetches timed out, want no entry", count)
+	}
+}
+
+// Hashes in the fetching table are still outstanding work for the peer that
+// announced them, so they count toward HashLimit.
+func TestAnnounces_FetchingCountsTowardHashLimit(t *testing.T) {
+	h, _, fetching, blocks := newAccountingHarness(HashLimit + 8)
+	defer h.stop()
+
+	announceAll(t, h, "announcer", blocks[:HashLimit])
+	waitForFetching(t, fetching, HashLimit)
+	announceAll(t, h, "announcer", blocks[HashLimit:])
+
+	h.stop()
+	if len(h.f.fetching) != HashLimit {
+		t.Fatalf("%d fetching entries, want %d", len(h.f.fetching), HashLimit)
+	}
+	if len(h.f.announced) != 0 {
+		t.Fatalf("%d announces accepted past HashLimit while %d hashes were fetching", len(h.f.announced), HashLimit)
+	}
+	checkAccounting(t, h.f)
+}
+
+// Repeated lifecycles must not widen the set of announces a peer may hold:
+// after a full batch completes, the next batch is still bounded by HashLimit.
+func TestAnnounces_LimitHoldsAcrossLifecycles(t *testing.T) {
+	h, imported, fetching, blocks := newAccountingHarness(2*HashLimit + 8)
+	defer h.stop()
+
+	for round := 0; round < 2; round++ {
+		batch := blocks[round*HashLimit : (round+1)*HashLimit]
+		announceAll(t, h, "announcer", batch)
+		waitForFetching(t, fetching, HashLimit)
+		imported.add(batch)
+		h.f.Filter("deliverer", batch)
+	}
+	announceAll(t, h, "announcer", blocks[2*HashLimit:])
+	announceAll(t, h, "announcer", blocks[:HashLimit]) // already imported hashes are still announces
+
+	h.stop()
+	// Some of the final announces may already have moved to fetching, or
+	// been dropped as known, if a timer fired meanwhile; the bound is on
+	// what the peer holds in total, not on the announced table alone.
+	if got := len(h.f.announced) + len(h.f.fetching); got > HashLimit {
+		t.Fatalf("%d announced or fetching entries held after two completed lifecycles, want at most %d", got, HashLimit)
+	}
+	checkAccounting(t, h.f)
 }

--- a/protocol/fetcher/fetcher_test.go
+++ b/protocol/fetcher/fetcher_test.go
@@ -441,6 +441,11 @@ func newAccountingHarness(n int) (*testHarness, *importedSet, *accountingEvents,
 		func(hashes []types.Hash) { events.fetching <- hashes },
 		func(hashes []types.Hash) { events.expired <- hashes },
 	)
+	return h, imported, events, testBlocks(n)
+}
+
+// testBlocks returns n distinct chained blocks starting at height 2.
+func testBlocks(n int) []*nom.DetailedMomentum {
 	blocks := make([]*nom.DetailedMomentum, n)
 	prev := types.Hash{}
 	for i := range blocks {
@@ -448,7 +453,7 @@ func newAccountingHarness(n int) (*testHarness, *importedSet, *accountingEvents,
 		blocks[i] = &nom.DetailedMomentum{Momentum: m}
 		prev = m.Hash
 	}
-	return h, imported, events, blocks
+	return blocks
 }
 
 // announceAll sends every block's hash to the fetcher on behalf of peer with a
@@ -634,11 +639,98 @@ func TestAnnounces_ExpiredFetchesFreeAllowanceBeforeNextAnnounce(t *testing.T) {
 	announceAll(t, h, "announcer", blocks[HashLimit:])
 
 	h.stop()
-	if len(h.f.fetching) != 0 {
-		t.Fatalf("%d fetching entries survived fetchTimeout", len(h.f.fetching))
-	}
-	if got := len(h.f.announced); got != 8 {
-		t.Fatalf("%d of 8 announces accepted after every fetch expired, want all 8", got)
-	}
+	// The new announces may already have moved to fetching if a timer fired
+	// meanwhile, so check the exact set the peer holds across both tables.
+	expectHeld(t, h.f, blocks[HashLimit:], blocks[:HashLimit])
 	checkAccounting(t, h.f)
+}
+
+// expectHeld fails unless the fetcher holds exactly the want blocks, each in
+// announced or fetching, and none of the gone blocks.
+func expectHeld(t *testing.T, f *Fetcher, want, gone []*nom.DetailedMomentum) {
+	t.Helper()
+	held := func(hash types.Hash) bool {
+		_, announced := f.announced[hash]
+		_, fetching := f.fetching[hash]
+		return announced || fetching
+	}
+	for i, b := range want {
+		if !held(b.Momentum.Hash) {
+			t.Errorf("wanted block %d is neither announced nor fetching", i)
+		}
+	}
+	for i, b := range gone {
+		if held(b.Momentum.Hash) {
+			t.Errorf("block %d should be gone but is still announced or fetching", i)
+		}
+	}
+	if total := len(f.announced) + len(f.fetching); total != len(want) {
+		t.Errorf("%d announced or fetching entries, want %d", total, len(want))
+	}
+}
+
+// newIdleFetcher returns a fetcher whose loop is not running, for driving
+// the admission path directly with hand-built state.
+func newIdleFetcher() *Fetcher {
+	return New(
+		func(types.Hash) *nom.DetailedMomentum { return nil },
+		func(*nom.DetailedMomentum) error { return nil },
+		func(*nom.DetailedMomentum, bool) {},
+		func() uint64 { return 1 },
+		func([]*nom.DetailedMomentum) (int, error) { return 0, nil },
+		func(string) {},
+	)
+}
+
+// fillFetching puts HashLimit fetches from peer into the fetcher, all with
+// the given announce time, and charges the peer for them as the loop would.
+func fillFetching(f *Fetcher, peer string, blocks []*nom.DetailedMomentum, at time.Time) {
+	for _, b := range blocks {
+		f.fetching[b.Momentum.Hash] = &announce{hash: b.Momentum.Hash, time: at, origin: peer}
+	}
+	f.announces[peer] = len(blocks)
+	f.oldestFetch = at
+}
+
+// A peer at its limit whose fetches have timed out since the last sweep has
+// them released before its next announce is judged. This is the state
+// between the loop's sweep and its select when the timeout passes and a
+// notification wins the select ahead of the expiry timer.
+func TestReleaseExpired_FreesAllowanceOfTimedOutFetches(t *testing.T) {
+	blocks := testBlocks(HashLimit)
+	f := newIdleFetcher()
+	stale := time.Now().Add(-fetchTimeout - time.Second)
+	fillFetching(f, "announcer", blocks, stale)
+
+	f.releaseExpired("announcer")
+
+	expectHeld(t, f, nil, blocks)
+	checkAccounting(t, f)
+	if count := f.announces["announcer"]; count+1 > HashLimit {
+		t.Fatalf("announcer still charged %d after every fetch timed out, next announce would be refused", count)
+	}
+}
+
+// Live fetches are left alone: a peer at its limit stays refused, and a
+// peer under its limit never triggers a sweep.
+func TestReleaseExpired_LeavesLiveFetchesAlone(t *testing.T) {
+	blocks := testBlocks(HashLimit)
+	f := newIdleFetcher()
+	fillFetching(f, "announcer", blocks, time.Now())
+
+	f.releaseExpired("announcer")
+
+	expectHeld(t, f, blocks, nil)
+	checkAccounting(t, f)
+	if count := f.announces["announcer"]; count+1 <= HashLimit {
+		t.Fatalf("announcer charged %d with %d live fetches, next announce would be accepted", count, HashLimit)
+	}
+
+	// Under the limit with stale fetches: the sweep is not this peer's
+	// problem, and nothing is released on its behalf.
+	other := testBlocks(HashLimit / 2)
+	g := newIdleFetcher()
+	fillFetching(g, "quiet", other, time.Now().Add(-fetchTimeout-time.Second))
+	g.releaseExpired("quiet")
+	expectHeld(t, g, other, nil)
 }

--- a/protocol/fetcher/fetcher_test.go
+++ b/protocol/fetcher/fetcher_test.go
@@ -529,12 +529,9 @@ func TestAnnounces_ExactThroughFetchTimeout(t *testing.T) {
 	announceAll(t, h, "announcer", blocks)
 	waitForFetching(t, fetching, len(blocks))
 	// Fetch age is measured from the announce, so by now every fetch is
-	// older than fetchTimeout.
+	// older than fetchTimeout and the expiry timer has swept it without any
+	// other event waking the loop.
 	time.Sleep(fetchTimeout + 250*time.Millisecond)
-
-	// Expired fetches are swept at the top of the loop, so nudge it with an
-	// empty delivery.
-	h.f.Filter("nobody", nil)
 
 	h.stop()
 	if len(h.f.fetching) != 0 {
@@ -588,6 +585,32 @@ func TestAnnounces_LimitHoldsAcrossLifecycles(t *testing.T) {
 	// what the peer holds in total, not on the announced table alone.
 	if got := len(h.f.announced) + len(h.f.fetching); got > HashLimit {
 		t.Fatalf("%d announced or fetching entries held after two completed lifecycles, want at most %d", got, HashLimit)
+	}
+	checkAccounting(t, h.f)
+}
+
+// Fetches that time out while the loop is idle must free the peer's
+// allowance before its next announce is judged, not after.
+func TestAnnounces_ExpiredFetchesFreeAllowanceBeforeNextAnnounce(t *testing.T) {
+	if testing.Short() {
+		t.Skip("waits out fetchTimeout")
+	}
+	h, _, fetching, blocks := newAccountingHarness(HashLimit + 8)
+	defer h.stop()
+
+	announceAll(t, h, "announcer", blocks[:HashLimit])
+	waitForFetching(t, fetching, HashLimit)
+	// Let every fetch expire with the loop otherwise idle: nothing else
+	// wakes it between here and the next announce.
+	time.Sleep(fetchTimeout + 250*time.Millisecond)
+	announceAll(t, h, "announcer", blocks[HashLimit:])
+
+	h.stop()
+	if len(h.f.fetching) != 0 {
+		t.Fatalf("%d fetching entries survived fetchTimeout", len(h.f.fetching))
+	}
+	if got := len(h.f.announced); got != 8 {
+		t.Fatalf("%d of 8 announces accepted after every fetch expired, want all 8", got)
 	}
 	checkAccounting(t, h.f)
 }


### PR DESCRIPTION
## Summary

Follow-up to #84, where the fetcher's announce counter drift was noted and deferred, and which a reviewer asked to have tracked separately.

The fetcher caps the announces it retains for one peer at `hashLimit` (256) using a per-peer counter. When an announce timer expires, the loop calls `forgetHash`, which decrements the counter for every announcer of that hash, and then moves the chosen announce into the `fetching` table without counting it again. When the fetch later completes or times out, `forgetHash` decrements the counter once more for the fetching entry. Every announced hash that reaches the fetching table therefore ends its lifecycle one below where it started. Because a counter was only deleted when it reached exactly zero, one that passed through zero stayed negative and kept falling, so each completed batch widened the set of announces the peer could hold next time, without bound.

## Changes

- **Transition into `fetching` counts the entry.** The chosen peer's counter is incremented when its announce becomes a fetch, since `forgetHash` released the announce and will release the fetching entry on completion or timeout. Announced plus fetching entries per peer now equal the counter at every point, so a peer with `hashLimit` hashes in flight cannot announce more until some complete.
- **`forgetHash` floors at zero.** A counter at or below zero is deleted, so no future miscount can leave a peer with a negative balance.
- **Expired fetches are swept on a timer.** The sweep ran only at the top of the loop, so with nothing else waking the loop after `fetchTimeout`, stale entries stayed counted until the next event. Since fetching entries are now charged to their peer, that next event could be the peer's own announce, judged against a count that still included timed-out fetches: a peer whose whole batch expired while the loop was idle had its next announce rejected. The sweep now records the oldest surviving fetch as it walks the table and arms a timer for it, so the loop wakes when that fetch times out. The table is walked once per iteration, as it was before the timer existed. Two alternatives were considered: sweeping inside the announce handler on every announce would make each message, including refused ones, cost a walk of the fetching table; sweeping only when an announce is about to be refused would fix the rejection but would leave timed-out entries in memory until some event arrived. The timer releases them on time either way.
- **Admission releases timed-out fetches first.** The sweep runs before the loop blocks in `select`. If the oldest fetch times out while the loop is blocked and a notification becomes ready alongside the expiry timer, `select` can take the notification first, and a peer at its limit would be refused against fetches that have already timed out. The notify path now calls `releaseExpired` for the announcing peer: when that peer is at its allowance and the oldest pending fetch is past its timeout, the sweep runs before counting. The sweep records the oldest surviving fetch's announce time, so the check costs nothing when nothing is due, and since the sweep only runs from this path when something has actually expired, a peer at its limit cannot make refused announces cost repeated walks of the table.
- **`hashLimit` becomes `HashLimit`** with the same wording as #84, so the two branches merge cleanly in either order and the tests here compile against both. Verified by applying both onto `dev` and running the protocol tests under `-race`.

go-ethereum's block fetcher has the same double decrement and only applies the zero floor. That stops the counter going negative but still lets a peer with `hashLimit` hashes in flight announce `hashLimit` more; the increment here makes the counter cover announced plus fetching, which is what the limit's comment says it bounds.

No wire format or peer-visible behaviour changes except that a peer can no longer exceed its announce allowance.

## Tests

`protocol/fetcher/fetcher_test.go` drives whole lifecycles through the real loop and, once the loop is stopped, compares every counter with the announced and fetching entries attributed to that peer, failing on any negative or stale value. The tests wait on the fetcher's `fetchingHook`, and on a new `expiredHook` that the sweep calls after removing timed-out entries, rather than sleeping past `arriveTimeout` or `fetchTimeout`. A slow loop delays them instead of failing them, and the two timeout tests observe the sweep rather than infer it from the clock. Both hooks are nil outside tests. The tests:

- Announce, fetch, and delivery of an already imported block leaves no counter behind. On the unpatched code the counter reads -8 for eight hashes.
- Announce, fetch, and `fetchTimeout` leaves no counter behind, with nothing but the timer waking the loop. Skipped under `-short` since it waits out the timeout.
- With every fetch expired while the loop is idle, all of the peer's next announces are accepted, checked as the exact set held across announced and fetching so a timer firing meanwhile cannot fail it. Also skipped under `-short`. Before the timer, the first was rejected (7 of 8 accepted); without the timer, both this and the previous test now fail at the expiry deadline with no hashes swept.
- Two direct tests on a fetcher with no loop build the state between sweep and `select` by hand: with `HashLimit` fetches from one peer all past `fetchTimeout`, `releaseExpired` frees them and the peer's next announce would be accepted; with live fetches it changes nothing and the peer stays refused, and a peer under its limit triggers no sweep even with stale fetches. These do not depend on `select` ordering or on waiting for the expiry hook. The one-line call site in the notify case is not itself pinned by a test, since forcing a notification to win the `select` against a ready timer would need control over `select` ordering or a clock abstraction.
- With `hashLimit` hashes fetching, further announces from the same peer are refused. This test fails if only the zero floor is applied, so the exact accounting is what is pinned.
- After two completed batches of `hashLimit`, the peer still holds at most `hashLimit` announces. On the unpatched code 264 are accepted.

The five lifecycle tests fail on the unpatched code. The two timeout tests also fail with the accounting fix applied but the timer removed, and the first direct test fails without the admission-time release.

## Verification

`GOWORK=off`: gofmt and vet clean; `go test -race -count=3 ./protocol/...`; `golangci-lint run ./protocol/fetcher/...` reports the same issues before and after, none on changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAfAxvtiPqYU6873a9K4uH
