### PR TITLE
p2p/discover: expire node database entries without a node record

### DIFF
--- a/p2p/discover/database.go
+++ b/p2p/discover/database.go
@@ -24,6 +24,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
@@ -248,6 +249,11 @@ func (db *nodeDB) expirer() {
 
 // expireNodes iterates over the database and deletes all nodes that have not
 // been seen (i.e. received a pong from) for some alloted time.
+//
+// An identity is considered whenever any discovery field is stored for it,
+// not only when it has a node record: a ping that was never answered leaves
+// timing metadata alone, and those entries expire on the same terms as a
+// node record whose last pong is old.
 func (db *nodeDB) expireNodes() error {
 	threshold := time.Now().Add(-nodeDBNodeExpiration)
 
@@ -255,12 +261,21 @@ func (db *nodeDB) expireNodes() error {
 	it := db.lvl.NewIterator(nil, nil)
 	defer it.Release()
 
+	var (
+		lastID  NodeID
+		checked bool
+	)
 	for it.Next() {
-		// Skip the item if not a discovery node
+		// Skip the item if not a discovery field
 		id, field := splitKey(it.Key())
-		if field != nodeDBDiscoverRoot {
+		if !strings.HasPrefix(field, nodeDBDiscoverRoot) {
 			continue
 		}
+		// The fields of one identity are adjacent; decide it once
+		if checked && id == lastID {
+			continue
+		}
+		lastID, checked = id, true
 		// Skip the node if not expired yet (and not self)
 		if bytes.Compare(id[:], db.self[:]) != 0 {
 			if seen := db.lastPong(id); seen.After(threshold) {

--- a/p2p/discover/database_test.go
+++ b/p2p/discover/database_test.go
@@ -1,0 +1,77 @@
+package discover
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func newTestNodeID(t *testing.T) NodeID {
+	t.Helper()
+	priv, err := crypto.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return PubkeyID(&priv.PublicKey)
+}
+
+// hasEntries reports whether any key is stored for id.
+func (db *nodeDB) hasEntries(id NodeID) bool {
+	it := db.lvl.NewIterator(nil, nil)
+	defer it.Release()
+	for it.Next() {
+		if kid, _ := splitKey(it.Key()); kid == id {
+			return true
+		}
+	}
+	return false
+}
+
+// A ping that is never answered leaves timing metadata without a node
+// record. Expiration must reclaim such entries the same way it reclaims
+// stale node records, while leaving recently seen nodes alone.
+func TestExpireNodesReclaimsEntriesWithoutNodeRecord(t *testing.T) {
+	self := newTestNodeID(t)
+	db, err := newNodeDB("", Version, self)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.close()
+
+	stale := time.Now().Add(-2 * nodeDBNodeExpiration)
+	fresh := time.Now()
+
+	unanswered := newTestNodeID(t)
+	if err := db.updateLastPing(unanswered, stale); err != nil {
+		t.Fatal(err)
+	}
+	bonded := newTestNodeID(t)
+	if err := db.updateNode(newNode(bonded, net.IPv4(10, 0, 0, 2), 30303, 30303)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.updateLastPong(bonded, fresh); err != nil {
+		t.Fatal(err)
+	}
+	gone := newTestNodeID(t)
+	if err := db.updateNode(newNode(gone, net.IPv4(10, 0, 0, 3), 30303, 30303)); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.updateLastPong(gone, stale); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.expireNodes(); err != nil {
+		t.Fatal(err)
+	}
+	if db.hasEntries(unanswered) {
+		t.Error("entries for the unanswered identity were not reclaimed")
+	}
+	if !db.hasEntries(bonded) {
+		t.Error("entries for the recently seen node were removed")
+	}
+	if db.hasEntries(gone) {
+		t.Error("entries for the stale node were not reclaimed")
+	}
+}


### PR DESCRIPTION
Follow-up to #86, addressing the retention point raised in review there. The behaviour is pre-existing on `dev` and independent of the admission change, so it is fixed separately.

### Problem

`Table.ping` records the ping time before the pong arrives. When the exchange fails, no node record is ever written, but the timing key stays. `expireNodes` only considered node-record keys, so these entries were never reclaimed. Every unanswered bond, whether from an unsolicited ping or from a lookup reaching a peer that has gone away, left a permanent key in the node database.

Growth is bounded by the bonding rate (16 slots, 500 ms timeout, so at most 32 identities per second) but unbounded in total. It also lengthens the hourly expiration scan and the linear seed scan used when the table is empty.

### Change

`expireNodes` now considers an identity whenever any discovery field is stored for it. The retention rule is unchanged: an identity is deleted when its last pong is older than the expiration window, which for an identity that was never answered is immediately. Nothing reads the ping time back, so no known-peer state is lost, and node records with a recent pong are kept exactly as before. Fields of one identity are adjacent in key order, so each identity is decided once per scan.

### Tests

`p2p/discover/database_test.go` (new): a stale ping-only identity is reclaimed, a node record with a recent pong is kept, and a node record with a stale pong is reclaimed as before. The first check fails on the previous code.

### Verification

- `GOWORK=off go vet ./p2p/discover/`
- `GOWORK=off go test -race -count=3 ./p2p/discover/`
- `GOWORK=off go test ./...`
- `GOWORK=off golangci-lint run ./p2p/discover/` (no new findings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAfAxvtiPqYU6873a9K4uH
