### PR TITLE
node: stop the WebSocket RPC server on shutdown

### DIFF
--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -240,7 +240,7 @@ func (h *httpServer) doStop() {
 
 	// Shut down the server.
 	httpHandler := h.httpHandler.Load().(*rpcHandler)
-	wsHandler := h.httpHandler.Load().(*rpcHandler)
+	wsHandler := h.wsHandler.Load().(*rpcHandler)
 	if httpHandler != nil {
 		h.httpHandler.Store((*rpcHandler)(nil))
 		httpHandler.server.Stop()

--- a/node/rpcstack_test.go
+++ b/node/rpcstack_test.go
@@ -1,0 +1,102 @@
+package node
+
+import (
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	rpc "github.com/zenon-network/go-zenon/rpc/server"
+)
+
+// stackProbe is the only API registered by these tests.
+type stackProbe struct{}
+
+func (stackProbe) Ping() string { return "pong" }
+
+var stackAPIs = []rpc.API{{Namespace: "probe", Service: stackProbe{}, Public: true}}
+
+// startStackServer configures an httpServer on an ephemeral loopback port
+// with WebSocket enabled and, when withHTTP is set, HTTP JSON-RPC too.
+func startStackServer(t *testing.T, withHTTP bool) *httpServer {
+	t.Helper()
+	h := newHTTPServer(rpc.DefaultHTTPTimeouts)
+	if err := h.setListenAddr("127.0.0.1", 0); err != nil {
+		t.Fatal(err)
+	}
+	if withHTTP {
+		if err := h.enableRPC(stackAPIs, httpConfig{Modules: []string{"probe"}}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := h.enableWS(stackAPIs, wsConfig{Modules: []string{"probe"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := h.start(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(h.stop)
+	return h
+}
+
+// dialStackWS opens a WebSocket connection to the server and proves it is
+// live with one JSON-RPC round trip.
+func dialStackWS(t *testing.T, h *httpServer) *websocket.Conn {
+	t.Helper()
+	dialer := websocket.Dialer{HandshakeTimeout: 2 * time.Second}
+	conn, _, err := dialer.Dial("ws://"+h.listenAddr(), nil)
+	if err != nil {
+		t.Fatalf("WS dial: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	req := []byte(`{"jsonrpc":"2.0","id":1,"method":"probe.ping","params":[]}`)
+	if err := conn.WriteMessage(websocket.TextMessage, req); err != nil {
+		t.Fatalf("WS write: %v", err)
+	}
+	conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, _, err := conn.ReadMessage(); err != nil {
+		t.Fatalf("WS read before stop: %v", err)
+	}
+	return conn
+}
+
+// Stopping the server must close established WebSocket connections. An
+// upgraded connection is hijacked from the HTTP server, so closing the
+// listener and shutting down net/http does not reach it; only stopping the
+// WebSocket RPC server closes its codecs.
+func TestHTTPServerStopClosesWebSocketConnections(t *testing.T) {
+	cases := []struct {
+		name     string
+		withHTTP bool
+	}{
+		{"ws only", false},
+		{"shared with http", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			h := startStackServer(t, tc.withHTTP)
+			conn := dialStackWS(t, h)
+
+			h.stop()
+
+			if h.wsAllowed() {
+				t.Error("WebSocket handler still installed after stop")
+			}
+			if h.rpcAllowed() {
+				t.Error("HTTP handler still installed after stop")
+			}
+
+			// A closed connection surfaces as a read error. A live one would
+			// block until the deadline and return a timeout instead.
+			conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+			_, _, err := conn.ReadMessage()
+			if err == nil {
+				t.Fatal("WebSocket connection still delivering messages after stop")
+			}
+			if ne, ok := err.(interface{ Timeout() bool }); ok && ne.Timeout() {
+				t.Fatalf("WebSocket connection still open after stop: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to a review finding on #87. Pre-existing and independent of that change.

## Problem

`httpServer.doStop` in `node/rpcstack.go` loads both handler variables from the HTTP handler slot:

```go
httpHandler := h.httpHandler.Load().(*rpcHandler)
wsHandler := h.httpHandler.Load().(*rpcHandler)
```

The WebSocket `rpc.Server` never receives its `Stop()` call. `Stop()` is what closes the codecs behind established WebSocket connections. Those connections are hijacked from `net/http` during the upgrade, so `http.Server.Shutdown` and closing the listener do not reach them. A client connected over WebSocket keeps an open, working connection after `stopRPC` returns. The WebSocket handler slot is also only cleared as a side effect when an HTTP handler happens to be installed on the same server.

In practice the process exits shortly after `stopRPC`, which is why this went unnoticed.

## Fix

Read the WebSocket handler from its own slot. One line.

## Test

`TestHTTPServerStopClosesWebSocketConnections` starts an `httpServer` with WebSocket enabled, opens a WebSocket client, proves it live with one JSON-RPC round trip, stops the server, then checks that the client's next read fails with a non-timeout error and that both handler slots are cleared. It covers a WebSocket-only server and one sharing its listener with HTTP, since the two shapes took different paths through the old code. Both subtests fail before the fix by timing out on the read.

```
GOWORK=off go test ./node/ -count=3   # ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAfAxvtiPqYU6873a9K4uH
